### PR TITLE
bugFix: when hostname start with applicationName, will cause parse faile…

### DIFF
--- a/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/sender/eureka/EurekaRPCServerLoader.scala
+++ b/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/sender/eureka/EurekaRPCServerLoader.scala
@@ -39,7 +39,7 @@ class EurekaRPCServerLoader extends AbstractRPCServerLoader {
   }
 
   private[rpc] def getInstance(applicationName: String, instanceId: String): String =
-    if (instanceId.toLowerCase.indexOf(applicationName.toLowerCase) > 0) {
+    if (instanceId.toLowerCase.indexOf(":" + applicationName.toLowerCase + ":") > 0) {
       val instanceInfos = instanceId.split(":")
       instanceInfos(0) + ":" + instanceInfos(2)
     } else instanceId


### PR DESCRIPTION
### What is the purpose of the change
when hostname start with applicationName, will cause parse failed, resuslt in can't find instace from eureka. 
for example,
hostname："linkis-cg-linkis-cg-engineconnmanager-1"
aplicationName: "linkis-cg-engineconnmanager"
he service registed in eureka: "linkis-cg-linkis-cg-engineconnmanager-1:linkis-cg-linkis-cg-engineconnmanager:9102"

the code "instanceId.toLowerCase.indexOf(applicationName.toLowerCase)"  will return 0.

### Brief change log
- More stringent match in the code line 42  of EurekaRPCServerLoader.java

### Verifying this change
This change added tests and can be verified as follows:  
- 1. set engineconnmanager's hostname "linkis-cg-linkis-cg-engineconnmanager-1",which contains aplicationName "linkis-cg-engineconnmanager", then start all service.
- 2. start a shell engine, if execute success the pass the test.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)