### PR TITLE
upgrade maven-assembly-plugin 2.3 to 3.2.0 and add asf parent pom

### DIFF
--- a/assembly-combined-package/assembly-combined/pom.xml
+++ b/assembly-combined-package/assembly-combined/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>dist</id>

--- a/assembly-combined-package/assembly-combined/public-module-combined/pom.xml
+++ b/assembly-combined-package/assembly-combined/public-module-combined/pom.xml
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/assembly-combined-package/pom.xml
+++ b/assembly-combined-package/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>dist</id>

--- a/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-application/pom.xml
+++ b/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-application/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/pom.xml
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/pom.xml
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-computation-governance/linkis-entrance/pom.xml
+++ b/linkis-computation-governance/linkis-entrance/pom.xml
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/pom.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/pom.xml
@@ -144,7 +144,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
@@ -449,7 +449,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/pom.xml
@@ -302,7 +302,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/pom.xml
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/pipeline/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/pipeline/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/python/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/python/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/shell/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/shell/pom.xml
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/engineconn-plugins/spark/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/pom.xml
@@ -342,7 +342,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/pom.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/pom.xml
@@ -143,7 +143,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-extensions/linkis-io-file-client/pom.xml
+++ b/linkis-extensions/linkis-io-file-client/pom.xml
@@ -65,7 +65,7 @@
            <!-- <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-public-enhancements/linkis-bml/linkis-bml-server/pom.xml
+++ b/linkis-public-enhancements/linkis-bml/linkis-bml-server/pom.xml
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-server/pom.xml
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-server/pom.xml
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/pom.xml
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-public-enhancements/linkis-datasource/metadatamanager/service/hive/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/metadatamanager/service/hive/pom.xml
@@ -109,7 +109,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.0</version>
         <inherited>false</inherited>
         <executions>
           <execution>

--- a/linkis-public-enhancements/linkis-publicservice/pom.xml
+++ b/linkis-public-enhancements/linkis-publicservice/pom.xml
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-server-support/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-server-support/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 WeBank
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~  you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +20,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>23</version>
+    </parent>
+
 
     <groupId>org.apache.linkis</groupId>
     <artifactId>linkis</artifactId>
@@ -123,6 +134,8 @@
         <commons-io.version>2.4</commons-io.version>
         <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
         <assembly.package.rootpath>${basedir}</assembly.package.rootpath>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencyManagement>
@@ -438,8 +451,18 @@
                             <exclude>**/.idea/</exclude>
                             <exclude>**/*.iml</exclude>
                             <exclude>**/*.txt</exclude>
-                            <exclude>**/*.properties</exclude>
-                            <exclude>**/*.sh</exclude>
+                            <exclude>**/*.svg</exclude>
+                            <exclude>**/*.png</exclude>
+                            <exclude>**/*.json</exclude>
+                            <exclude>**/*.patch</exclude>
+
+                            <exclude>**/*.editorconfig</exclude>
+                            <exclude>**/*.env</exclude>
+                            <exclude>**/*.eslintignore</exclude>
+                            <exclude>**/*.jshintrc</exclude>
+                            <exclude>**/*.patch</exclude>
+<!--                            <exclude>**/*.properties</exclude>-->
+<!--                            <exclude>**/*.sh</exclude>-->
                             <exclude>**/*.md</exclude>
                             <exclude>.git/</exclude>
                             <exclude>.gitignore</exclude>


### PR DESCRIPTION
### What is the purpose of the change
upgrade maven-assembly-plugin 2.3 to 3.2.0 and add asf parent pom

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)
- Anything that affects deployment: (yes)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes)

### Documentation
- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (not documented)