### PR TITLE
bugFix:instance Label parase failed when hostname contains servicename.

### DIFF
--- a/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/em/EMInstanceLabel.java
+++ b/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/em/EMInstanceLabel.java
@@ -74,7 +74,7 @@ public class EMInstanceLabel extends GenericLabel implements NodeInstanceLabel, 
 
     @Override
     protected void setStringValue(String stringValue){
-        String instance = stringValue.replace(LabelCommonConfig.ENGINE_CONN_MANAGER_SPRING_NAME.getValue() + "-", "");
+        String instance = stringValue.replaceFirst(LabelCommonConfig.ENGINE_CONN_MANAGER_SPRING_NAME.getValue() + "-", "");
         String serviceName = LabelCommonConfig.ENGINE_CONN_MANAGER_SPRING_NAME.getValue();
         setInstance(instance);
         setServiceName(serviceName);

--- a/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/engine/EngineInstanceLabel.java
+++ b/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/engine/EngineInstanceLabel.java
@@ -73,7 +73,7 @@ public class EngineInstanceLabel extends GenericLabel implements NodeInstanceLab
 
     @Override
     protected void setStringValue(String stringValue){
-        String instance = stringValue.replace(LabelCommonConfig.ENGINE_CONN_SPRING_NAME.getValue() + "-", "");
+        String instance = stringValue.replaceFirst(LabelCommonConfig.ENGINE_CONN_SPRING_NAME.getValue() + "-", "");
         String serviceName = LabelCommonConfig.ENGINE_CONN_SPRING_NAME.getValue();
         setInstance(instance);
         setServiceName(serviceName);


### PR DESCRIPTION
### What is the purpose of the change
bugFix:instance Label Parase failed when hostname contains servicename.
for example,
hostname: linkis-cg-engineconnmanager-0.linkis-svc.default.svc.cluster.local
serviceName:linkis-cg-engineconnmanager
str:linkis-cg-engineconnmanager-linkis-cg-engineconnmanager-0.linkis-svc.default.svc.cluster.local:9104
after setStringValue:
instance = -0.linkis-svc.default.svc.cluster.local:9104
correct value should be: linkis-cg-engineconnmanager-0.linkis-svc.default.svc.cluster.local:9104

### Brief change log
- replace replace with replaceFirst in EMInstanceLabel.java and EngineInstanceLabel.java 

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: ( no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not applicable)