### PR TITLE
fix addPathToClassPath use pwd as extraclasspath directory

### DIFF
--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
@@ -97,12 +97,12 @@ abstract class JavaProcessEngineConnLaunchBuilder extends ProcessEngineConnLaunc
       }
     }
     getExtraClassPathFile.foreach { file: String =>
-      addPathToClassPath(environment, Seq(variable(PWD), new File(file).getName))
+      addPathToClassPath(environment, file)
     }
     engineConnBuildRequest match {
       case richer: RicherEngineConnBuildRequest =>
         def addFiles(files: String): Unit = if (StringUtils.isNotBlank(files)) {
-          files.split(",").foreach(file => addPathToClassPath(environment, Seq(variable(PWD), new File(file).getName)))
+          files.split(",").foreach(addPathToClassPath(environment, _))
         }
 
         val configs: util.Map[String, String] = richer.getStartupConfigs.filter(_._2.isInstanceOf[String]).map { case (k, v: String) => k -> v }


### PR DESCRIPTION
### What is the purpose of the change

Fix a bug that JavaProcessEngineConnLaunchBuilder unexpectedly transform configured extraclasspath to engine work dir.

Related issues: #918. 

### Brief change log
- remove the code that change directory to PWD

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)