### PR TITLE
Optimize the OnceEngineConn architecture and Flink EngineConn.

### DIFF
--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/conf/ECMErrorCode.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/conf/ECMErrorCode.scala
@@ -23,4 +23,6 @@ object ECMErrorCode {
 
   val PROCESS_WAITFOR_ERROR = 20001
 
+  val EC_START_FAILED = 11102
+
 }

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/service/impl/AbstractEngineConnLaunchService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/service/impl/AbstractEngineConnLaunchService.scala
@@ -63,6 +63,7 @@ abstract class AbstractEngineConnLaunchService extends EngineConnLaunchService w
 
   override def launchEngineConn(request: EngineConnLaunchRequest, duration: Long): EngineNode = {
     //1.创建engineConn和runner,launch 并设置基础属性
+    info(s"Try to launch a new EngineConn with $request.")
     val conn = createEngineConn
     val runner = createEngineConnLaunchRunner
     val launch = createEngineConnLaunch

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/creation/OnceExecutorManager.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/creation/OnceExecutorManager.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.once.executor.creation
+
+import org.apache.linkis.engineconn.core.executor.{ExecutorManager, LabelExecutorManager, LabelExecutorManagerImpl}
+import org.apache.linkis.engineconn.executor.entity.{Executor, SensibleExecutor}
+import org.apache.linkis.engineconn.once.executor.OnceExecutor
+import org.apache.linkis.engineconn.once.executor.exception.OnceEngineConnErrorException
+import org.apache.linkis.manager.label.entity.Label
+
+
+trait OnceExecutorManager extends LabelExecutorManager {
+
+  override def getReportExecutor: OnceExecutor
+
+}
+
+object OnceExecutorManager {
+
+  private lazy val executorManager = ExecutorManager.getInstance match {
+    case manager: OnceExecutorManager => manager
+  }
+
+  def getInstance: OnceExecutorManager = executorManager
+
+}
+
+class OnceExecutorManagerImpl extends LabelExecutorManagerImpl with OnceExecutorManager {
+
+  override def getReportExecutor: OnceExecutor = if (getExecutors.isEmpty) {
+    val labels = if (null == engineConn.getEngineCreationContext.getLabels()) throw new OnceEngineConnErrorException(12560, "No labels is exists.")
+    else engineConn.getEngineCreationContext.getLabels()
+    createExecutor(engineConn.getEngineCreationContext, labels.toArray[Label[_]](Array.empty[Label[_]])).asInstanceOf[OnceExecutor]
+  } else getExecutors.filter(_.isInstanceOf[OnceExecutor]).maxBy {
+    case executor: SensibleExecutor => executor.getStatus.ordinal()
+    case executor: Executor => executor.getId.hashCode
+  }.asInstanceOf[OnceExecutor]
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/execution/OnceEngineConnExecution.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/execution/OnceEngineConnExecution.scala
@@ -16,16 +16,19 @@
 
 package org.apache.linkis.engineconn.once.executor.execution
 
+import org.apache.linkis.DataWorkCloudApplication
 import org.apache.linkis.common.exception.LinkisException
 import org.apache.linkis.common.utils.Utils
 import org.apache.linkis.engineconn.common.creation.EngineCreationContext
 import org.apache.linkis.engineconn.common.engineconn.EngineConn
+import org.apache.linkis.engineconn.common.execution.EngineConnExecution
 import org.apache.linkis.engineconn.core.execution.AbstractEngineConnExecution
+import org.apache.linkis.engineconn.executor.conf.EngineConnExecutorConfiguration
 import org.apache.linkis.engineconn.executor.entity.Executor
 import org.apache.linkis.engineconn.once.executor.OnceExecutor
 import org.apache.linkis.engineconn.once.executor.exception.OnceEngineConnErrorException
 import org.apache.linkis.manager.label.entity.engine.EngineConnMode._
-import org.apache.linkis.manager.label.entity.engine.{CodeLanguageLabel, RunType}
+import org.apache.linkis.manager.label.entity.engine.{CodeLanguageLabel, EngineConnModeLabel, RunType}
 import org.apache.linkis.scheduler.executer.{AsynReturnExecuteResponse, ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
 
 import scala.collection.convert.decorateAsScala._
@@ -98,5 +101,29 @@ class OnceEngineConnExecution extends AbstractEngineConnExecution {
 object OnceEngineConnExecution {
 
   def getSupportedEngineConnModes: Array[EngineConnMode] = Array(Once, Computation_With_Once, Once_With_Cluster)
+
+}
+
+
+class OnceExecutorManagerEngineConnExecution extends EngineConnExecution {
+
+  override def execute(engineCreationContext: EngineCreationContext, engineConn: EngineConn): Unit = {
+    var shouldSet = false
+    engineCreationContext.getLabels().asScala.foreach {
+      case engineConnModeLabel: EngineConnModeLabel =>
+        val mode = toEngineConnMode(engineConnModeLabel.getEngineConnMode)
+        shouldSet = OnceEngineConnExecution.getSupportedEngineConnModes.contains(mode)
+      case _ =>
+    }
+    if(shouldSet) DataWorkCloudApplication.setProperty(EngineConnExecutorConfiguration.EXECUTOR_MANAGER_CLASS.key,
+      "com.webank.wedatasphere.linkis.engineconn.once.executor.creation.OnceExecutorManagerImpl")
+  }
+
+  /**
+   * The smallest got the first execution opportunity.
+   *
+   * @return
+   */
+  override def getOrder: Int = 4
 
 }

--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/execute/ComputationEngineConnExecution.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/execute/ComputationEngineConnExecution.scala
@@ -60,7 +60,7 @@ class ComputationExecutorManagerEngineConnExecution extends EngineConnExecution 
       case engineConnModeLabel: EngineConnModeLabel =>
         val mode = toEngineConnMode(engineConnModeLabel.getEngineConnMode)
         shouldSet = ComputationEngineConnExecution.getSupportedEngineConnModes.contains(mode)
-      case _ => false
+      case _ =>
     }
     if(shouldSet) DataWorkCloudApplication.setProperty(EngineConnExecutorConfiguration.EXECUTOR_MANAGER_CLASS.key,
       "org.apache.linkis.engineconn.computation.executor.creation.ComputationExecutorManagerImpl")

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-launch/src/main/scala/org/apache/linkis/engineconn/launch/EngineConnServer.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-launch/src/main/scala/org/apache/linkis/engineconn/launch/EngineConnServer.scala
@@ -61,9 +61,9 @@ object EngineConnServer extends Logging {
       EngineConnHook.getEngineConnHooks.foreach(_.afterEngineServerStartSuccess(getEngineCreationContext, engineConn))
     } catch {
       case t: Throwable =>
-      EngineConnHook.getEngineConnHooks.foreach(_.afterEngineServerStartFailed(getEngineCreationContext, t))
-      error("EngineConnServer Start Failed", t)
-      System.exit(1)
+        error("EngineConnServer Start Failed", t)
+        EngineConnHook.getEngineConnHooks.foreach(_.afterEngineServerStartFailed(getEngineCreationContext, t))
+        System.exit(1)
     }
 
     //4. 等待Executions执行完毕

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/YarnApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/YarnApplicationClusterDescriptorAdapter.java
@@ -17,16 +17,17 @@
  */
 package org.apache.linkis.engineconnplugin.flink.client.deployment;
 
-import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
-import org.apache.linkis.engineconnplugin.flink.exception.JobExecutionException;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import org.apache.flink.api.common.JobID;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.yarn.YarnClusterDescriptor;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
+import org.apache.linkis.engineconnplugin.flink.exception.JobExecutionException;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public class YarnApplicationClusterDescriptorAdapter extends ClusterDescriptorAdapter  {
 
@@ -46,7 +47,7 @@ public class YarnApplicationClusterDescriptorAdapter extends ClusterDescriptorAd
             super.clusterID  = clusterClient.getClusterId();
             super.webInterfaceUrl = clusterClient.getWebInterfaceURL();
         } catch (Exception e) {
-            throw new JobExecutionException(e.getMessage());
+            throw new JobExecutionException(ExceptionUtils.getRootCauseMessage(e), e);
         }
 
     }

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/factory/LinkisYarnClusterClientFactory.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/factory/LinkisYarnClusterClientFactory.java
@@ -87,14 +87,16 @@ public class LinkisYarnClusterClientFactory extends YarnClusterClientFactory imp
     public void close() throws IOException {
         if(yarnClient != null) {
             ApplicationId applicationId = getClusterId(configuration);
-            LOG.info("Begin to kill application {}", applicationId);
-            try {
-                yarnClient.killApplication(applicationId);
-            } catch (YarnException e) {
-                LOG.error("Failed to kill application {}", applicationId, e);
+            if(applicationId != null) {
+                LOG.info("Begin to kill application {}", applicationId);
+                try {
+                    yarnClient.killApplication(applicationId);
+                } catch (YarnException e) {
+                    LOG.error("Failed to kill application {}.", applicationId, e);
+                }
             }
             yarnClient.close();
-            LOG.info("End to kill application {}", applicationId);
+            LOG.info("End to kill application {},", applicationId);
         } else{
             LOG.warn("yarnClient is null, this is not able to kill application");
         }

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/InsertOperation.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/InsertOperation.java
@@ -95,16 +95,21 @@ public class InsertOperation extends AbstractJobOperation {
 
     protected void asyncNotify(TableResult tableResult) {
         CompletableFuture.completedFuture(tableResult)
-            .thenAccept(result -> {
+            .thenApply(result -> {
                 CloseableIterator<Row> iterator = result.collect();
                 int affected = 0;
                 while(iterator.hasNext()) {
                     Row row = iterator.next();
-                    affected = (int) row.getField(0);
+                    affected = Integer.parseInt(row.getField(0).toString());
                 }
-                int finalAffected = affected;
-                getFlinkStatusListeners().forEach(listener -> listener.onSuccess(finalAffected, RowsType.Affected()));
-            }).whenComplete((unused, throwable) -> getFlinkStatusListeners().forEach(listener -> listener.onFailed("Error while submitting job.", throwable, RowsType.Affected())));
+                return affected;
+            }).whenComplete((affected, throwable) -> {
+                if(throwable != null) {
+                    getFlinkStatusListeners().forEach(listener -> listener.onFailed("Error while submitting job.", throwable, RowsType.Affected()));
+                } else {
+                    getFlinkStatusListeners().forEach(listener -> listener.onSuccess(affected, RowsType.Affected()));
+                }
+            });
     }
 
 }

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
@@ -27,9 +27,10 @@ object FlinkEnvConfiguration {
 
   val FLINK_HOME_ENV = "FLINK_HOME"
   val FLINK_CONF_DIR_ENV = "FLINK_CONF_DIR"
+  val FLINK_VERSION = CommonVars("flink.version", "1.12.2")
   val FLINK_HOME = CommonVars("flink.home", CommonVars(FLINK_HOME_ENV, "/appcom/Install/flink").getValue)
   val FLINK_CONF_DIR = CommonVars("flink.conf.dir", CommonVars(FLINK_CONF_DIR_ENV, "/appcom/config/flink-config").getValue)
-  val FLINK_DIST_JAR_PATH = CommonVars("flink.dist.jar.path", CommonVars(FLINK_HOME_ENV, "/appcom/Install/flink").getValue + "/lib/flink-dist_2.11-1.12.2.jar")
+  val FLINK_DIST_JAR_PATH = CommonVars("flink.dist.jar.path", FLINK_HOME.getValue + s"/lib/flink-dist_2.11-${FLINK_VERSION.getValue}.jar")
   val FLINK_LIB_REMOTE_PATH = CommonVars("flink.lib.path", "")
   val FLINK_USER_LIB_REMOTE_PATH = CommonVars("flink.user.lib.path", "", "The hdfs lib path of each user in Flink EngineConn.")
   val FLINK_LIB_LOCAL_PATH = CommonVars("flink.local.lib.path", "/appcom/Install/flink/lib", "The local lib path of Flink EngineConn.")
@@ -48,6 +49,7 @@ object FlinkEnvConfiguration {
   val FLINK_APPLICATION_ARGS = CommonVars("flink.app.args", "")
   val FLINK_APPLICATION_MAIN_CLASS = CommonVars("flink.app.main.class", "")
   val FLINK_APPLICATION_MAIN_CLASS_JAR = CommonVars("flink.app.main.class.jar", "")
+  val FLINK_APPLICATION_CLASSPATH = CommonVars("flink.app.user.class.path", "")
 
   val FLINK_CLIENT_REQUEST_TIMEOUT = CommonVars("flink.client.request.timeout", new TimeType("30s"))
   val FLINK_ONCE_APP_STATUS_FETCH_INTERVAL = CommonVars("flink.app.fetch.status.interval", new TimeType("5s"))

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkJarOnceExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkJarOnceExecutor.scala
@@ -43,6 +43,7 @@ class FlinkJarOnceExecutor(override val id: Long,
 
   override protected def waitToRunning(): Unit = {
     Utils.waitUntil(() => clusterDescriptor.initJobId(), Duration.Inf)
+    setJobID(clusterDescriptor.getJobId.toHexString)
     super.waitToRunning()
   }
 }

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkOnceExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkOnceExecutor.scala
@@ -50,11 +50,10 @@ trait FlinkOnceExecutor[T <: ClusterDescriptorAdapter] extends ManageableOnceExe
     if(isCompleted) return
     if (null == clusterDescriptor.getClusterID)
       throw new ExecutorInitException("The application start failed, since yarn applicationId is null.")
-    if(clusterDescriptor.getJobId != null) setJobID(clusterDescriptor.getJobId.toHexString)
     setApplicationId(clusterDescriptor.getClusterID.toString)
     setApplicationURL(clusterDescriptor.getWebInterfaceUrl)
     info(s"Application is started, applicationId: $getApplicationId, applicationURL: $getApplicationURL.")
-    info(s"Application is started, applicationId: ${clusterDescriptor.getClusterID}, webUrl: ${clusterDescriptor.getWebInterfaceUrl}.")
+    if(clusterDescriptor.getJobId != null) setJobID(clusterDescriptor.getJobId.toHexString)
   }
 
   protected def isCompleted: Boolean = isClosed || NodeStatus.isCompleted(getStatus)
@@ -66,12 +65,12 @@ trait FlinkOnceExecutor[T <: ClusterDescriptorAdapter] extends ManageableOnceExe
   override def getId: String = "FlinkOnceApp_"+ id
 
   protected def closeDaemon(): Unit = {
-    if(daemonThread != null) daemonThread.cancel(true)
+    if (daemonThread != null) daemonThread.cancel(true)
   }
 
   override def close(): Unit = {
     closeDaemon()
-    if(clusterDescriptor != null) {
+    if (clusterDescriptor != null) {
       clusterDescriptor.cancelJob()
       clusterDescriptor.close()
     }
@@ -81,9 +80,16 @@ trait FlinkOnceExecutor[T <: ClusterDescriptorAdapter] extends ManageableOnceExe
 
   override protected def waitToRunning(): Unit = {
     if(!isCompleted) daemonThread = Utils.defaultScheduler.scheduleAtFixedRate(new Runnable {
+      private var lastStatus: JobStatus = JobStatus.INITIALIZING
+      private var lastPrintTime = 0l
+      private val printInterval = math.max(FLINK_ONCE_APP_STATUS_FETCH_INTERVAL.getValue.toLong, 5 * 60 * 1000)
       override def run(): Unit = {
         val jobStatus = clusterDescriptor.getJobStatus
-        info(s"The jobStatus of $getJobID is $jobStatus.")
+        if (jobStatus != lastStatus || System.currentTimeMillis -lastPrintTime >= printInterval) {
+          info(s"The jobStatus of $getJobID is $jobStatus.")
+          lastPrintTime = System.currentTimeMillis
+        }
+        lastStatus = jobStatus
         jobStatus match {
           case JobStatus.FAILED | JobStatus.CANCELED =>
             tryFailed()
@@ -93,21 +99,6 @@ trait FlinkOnceExecutor[T <: ClusterDescriptorAdapter] extends ManageableOnceExe
         }
       }
     }, FLINK_ONCE_APP_STATUS_FETCH_INTERVAL.getValue.toLong, FLINK_ONCE_APP_STATUS_FETCH_INTERVAL.getValue.toLong, TimeUnit.MILLISECONDS)
-  }
-
-
-  override def trySucceed(): Boolean = {
-    super.trySucceed()
-    warn(s"$getId has finished with status $getStatus, now stop it.")
-    ShutdownHook.getShutdownHook.notifyStop()
-    true
-  }
-
-  override def tryFailed(): Boolean = {
-    super.tryFailed()
-    error(s"$getId has failed with status $getStatus, now stop it.")
-    ShutdownHook.getShutdownHook.notifyStop()
-    true
   }
 
   override def supportCallBackLogs(): Boolean = true

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkSQLComputationExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkSQLComputationExecutor.scala
@@ -131,6 +131,12 @@ class FlinkSQLComputationExecutor(id: Long,
 
   override def getProgressInfo: Array[JobProgressInfo] = Array.empty
 
+  override def killTask(taskId: String): Unit = {
+    info(s"Start to kill task $taskId, the flink jobId is ${clusterDescriptor.getJobId}.")
+    if(operation != null) operation.cancelJob()
+    super.killTask(taskId)
+  }
+
   override def getId: String = "FlinkComputationSQL_"+ id
 
   override def close(): Unit = {

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/launch/FlinkEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/launch/FlinkEngineConnLaunchBuilder.scala
@@ -17,13 +17,20 @@
  */
 package org.apache.linkis.engineconnplugin.flink.launch
 
+import java.util
+
+import org.apache.linkis.common.utils.JsonUtils
 import org.apache.linkis.engineconnplugin.flink.config.FlinkEnvConfiguration._
 import org.apache.linkis.engineconnplugin.flink.config.FlinkResourceConfiguration
 import org.apache.linkis.manager.engineplugin.common.conf.EnvConfiguration
 import org.apache.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
 import org.apache.linkis.manager.engineplugin.common.launch.process.JavaProcessEngineConnLaunchBuilder
 import org.apache.linkis.hadoop.common.conf.HadoopConf
+import org.apache.linkis.manager.common.protocol.bml.BmlResource
 import org.apache.linkis.manager.engineplugin.common.launch.process.Environment.{USER, variable}
+import org.apache.linkis.manager.label.entity.engine.UserCreatorLabel
+
+import scala.collection.JavaConverters._
 
 class FlinkEngineConnLaunchBuilder extends JavaProcessEngineConnLaunchBuilder {
 
@@ -31,6 +38,47 @@ class FlinkEngineConnLaunchBuilder extends JavaProcessEngineConnLaunchBuilder {
     val properties = engineConnBuildRequest.engineConnCreationDesc.properties
     properties.put(EnvConfiguration.ENGINE_CONN_MEMORY.key, FlinkResourceConfiguration.LINKIS_FLINK_CLIENT_MEMORY.getValue(properties) + "G")
     super.getCommands
+  }
+
+  override protected def getBmlResources(implicit engineConnBuildRequest: EngineConnBuildRequest): util.List[BmlResource] = {
+    val bmlResources = new util.ArrayList[BmlResource](super.getBmlResources)
+    val properties = engineConnBuildRequest.engineConnCreationDesc.properties
+    val userName = engineConnBuildRequest.labels.asScala.find(_.isInstanceOf[UserCreatorLabel])
+      .map { case label: UserCreatorLabel => label.getUser}.get
+    properties.get("flink.app.main.class.jar.bml.json") match {
+      case mainClassJarContent: String =>
+        val bmlResource = contentToBmlResource(userName, mainClassJarContent)
+        info(s"Add a BmlResource(${bmlResource.getFileName}, ${bmlResource.getResourceId}, ${bmlResource.getVersion}) for user $userName and ticketId ${engineConnBuildRequest.ticketId}.")
+        bmlResources.add(bmlResource)
+        properties.remove("flink.app.main.class.jar.bml.json")
+      case _ =>
+    }
+    properties.get("flink.app.user.class.path.bml.json") match {
+      case classpathContent: String =>
+        val contentList = JsonUtils.jackson.readValue(classpathContent, classOf[util.List[util.Map[String, Object]]])
+        contentList.asScala.map(contentToBmlResource(userName, _)).foreach { bmlResource =>
+          info(s"Add a BmlResource(${bmlResource.getFileName}, ${bmlResource.getResourceId}, ${bmlResource.getVersion}) for user $userName and ticketId ${engineConnBuildRequest.ticketId}.")
+          bmlResources.add(bmlResource)
+        }
+        properties.remove("flink.app.user.class.path.bml.json")
+      case _ =>
+    }
+    bmlResources
+  }
+
+  private def contentToBmlResource(userName: String, content: String): BmlResource = {
+    val contentMap = JsonUtils.jackson.readValue(content, classOf[util.Map[String, Object]])
+    contentToBmlResource(userName, contentMap)
+  }
+
+  private def contentToBmlResource(userName: String, contentMap: util.Map[String, Object]): BmlResource = {
+    val bmlResource = new BmlResource
+    bmlResource.setFileName(contentMap.get("fileName").asInstanceOf[String])
+    bmlResource.setResourceId(contentMap.get("resourceId").asInstanceOf[String])
+    bmlResource.setVersion(contentMap.get("version").asInstanceOf[String])
+    bmlResource.setOwner(userName)
+    bmlResource.setVisibility(BmlResource.BmlResourceVisibility.Private)
+    bmlResource
   }
 
   override protected def getNecessaryEnvironment(implicit engineConnBuildRequest: EngineConnBuildRequest): Array[String] =


### PR DESCRIPTION
### What is the purpose of the change
Optimize the OnceEngineConn architecture and Flink EngineConn.

### Brief change log
- Fix a bug that will cause the Insert sql to never stop during debugging.
- Optimize the kill operation of Flink computation executor.
- Optimize OnceEngineConn architecture.
- Add some logs for engineConn launch.
- Optimize the localization process of private BmlResource.
- Optimize the shutdown process of Once EngineConn.
- Optimize the execution of Once EngineConn.
- Optimize the BmlResources launch style of flink jar EngineConn.
- Optimize flink EngineConn in prod mode for jar application submitting.
- Fixes some bugs for Flink EngineConn.
- Fixes the bug which will cause the job failed when InsertOperation stopped.
- Optimize flink EngineConn in prod mode, reduce the print log of job status.
