### PR TITLE
Support kerberos proxy user in Flink engine

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/launch/FlinkEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/launch/FlinkEngineConnLaunchBuilder.scala
@@ -22,7 +22,8 @@ import org.apache.linkis.engineconnplugin.flink.config.FlinkResourceConfiguratio
 import org.apache.linkis.manager.engineplugin.common.conf.EnvConfiguration
 import org.apache.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
 import org.apache.linkis.manager.engineplugin.common.launch.process.JavaProcessEngineConnLaunchBuilder
-
+import org.apache.linkis.hadoop.common.conf.HadoopConf
+import org.apache.linkis.manager.engineplugin.common.launch.process.Environment.{USER, variable}
 
 class FlinkEngineConnLaunchBuilder extends JavaProcessEngineConnLaunchBuilder {
 
@@ -34,6 +35,10 @@ class FlinkEngineConnLaunchBuilder extends JavaProcessEngineConnLaunchBuilder {
 
   override protected def getNecessaryEnvironment(implicit engineConnBuildRequest: EngineConnBuildRequest): Array[String] =
     Array(FLINK_HOME_ENV, FLINK_CONF_DIR_ENV) ++: super.getNecessaryEnvironment
+
+  override protected def getExtractJavaOpts: String = {
+    if (!HadoopConf.KEYTAB_PROXYUSER_ENABLED.getValue) super.getExtractJavaOpts else super.getExtractJavaOpts + s" -DHADOOP_PROXY_USER=${variable(USER)}".trim
+  }
 
   override protected def ifAddHiveConfigPath: Boolean = true
 


### PR DESCRIPTION
### What is the purpose of the change
Support kerberos proxy user in Flink engine.

### Brief change log
- If kerberos proxy user is enabled, will add current user as proxy user, and append it into engine jar start command as new environment variables, so that the method UserGroupInformation.getCurrentUser().getUserName() can fetch.

### Verifying this change
This change added tests and can be verified as follows:  
(example:)  
- Make sure your cluster has integrated with kerberos;
- Remove the remark of kerberos setting, switch the wds.linkis.keytab.host.enabled and wds.linkis.keytab.proxyuser.enable onto true;
- Set security.kerberos.login.use-ticket-cache: true in flink-conf.yaml, but don't specify the keytab.
- Use Linkis API to submit Flink task, then the USER in Yarn UI will be the current user in Linkis.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)