### PR TITLE
Add kafka,json and hadoop-mapreduce-client-core jar in flink engine

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
@@ -187,11 +187,19 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-hive_2.11</artifactId>
+            <artifactId>flink-connector-hive_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
-<!--            <scope>provided</scope>-->
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-kafka_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
         <!-- flink end-->
 
         <dependency>
@@ -306,6 +314,17 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-logging</artifactId>
+                    <groupId>commons-logging</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.linkis</groupId>


### PR DESCRIPTION
### What is the purpose of the change
1. Fix a ClassNotfoundException issue because of lacking hadoop-mapreduce-client-core dependency in Flink engine pom;
2. Since Kafka and Json are the more usual used in Flink streaming use case, it's necessary to add on in pom, in case user use them in Flink SQL.

### Brief change log
- Add kafka, json and hadoop-mapreduce-client-core jar in flink engine pom.

### Verifying this change
This change is already covered by existing tests.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)