### PR TITLE
Linkis jar package upgrade to solve security vulnerabilities 

### DIFF
--- a/assembly-combined-package/assembly-combined/public-module-combined/pom.xml
+++ b/assembly-combined-package/assembly-combined/public-module-combined/pom.xml
@@ -108,6 +108,17 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
 
         <dependency>

--- a/linkis-commons/linkis-common/pom.xml
+++ b/linkis-commons/linkis-common/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>${commons-codec.version}</version>
         </dependency>
 
         <dependency>

--- a/linkis-commons/linkis-hadoop-common/pom.xml
+++ b/linkis-commons/linkis-hadoop-common/pom.xml
@@ -124,9 +124,18 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>

--- a/linkis-commons/linkis-module/pom.xml
+++ b/linkis-commons/linkis-module/pom.xml
@@ -232,7 +232,7 @@
                 </exclusion>
             </exclusions>
             <groupId>org.springframework.cloud</groupId>
-            <version>${spring.cloud.version}</version>
+            <version>${spring.cloud.config.client.version}</version>
         </dependency>
         <dependency>
             <artifactId>spring-cloud-starter</artifactId>
@@ -249,11 +249,19 @@
                     <artifactId>spring-boot-starter</artifactId>
                     <groupId>org.springframework.boot</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
             <groupId>org.springframework.cloud</groupId>
             <version>${spring.cloud.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bcpkix-jdk15on.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-context</artifactId>
@@ -363,7 +371,16 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>bean-validator</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>bean-validator</artifactId>
+            <version>${bean-validator.version}</version>
         </dependency>
 
 

--- a/linkis-commons/linkis-rpc/pom.xml
+++ b/linkis-commons/linkis-rpc/pom.xml
@@ -108,7 +108,16 @@
                     <artifactId>spring-web</artifactId>
                     <groupId>org.springframework</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-netflix-ribbon</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-netflix-ribbon</artifactId>
+            <version>${spring-cloud-netflix-ribbon.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/linkis-commons/linkis-storage/pom.xml
+++ b/linkis-commons/linkis-storage/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.monitorjbl</groupId>
             <artifactId>xlsx-streamer</artifactId>
-            <version>1.2.1</version>
+            <version>${xlsx-streamer.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
@@ -34,10 +34,27 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-crypto</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
             <version>${spring.cloud.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bcpkix-jdk15on.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${spring.security.cryto.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
@@ -57,8 +74,67 @@
                     <groupId>javax.servlet</groupId>
                 </exclusion>
 
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-cbor</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-web</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context-support</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-websocket</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat-embed.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>${tomcat-embed.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
@@ -69,6 +145,18 @@
             <artifactId>jackson-databind</artifactId>
             <groupId>com.fasterxml.jackson.core</groupId>
             <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/pom.xml
@@ -79,6 +79,18 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
 
         <!--linkis-label-common -->

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-server-support/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-server-support/pom.xml
@@ -63,8 +63,27 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-            <version>${spring.cloud.version}</version>
+            <version>${spring.boot.actuator.autoconfigure.version}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-aop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-spring-cloud-gateway/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-spring-cloud-gateway/pom.xml
@@ -78,7 +78,29 @@
                     <artifactId>reactor-core</artifactId>
                     <groupId>io.projectreactor</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-crypto</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webflux</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bcpkix-jdk15on.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -105,7 +127,7 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
-            <version>0.9.7.RELEASE</version>
+            <version>${reactor-netty.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,36 +71,45 @@
     <properties>
         <linkis.version>1.0.1</linkis.version>
         <hadoop.version>2.7.2</hadoop.version>
-        <spring.eureka.version>2.2.1.RELEASE</spring.eureka.version>
-        <spring.feign.version>2.2.1.RELEASE</spring.feign.version>
-        <spring.boot.version>2.3.2.RELEASE</spring.boot.version>
+        <spring.eureka.version>2.2.4.RELEASE</spring.eureka.version>
+        <spring.feign.version>2.2.4.RELEASE</spring.feign.version>
+        <spring.boot.version>2.3.12.RELEASE</spring.boot.version>
         <spring.cloud.version>2.2.1.RELEASE</spring.cloud.version>
-        <guava.version>25.1-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <gson.version>2.8.5</gson.version>
-        <fasterxml.jackson.version>2.11.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.11.4</fasterxml.jackson.version>
         <scala.version>2.11.12</scala.version>
         <jdk.compile.version>1.8</jdk.compile.version>
         <plugin.scala.version>2.15.2</plugin.scala.version>
         <scala.binary.version>2.11</scala.binary.version>
-        <netty.version>4.1.44.Final</netty.version>
+        <netty.version>4.1.65.Final</netty.version>
         <json4s.version>3.5.3</json4s.version>
         <jersey.version>2.16</jersey.version>
         <jersey.servlet.version>2.23.1</jersey.servlet.version>
-        <jetty.version>9.4.20.v20190813</jetty.version>
-        <httpclient.version>4.5.4</httpclient.version>
-        <httpmime.version>4.5.4</httpmime.version>
+        <jetty.version>9.4.39.v20210325</jetty.version>
+        <httpclient.version>4.5.13</httpclient.version>
+        <httpmime.version>4.5.13</httpmime.version>
         <slf4j.version>1.7.30</slf4j.version>
         <maven.version>3.3.3</maven.version>
-        <xstream.core.version>1.4.15</xstream.core.version>
-        <spring.version>5.2.12.RELEASE</spring.version>
-        <spring.security.cryto.version>5.3.6.RELEASE</spring.security.cryto.version>
+        <xstream.core.version>1.4.17</xstream.core.version>
+        <spring.version>5.2.15.RELEASE</spring.version>
+        <spring.security.cryto.version>5.3.9.RELEASE</spring.security.cryto.version>
         <reflections.version>0.9.10</reflections.version>
-        <mybatis-plus.boot.starter.version>3.4.1</mybatis-plus.boot.starter.version>
+        <mybatis-plus.boot.starter.version>3.4.3</mybatis-plus.boot.starter.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javassist.version>3.19.0-GA</javassist.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.7</commons-io.version>
+        <spring.cloud.config.client.version>2.2.3.RELEASE</spring.cloud.config.client.version>
+        <spring.boot.actuator.autoconfigure.version>2.3.12.RELEASE</spring.boot.actuator.autoconfigure.version>
+        <commons-codec.version>1.13</commons-codec.version>
+        <bcpkix-jdk15on.version>1.68</bcpkix-jdk15on.version>
+        <bean-validator.version>2.5.0-b06</bean-validator.version>
+        <spring-cloud-netflix-ribbon.version>2.2.4.RELEASE</spring-cloud-netflix-ribbon.version>
+        <tomcat-embed.version>9.0.46</tomcat-embed.version>
+        <reactor-netty.version>0.9.20.RELEASE</reactor-netty.version>
+        <xlsx-streamer.version>2.2.0</xlsx-streamer.version>
         <assembly.package.rootpath>${basedir}</assembly.package.rootpath>
     </properties>
 


### PR DESCRIPTION
#939 
At present, the versions of some jar packages used by linkis are relatively low and there are security vulnerabilities. The relevant jar packages of the following modules have been upgraded。
eg:
modified: assembly-combined-package/assembly-combined/public-module-combined/pom.xml
modified: linkis-commons/linkis-common/pom.xml
modified: linkis-commons/linkis-hadoop-common/pom.xml
modified: linkis-commons/linkis-module/pom.xml
modified: linkis-commons/linkis-rpc/pom.xml
modified: linkis-commons/linkis-storage/pom.xml
modified: linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
modified: linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/pom.xml
modified: linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-server-support/pom.xml
modified: linkis-spring-cloud-services/linkis-service-gateway/linkis-spring-cloud-gateway/pom.xml
modified: pom.xml
After modification, the micro service compile and Running is ok, and the hive / spark / Python / shell execution engine is verified