### PR TITLE
Add special judgment for uri without user login in Linkis-module.

### DIFF
--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/ServerConfiguration.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/ServerConfiguration.scala
@@ -77,6 +77,7 @@ object ServerConfiguration extends Logging{
   val BDP_SERVER_RESTFUL_URI = CommonVars("wds.linkis.server.restful.uri", "/api/rest_j/" + BDP_SERVER_VERSION)
   val BDP_SERVER_USER_URI = CommonVars("wds.linkis.server.user.restful.uri", "/api/rest_j/" + BDP_SERVER_VERSION + "/user")
   val BDP_SERVER_RESTFUL_LOGIN_URI = CommonVars("wds.linkis.server.user.restful.login.uri", new File(BDP_SERVER_USER_URI.getValue, "login").getPath)
+  val BDP_SERVER_RESTFUL_PASS_AUTH_REQUEST_URI = CommonVars("wds.linkis.server.user.restful.uri.pass.auth", "").getValue.split(",")
   val BDP_SERVER_SECURITY_SSL_URI = CommonVars("wds.linkis.server.user.security.ssl.uri", new File(BDP_SERVER_USER_URI.getValue, "publicKey").getPath)
   val BDP_SERVER_SOCKET_URI = CommonVars("wds.linkis.server.socket.uri", "/ws")
   val BDP_SERVER_SOCKET_LOGIN_URI = CommonVars("wds.linkis.server.socket.login.uri", "/ws/user/login")

--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/SecurityFilter.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/SecurityFilter.scala
@@ -70,7 +70,10 @@ class SecurityFilter extends Filter {
       false
     } else if(request.getRequestURI == ServerConfiguration.BDP_SERVER_RESTFUL_LOGIN_URI.getValue) {
       true
-    } else {
+    } else if( ServerConfiguration.BDP_SERVER_RESTFUL_PASS_AUTH_REQUEST_URI.exists(request.getRequestURI.startsWith)) {
+      SecurityFilter.info("pass auth uri: " + request.getRequestURI)
+      true
+    }else {
       val userName = Utils.tryCatch(SecurityFilter.getLoginUser(request)){
         case n: NonLoginException =>
           if(Configuration.IS_TEST_MODE.getValue) None else {


### PR DESCRIPTION
### What is the purpose of the change
Due to access to third-party monitoring or other reasons, it is necessary to call some APIs of linkis without userlogin. At present, you can set  setting the gateway parameter wds.links.gateway.conf.url.pass.auth for uri without login. However, the operation of obtaining the login user name is added in the linkis module by default, resulting in failure.


### Brief change log
- Add wds.linkis.server.user.restful.uri.pass.auth param,default '';
- Add special judgment for uri without user login.

### Verifying this change
This change added tests and can be verified as follows:  
(example /api/rest_j/v1/linkisManager/listAllEMs :)  
- 1. set wds.links.gateway.conf.url.pass.auth=/dws/,/api/rest_j/v1/linkisManager/listAllEMs in linkis-mg-gateway.properties
- 2. set wds.linkis.server.user.restful.uri.pass.auth =/api/rest_j/v1/linkisManager/listAllEMs, in linkis-cg-linkismanager.properties ;
- 3. in web browser or postman, call uri: ${gatewayhost:port}/api/rest_j/v1/linkisManager/listAllEMs ;
- 4. if result like '{"method":"/api/linkisManager/listAllEMs","status":0,"message":"OK","data":{"EMs":[{,....' ,will be ok.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)