### PR TITLE
bugFix:unified the width of all instance related field to be 128.

### DIFF
--- a/db/linkis_ddl.sql
+++ b/db/linkis_ddl.sql
@@ -571,7 +571,7 @@ DROP TABLE IF EXISTS `linkis_ps_instance_label_relation`;
 CREATE TABLE `linkis_ps_instance_label_relation` (
   `id` int(20) NOT NULL AUTO_INCREMENT,
   `label_id` int(20) DEFAULT NULL COMMENT 'id reference linkis_ps_instance_label -> id',
-  `service_instance` varchar(64) NOT NULL COLLATE utf8_bin COMMENT 'structure like ${host|machine}:${port}',
+  `service_instance` varchar(128) NOT NULL COLLATE utf8_bin COMMENT 'structure like ${host|machine}:${port}',
   `update_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'update unix timestamp',
   `create_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'create unix timestamp',
   PRIMARY KEY (`id`)
@@ -659,8 +659,8 @@ CREATE TABLE `linkis_cg_rm_external_resource_provider` (
 DROP TABLE IF EXISTS `linkis_cg_manager_engine_em`;
 CREATE TABLE `linkis_cg_manager_engine_em` (
   `id` int(20) NOT NULL AUTO_INCREMENT,
-  `engine_instance` varchar(64) COLLATE utf8_bin DEFAULT NULL,
-  `em_instance` varchar(64) COLLATE utf8_bin DEFAULT NULL,
+  `engine_instance` varchar(128) COLLATE utf8_bin DEFAULT NULL,
+  `em_instance` varchar(128) COLLATE utf8_bin DEFAULT NULL,
   `update_time` datetime DEFAULT CURRENT_TIMESTAMP,
   `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
@@ -706,7 +706,7 @@ DROP TABLE IF EXISTS `linkis_cg_manager_label_service_instance`;
 CREATE TABLE `linkis_cg_manager_label_service_instance` (
   `id` int(20) NOT NULL AUTO_INCREMENT,
   `label_id` int(20) DEFAULT NULL,
-  `service_instance` varchar(64) COLLATE utf8_bin DEFAULT NULL,
+  `service_instance` varchar(128) COLLATE utf8_bin DEFAULT NULL,
   `update_time` datetime DEFAULT CURRENT_TIMESTAMP,
   `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
### What is the purpose of the change
Iin table linkis_cg_manager_service_instance and table linkis_cg_manager_service_instance_metrics, 'instance' is 128,but in linkis_ps_instance_label_relation(service_instance)、linkis_cg_manager_label_service_instance(service_instance)、linkis_cg_manager_engine_em(engine_instance、em_instance) is 64.
if hostname use fqdn, then length will longer than 64,such as 'linkis-cg-engineconnmanager-0.linkis-svc.default.svc.cluster.local'

### Brief change log
- modify linkis_ps_instance_label_relation(service_instance)  64->128 ;
- modify linkis_cg_manager_label_service_instance(service_instance) 64->128;
- modify linkis_cg_manager_engine_em(engine_instance、em_instance) 64->128; 

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: ( no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)