### PR TITLE
Support engine operator

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/LinkisManagerClient.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/LinkisManagerClient.scala
@@ -19,8 +19,8 @@ package org.apache.linkis.computation.client.once
 
 import java.io.Closeable
 
-import org.apache.linkis.computation.client.once.action.{CreateEngineConnAction, GetEngineConnAction, KillEngineConnAction, LinkisManagerAction}
-import org.apache.linkis.computation.client.once.result.{CreateEngineConnResult, GetEngineConnResult, KillEngineConnResult, LinkisManagerResult}
+import org.apache.linkis.computation.client.once.action.{CreateEngineConnAction, EngineOperateAction, GetEngineConnAction, KillEngineConnAction, LinkisManagerAction}
+import org.apache.linkis.computation.client.once.result.{CreateEngineConnResult, EngineOperateResult, GetEngineConnResult, KillEngineConnResult, LinkisManagerResult}
 import org.apache.linkis.httpclient.dws.DWSHttpClient
 import org.apache.linkis.httpclient.request.Action
 import org.apache.linkis.ujes.client.{UJESClient, UJESClientImpl}
@@ -33,6 +33,8 @@ trait LinkisManagerClient extends Closeable {
   def getEngineConn(getEngineConnAction: GetEngineConnAction): GetEngineConnResult
 
   def killEngineConn(killEngineConnAction: KillEngineConnAction): KillEngineConnResult
+
+  def executeEngineOperation(engineOperateAction: EngineOperateAction): EngineOperateResult
 
 }
 object LinkisManagerClient {
@@ -58,6 +60,8 @@ class LinkisManagerClientImpl(ujesClient: UJESClient) extends LinkisManagerClien
   override def getEngineConn(getEngineConnAction: GetEngineConnAction): GetEngineConnResult = execute(getEngineConnAction)
 
   override def killEngineConn(killEngineConnAction: KillEngineConnAction): KillEngineConnResult = execute(killEngineConnAction)
+
+  override def executeEngineOperation(engineOperateAction: EngineOperateAction): EngineOperateResult = execute(engineOperateAction)
 
   override def close(): Unit = ujesClient.close()
 }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.once.action
+
+import java.util
+
+class EngineOperateAction extends GetEngineConnAction {
+
+  override def suffixURLs: Array[String] = Array("linkisManager", "executeEngineOperation")
+
+}
+
+object EngineOperateAction {
+
+  val OPERATOR_NAME_KEY = "__operator_name__"
+
+  def newBuilder(): Builder = new Builder
+
+  class Builder extends ServiceInstanceBuilder[EngineOperateAction] {
+
+    private var operatorName = ""
+
+    private var properties: util.Map[String, Any] = new util.HashMap[String, Any]
+
+    def operatorName(operatorName: String): this.type  = {
+      this.operatorName = operatorName
+      this
+    }
+
+    def setProperties(properties: util.Map[String, Any]): this.type = {
+      this.properties = properties
+      this
+    }
+
+    def addProperty(key: String, value: Any): this.type = {
+      if (this.properties == null) {
+        this.properties = new util.HashMap[String, Any]
+      }
+      this.properties.put(key, value)
+      this
+    }
+
+    override protected def createGetEngineConnAction(): EngineOperateAction = {
+      val action = new EngineOperateAction
+      addProperty(OPERATOR_NAME_KEY, operatorName)
+      action.addRequestPayload("properties", properties)
+      action
+    }
+  }
+
+}
+

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineOperateResult.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineOperateResult.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.once.result
+
+import java.util
+
+import org.apache.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/linkisManager/executeEngineOperation")
+class EngineOperateResult extends LinkisManagerResult {
+
+  private var result: util.Map[String, Any] = _
+
+  def setResult(result: util.Map[String, Any]): Unit = {
+    this.result = result
+  }
+
+  def getResult: util.Map[String, Any] = result
+
+  def getAs[T](key: String): Option[T] = {
+    if (result != null && result.get(key) != null) {
+      Some(result.get(key).asInstanceOf[T])
+    } else {
+      None
+    }
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
@@ -91,7 +91,7 @@ class SubmittableSimpleOnceJob(protected override val linkisManagerClient: Linki
     info(s"EngineConn created with status $lastEngineConnState, the nodeInfo is $lastNodeInfo.")
     addOperatorAction {
       case onceJobOperator: OnceJobOperator[_] =>
-        onceJobOperator.setServiceInstance(serviceInstance).setLinkisManagerClient(linkisManagerClient)
+        onceJobOperator.setUser(user).setServiceInstance(serviceInstance).setLinkisManagerClient(linkisManagerClient)
       case operator => operator
     }
     if(!isCompleted(lastEngineConnState) && !isRunning) {

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/OnceJobOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/OnceJobOperator.scala
@@ -23,11 +23,18 @@ import org.apache.linkis.computation.client.once.LinkisManagerClient
 
 trait OnceJobOperator[T] extends Operator[T] {
 
+  private var user: String = _
   private var serviceInstance: ServiceInstance = _
   private var linkisManagerClient: LinkisManagerClient = _
 
+  protected def getUser: String = user
   protected def getServiceInstance: ServiceInstance = serviceInstance
   protected def getLinkisManagerClient: LinkisManagerClient = linkisManagerClient
+
+  def setUser(user: String): this.type = {
+    this.user = user
+    this
+  }
 
   def setServiceInstance(serviceInstance: ServiceInstance): this.type = {
     this.serviceInstance = serviceInstance

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.linkis.computation.client.operator.impl
 
+import org.apache.linkis.computation.client.once.action.EngineOperateAction
 import org.apache.linkis.computation.client.operator.OnceJobOperator
 
 
@@ -25,8 +26,20 @@ class ApplicationInfoOperator extends OnceJobOperator[ApplicationInfo] {
   override def getName: String = ApplicationInfoOperator.OPERATOR_NAME
 
   override def apply(): ApplicationInfo = {
-    //TODO
-    ApplicationInfo("", "", "")
+
+    val engineOperateAction = EngineOperateAction.newBuilder()
+      .operatorName(getName)
+      .setUser(getUser)
+      .setApplicationName(getServiceInstance.getApplicationName)
+      .setInstance(getServiceInstance.getInstance)
+      .build()
+
+    val result = getLinkisManagerClient.executeEngineOperation(engineOperateAction)
+    ApplicationInfo(
+      result.getAs("applicationId").getOrElse(""),
+      result.getAs("applicationUrl").getOrElse(""),
+      result.getAs("queue").getOrElse("")
+    )
   }
 
 }

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/pom.xml
@@ -33,12 +33,6 @@
             <groupId>org.apache.linkis</groupId>
             <artifactId>linkis-executor-core</artifactId>
             <version>${linkis.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>reflections</artifactId>
-                    <groupId>org.reflections</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/Operator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/Operator.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.acessible.executor.operator
+
+import org.apache.linkis.manager.common.protocol.engine.EngineOperateResponse
+
+trait Operator {
+
+  def getName: String
+
+  def init(properties: Map[String, Any])
+
+  def apply(): EngineOperateResponse
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/OperatorFactory.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/OperatorFactory.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.acessible.executor.operator
+
+import org.apache.linkis.common.exception.WarnException
+import org.apache.linkis.common.utils.ClassUtils
+import org.apache.linkis.manager.common.protocol.engine.EngineOperateRequest
+
+trait OperatorFactory {
+
+  def createOperatorRequest(request: EngineOperateRequest): Operator
+
+}
+
+object OperatorFactory {
+
+  private val operatorFactory = new OperatorFactoryImpl
+
+  def apply(): OperatorFactory = operatorFactory
+
+}
+
+import scala.collection.convert.WrapAsScala._
+class OperatorFactoryImpl extends OperatorFactory {
+
+  private val operatorClasses: Map[String, Class[_ <: Operator]] = ClassUtils.reflections.getSubTypesOf(classOf[Operator])
+    .filterNot(ClassUtils.isInterfaceOrAbstract).map { clazz =>
+      clazz.newInstance().getName -> clazz
+    }.toMap
+
+  override def createOperatorRequest(request: EngineOperateRequest): Operator = {
+    request.properties.getOrElse(EngineOperateRequest.OPERATOR_NAME_KEY, null) match {
+      case operatorName: String if operatorClasses.contains(operatorName) =>
+        val operator = operatorClasses.get(operatorName).get.newInstance()
+        operator.init(request.properties)
+        operator
+      case _ => throw new WarnException(-1, s"Cannot find operator.")
+    }
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/DefaultOperateService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/DefaultOperateService.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.acessible.executor.service
+import org.apache.linkis.engineconn.acessible.executor.operator.OperatorFactory
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
+import org.apache.linkis.message.annotation.Receiver
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultOperateService extends OperateService {
+
+  @Receiver
+  override def executeOperation(engineOperateRequest: EngineOperateRequest): EngineOperateResponse = {
+    val operator = OperatorFactory().createOperatorRequest(engineOperateRequest)
+    operator()
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/OperateService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/OperateService.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.acessible.executor.service
+
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
+
+trait OperateService {
+
+  def executeOperation(engineOperateRequest: EngineOperateRequest): EngineOperateResponse
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/manager/DefaultEngineNodeManager.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/manager/DefaultEngineNodeManager.scala
@@ -29,6 +29,7 @@ import org.apache.linkis.manager.common.constant.AMConstant
 import org.apache.linkis.manager.common.entity.enumeration.NodeStatus
 import org.apache.linkis.manager.common.entity.node.{AMEngineNode, EngineNode, ScoreServiceInstance}
 import org.apache.linkis.manager.common.entity.persistence.PersistenceLabel
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
 import org.apache.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
 import org.apache.linkis.manager.label.entity.engine.EngineInstanceLabel
 import org.apache.linkis.manager.persistence.{LabelManagerPersistence, NodeManagerPersistence, NodeMetricManagerPersistence}
@@ -245,5 +246,8 @@ class DefaultEngineNodeManager extends EngineNodeManager with Logging {
     labelManagerPersistence.updateLabel(label.getId, persistenceLabel)
   }
 
-
+  override def executeOperation(engineNode: EngineNode, request: EngineOperateRequest): EngineOperateResponse = {
+    val engine = nodePointerBuilder.buildEngineNodePointer(engineNode)
+    engine.executeOperation(request)
+  }
 }

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/manager/EngineNodeManager.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/manager/EngineNodeManager.scala
@@ -21,6 +21,7 @@ package org.apache.linkis.manager.am.manager
 import org.apache.linkis.common.ServiceInstance
 import org.apache.linkis.manager.common.entity.enumeration.NodeStatus
 import org.apache.linkis.manager.common.entity.node.{EngineNode, ScoreServiceInstance}
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
 
 
 trait EngineNodeManager {
@@ -69,5 +70,7 @@ trait EngineNodeManager {
   def useEngine(engineNode: EngineNode): EngineNode
 
   def useEngine(engineNode: EngineNode, timeout: Long): EngineNode
+
+  def executeOperation(engineNode: EngineNode, request: EngineOperateRequest): EngineOperateResponse
 
 }

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/pointer/DefaultEngineNodPointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/pointer/DefaultEngineNodPointer.scala
@@ -18,7 +18,9 @@
 
 package org.apache.linkis.manager.am.pointer
 
+import org.apache.linkis.common.exception.WarnException
 import org.apache.linkis.manager.common.entity.node.Node
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
 import org.apache.linkis.manager.common.protocol.{RequestEngineLock, RequestEngineUnlock, ResponseEngineLock}
 import org.apache.linkis.manager.service.common.pointer.EngineNodePointer
 
@@ -48,5 +50,12 @@ class DefaultEngineNodPointer(val node: Node) extends AbstractNodePointer with E
 
   override def releaseLock(requestEngineUnlock: RequestEngineUnlock): Unit = {
     getSender.send(requestEngineUnlock)
+  }
+
+  override def executeOperation(engineOperateRequest: EngineOperateRequest): EngineOperateResponse = {
+    getSender.ask(engineOperateRequest) match {
+      case response: EngineOperateResponse => response
+      case _ => throw new WarnException(-1, "Illegal response of operation.")
+    }
   }
 }

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/DefaultEngineOperateService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/DefaultEngineOperateService.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.manager.am.service.engine
+
+import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.manager.common.entity.node.EngineNode
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultEngineOperateService extends AbstractEngineService with EngineOperateService with Logging {
+
+  override def executeOperation(engineNode: EngineNode, engineOperateRequest: EngineOperateRequest): EngineOperateResponse = {
+    getEngineNodeManager.executeOperation(engineNode, engineOperateRequest)
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/EngineOperateService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/EngineOperateService.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.manager.am.service.engine
+
+import org.apache.linkis.manager.common.entity.node.EngineNode
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
+
+trait EngineOperateService {
+
+  def executeOperation(engineNode: EngineNode, engineOperateRequest: EngineOperateRequest): EngineOperateResponse
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateRequest.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateRequest.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.manager.common.protocol.engine
+
+import org.apache.linkis.common.ServiceInstance
+import org.apache.linkis.protocol.message.RequestProtocol
+
+case class EngineOperateRequest(user: String,
+                           properties: Map[String, Any]) extends RequestProtocol
+
+
+case class EngineOperateRequestWithService(user: String, serviceInstance: ServiceInstance,
+                           properties: Map[String, Any]) extends RequestProtocol
+
+object EngineOperateRequest {
+
+  val OPERATOR_NAME_KEY = "__operator_name__"
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateResponse.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateResponse.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.manager.common.protocol.engine
+
+import org.apache.linkis.protocol.message.RequestProtocol
+
+case class EngineOperateResponse(result: Map[String, Any], status: Boolean = true, msg: String = "") extends RequestProtocol

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/org/apache/linkis/manager/service/common/pointer/EngineNodePointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/org/apache/linkis/manager/service/common/pointer/EngineNodePointer.scala
@@ -18,6 +18,7 @@
 
 package org.apache.linkis.manager.service.common.pointer
 
+import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
 import org.apache.linkis.manager.common.protocol.{RequestEngineLock, RequestEngineUnlock}
 
 
@@ -27,5 +28,7 @@ trait EngineNodePointer extends NodePointer {
 
 
   def releaseLock(requestEngineUnlock: RequestEngineUnlock): Unit
+
+  def executeOperation(engineOperateRequest: EngineOperateRequest): EngineOperateResponse
 
 }


### PR DESCRIPTION
### What is the purpose of the change

support engine operator.  #1063

### Brief change log

`linkis-computation-client` module
+ Define OperatorAction 
+ Linkismanagerclient add executeOperate method to send OperatorAction to LinkisManager

`linkis-application-manager` module
+ Implement the DefaultEngineOperatorService in the LinkisManager to receive the operator request and execute it through the EngineNodeManager.
+ Add the executeOperation method in the EngineNodeManager to execute the EngineOperateRequest through the EngineNodPointer
+ The EngineNodPointer adds the executeOperation method to send the request to EngineConn

`accessible-executor` module
+ Implement the OperatorService class to receive EngineOperateRequest
+ Define the Operator interface, which can be implemented in the EngineConn plugins

### Verifying this change

Not yet

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes / no) no
- Anything that affects deployment: (yes / no / don't know) no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes / no) no

### Documentation
- Does this pull request introduce a new feature? (yes / no) yes
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not documented