### PR TITLE
Add the support of EngineConn common operators and OnceEngineConn common operators.

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/LinkisManagerClient.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/LinkisManagerClient.scala
@@ -19,8 +19,8 @@ package org.apache.linkis.computation.client.once
 
 import java.io.Closeable
 
-import org.apache.linkis.computation.client.once.action.{CreateEngineConnAction, EngineOperateAction, GetEngineConnAction, KillEngineConnAction, LinkisManagerAction}
-import org.apache.linkis.computation.client.once.result.{CreateEngineConnResult, EngineOperateResult, GetEngineConnResult, KillEngineConnResult, LinkisManagerResult}
+import org.apache.linkis.computation.client.once.action.{CreateEngineConnAction, EngineConnOperateAction, GetEngineConnAction, KillEngineConnAction, LinkisManagerAction}
+import org.apache.linkis.computation.client.once.result.{CreateEngineConnResult, EngineConnOperateResult, GetEngineConnResult, KillEngineConnResult, LinkisManagerResult}
 import org.apache.linkis.httpclient.dws.DWSHttpClient
 import org.apache.linkis.httpclient.request.Action
 import org.apache.linkis.ujes.client.{UJESClient, UJESClientImpl}
@@ -34,7 +34,7 @@ trait LinkisManagerClient extends Closeable {
 
   def killEngineConn(killEngineConnAction: KillEngineConnAction): KillEngineConnResult
 
-  def executeEngineOperation(engineOperateAction: EngineOperateAction): EngineOperateResult
+  def executeEngineConnOperation(engineOperateAction: EngineConnOperateAction): EngineConnOperateResult
 
 }
 object LinkisManagerClient {
@@ -61,7 +61,7 @@ class LinkisManagerClientImpl(ujesClient: UJESClient) extends LinkisManagerClien
 
   override def killEngineConn(killEngineConnAction: KillEngineConnAction): KillEngineConnResult = execute(killEngineConnAction)
 
-  override def executeEngineOperation(engineOperateAction: EngineOperateAction): EngineOperateResult = execute(engineOperateAction)
+  override def executeEngineConnOperation(engineOperateAction: EngineConnOperateAction): EngineConnOperateResult = execute(engineOperateAction)
 
   override def close(): Unit = ujesClient.close()
 }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineConnOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineConnOperateAction.scala
@@ -19,46 +19,46 @@ package org.apache.linkis.computation.client.once.action
 
 import java.util
 
-class EngineOperateAction extends GetEngineConnAction {
+class EngineConnOperateAction extends GetEngineConnAction {
 
-  override def suffixURLs: Array[String] = Array("linkisManager", "executeEngineOperation")
+  override def suffixURLs: Array[String] = Array("linkisManager", "executeEngineConnOperation")
 
 }
 
-object EngineOperateAction {
+object EngineConnOperateAction {
 
   val OPERATOR_NAME_KEY = "__operator_name__"
 
   def newBuilder(): Builder = new Builder
 
-  class Builder extends ServiceInstanceBuilder[EngineOperateAction] {
+  class Builder extends ServiceInstanceBuilder[EngineConnOperateAction] {
 
     private var operatorName = ""
 
-    private var properties: util.Map[String, Any] = new util.HashMap[String, Any]
+    private var parameters: util.Map[String, Any] = new util.HashMap[String, Any]
 
     def operatorName(operatorName: String): this.type  = {
       this.operatorName = operatorName
       this
     }
 
-    def setProperties(properties: util.Map[String, Any]): this.type = {
-      this.properties = properties
+    def setParameters(properties: util.Map[String, Any]): this.type = {
+      this.parameters = properties
       this
     }
 
-    def addProperty(key: String, value: Any): this.type = {
-      if (this.properties == null) {
-        this.properties = new util.HashMap[String, Any]
+    def addParameter(key: String, value: Any): this.type = {
+      if (this.parameters == null) {
+        this.parameters = new util.HashMap[String, Any]
       }
-      this.properties.put(key, value)
+      this.parameters.put(key, value)
       this
     }
 
-    override protected def createGetEngineConnAction(): EngineOperateAction = {
-      val action = new EngineOperateAction
-      addProperty(OPERATOR_NAME_KEY, operatorName)
-      action.addRequestPayload("properties", properties)
+    override protected def createGetEngineConnAction(): EngineConnOperateAction = {
+      val action = new EngineConnOperateAction
+      addParameter(OPERATOR_NAME_KEY, operatorName)
+      action.addRequestPayload("parameters", parameters)
       action
     }
   }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineConnOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineConnOperateAction.scala
@@ -42,8 +42,8 @@ object EngineConnOperateAction {
       this
     }
 
-    def setParameters(properties: util.Map[String, Any]): this.type = {
-      this.parameters = properties
+    def setParameters(parameters: util.Map[String, Any]): this.type = {
+      this.parameters = parameters
       this
     }
 

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
  * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.once.action
+
+import java.util
+
+class EngineOperateAction extends GetEngineConnAction {
+
+  override def suffixURLs: Array[String] = Array("linkisManager", "executeEngineOperation")
+
+}
+
+object EngineOperateAction {
+
+  val OPERATOR_NAME_KEY = "__operator_name__"
+
+  def newBuilder(): Builder = new Builder
+
+  class Builder extends ServiceInstanceBuilder[EngineOperateAction] {
+
+    private var operatorName = ""
+
+    private var properties: util.Map[String, Any] = new util.HashMap[String, Any]
+
+    def operatorName(operatorName: String): this.type  = {
+      this.operatorName = operatorName
+      this
+    }
+
+    def setProperties(properties: util.Map[String, Any]): this.type = {
+      this.properties = properties
+      this
+    }
+
+    def addProperty(key: String, value: Any): this.type = {
+      if (this.properties == null) {
+        this.properties = new util.HashMap[String, Any]
+      }
+      this.properties.put(key, value)
+      this
+    }
+
+    override protected def createGetEngineConnAction(): EngineOperateAction = {
+      val action = new EngineOperateAction
+      addProperty(OPERATOR_NAME_KEY, operatorName)
+      action.addRequestPayload("properties", properties)
+      action
+    }
+  }
+
+}

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/action/EngineOperateAction.scala
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
@@ -35,7 +35,7 @@ class EngineConnOperateResult extends LinkisManagerResult {
 
   def setErrorMsg(errorMsg: String): Unit = this.errorMsg = errorMsg
 
-  def setIsError(isError: Boolean): Unit = this.isError = isError
+  def setError(isError: Boolean): Unit = this.isError = isError
 
   def getResult: util.Map[String, Any] = if(isError) throw new UJESJobException(20301, errorMsg) else result
 

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
@@ -39,13 +39,9 @@ class EngineConnOperateResult extends LinkisManagerResult {
 
   def getResult: util.Map[String, Any] = if(isError) throw new UJESJobException(20301, errorMsg) else result
 
-  def getAs[T](key: String): Option[T] = {
-    if (getResult != null && result.get(key) != null) {
-      Some(result.get(key).asInstanceOf[T])
-    } else {
-      None
-    }
-  }
+  def getAsOption[T](key: String): Option[T] = Option(getAs(key))
 
+  def getAs[T](key: String): T = if(getResult != null && result.containsKey(key)) result.get(key).asInstanceOf[T]
+   else null.asInstanceOf[T]
 
 }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
@@ -20,20 +20,27 @@ package org.apache.linkis.computation.client.once.result
 import java.util
 
 import org.apache.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import org.apache.linkis.ujes.client.exception.UJESJobException
 
-@DWSHttpMessageResult("/api/rest_j/v\\d+/linkisManager/executeEngineOperation")
-class EngineOperateResult extends LinkisManagerResult {
+@DWSHttpMessageResult("/api/rest_j/v\\d+/linkisManager/executeEngineConnOperation")
+class EngineConnOperateResult extends LinkisManagerResult {
 
   private var result: util.Map[String, Any] = _
+  private var errorMsg: String = _
+  private var isError: Boolean = _
 
   def setResult(result: util.Map[String, Any]): Unit = {
     this.result = result
   }
 
-  def getResult: util.Map[String, Any] = result
+  def setErrorMsg(errorMsg: String): Unit = this.errorMsg = errorMsg
+
+  def setIsError(isError: Boolean): Unit = this.isError = isError
+
+  def getResult: util.Map[String, Any] = if(isError) throw new UJESJobException(20301, errorMsg) else result
 
   def getAs[T](key: String): Option[T] = {
-    if (result != null && result.get(key) != null) {
+    if (getResult != null && result.get(key) != null) {
       Some(result.get(key).asInstanceOf[T])
     } else {
       None

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineOperateResult.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineOperateResult.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.once.result
+
+import java.util
+
+import org.apache.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/linkisManager/executeEngineOperation")
+class EngineOperateResult extends LinkisManagerResult {
+
+  private var result: util.Map[String, Any] = _
+
+  def setResult(result: util.Map[String, Any]): Unit = {
+    this.result = result
+  }
+
+  def getResult: util.Map[String, Any] = result
+
+  def getAs[T](key: String): Option[T] = {
+    if (result != null && result.get(key) != null) {
+      Some(result.get(key).asInstanceOf[T])
+    } else {
+      None
+    }
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/OnceJobOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/OnceJobOperator.scala
@@ -52,14 +52,14 @@ trait OnceJobOperator[T] extends Operator[T] with Logging {
   override def apply(): T = {
     val builder = EngineConnOperateAction.newBuilder()
       .operatorName(getName)
-      .setUser(getUser)
-      .setApplicationName(getServiceInstance.getApplicationName)
-      .setInstance(getServiceInstance.getInstance)
+      .setUser(user)
+      .setApplicationName(serviceInstance.getApplicationName)
+      .setInstance(serviceInstance.getInstance)
     addParameters(builder)
     val engineConnOperateAction = builder.build()
-    info(s"$getUser try to ask EngineConn($getServiceInstance) to execute $getName operation, parameters is ${engineConnOperateAction.getRequestPayload}.")
-    val result = getLinkisManagerClient.executeEngineConnOperation(engineConnOperateAction)
-    info(s"$getUser asked EngineConn($getServiceInstance) to execute $getName operation, results is ${result.getResult}.")
+    info(s"$getUser try to ask EngineConn($serviceInstance) to execute $getName operation, parameters is ${engineConnOperateAction.getRequestPayload}.")
+    val result = linkisManagerClient.executeEngineConnOperation(engineConnOperateAction)
+    info(s"$getUser asked EngineConn($serviceInstance) to execute $getName operation, results is ${result.getResult}.")
     resultToObject(result)
   }
 

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
@@ -17,27 +17,21 @@
  */
 package org.apache.linkis.computation.client.operator.impl
 
-import org.apache.linkis.computation.client.once.action.EngineOperateAction
+import org.apache.linkis.computation.client.once.result.EngineConnOperateResult
 import org.apache.linkis.computation.client.operator.OnceJobOperator
+import org.apache.linkis.ujes.client.exception.UJESJobException
 
 
 class ApplicationInfoOperator extends OnceJobOperator[ApplicationInfo] {
 
   override def getName: String = ApplicationInfoOperator.OPERATOR_NAME
 
-  override def apply(): ApplicationInfo = {
-
-    val engineOperateAction = EngineOperateAction.newBuilder()
-      .operatorName(getName)
-      .setUser(getUser)
-      .setApplicationName(getServiceInstance.getApplicationName)
-      .setInstance(getServiceInstance.getInstance)
-      .build()
-
-    val result = getLinkisManagerClient.executeEngineOperation(engineOperateAction)
+  override protected def resultToObject(result: EngineConnOperateResult): ApplicationInfo = {
     ApplicationInfo(
-      result.getAs("applicationId").getOrElse(""),
-      result.getAs("applicationUrl").getOrElse(""),
+      result.getAs("applicationId")
+        .getOrElse(throw new UJESJobException(20300, s"Cannot get applicationId from EngineConn $getServiceInstance.")),
+      result.getAs("applicationUrl")
+        .getOrElse(throw new UJESJobException(20300, s"Cannot get applicationUrl from EngineConn $getServiceInstance.")),
       result.getAs("queue").getOrElse("")
     )
   }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.operator.impl
+
+import org.apache.linkis.computation.client.once.action.EngineOperateAction
+import org.apache.linkis.computation.client.operator.OnceJobOperator
+
+
+class ApplicationInfoOperator extends OnceJobOperator[ApplicationInfo] {
+
+  override def getName: String = ApplicationInfoOperator.OPERATOR_NAME
+
+  override def apply(): ApplicationInfo = {
+
+    val engineOperateAction = EngineOperateAction.newBuilder()
+      .operatorName(getName)
+      .setUser(getUser)
+      .setApplicationName(getServiceInstance.getApplicationName)
+      .setInstance(getServiceInstance.getInstance)
+      .build()
+
+    val result = getLinkisManagerClient.executeEngineOperation(engineOperateAction)
+    ApplicationInfo(
+      result.getAs("applicationId").getOrElse(""),
+      result.getAs("applicationUrl").getOrElse(""),
+      result.getAs("queue").getOrElse("")
+    )
+  }
+
+}
+
+object ApplicationInfoOperator {
+  val OPERATOR_NAME = "application"
+}
+
+case class ApplicationInfo(applicationId: String, applicationUrl: String, queue: String)

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/ApplicationInfoOperator.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
 package org.apache.linkis.computation.client.operator.impl
 
 import org.apache.linkis.computation.client.once.action.EngineOperateAction

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnApplicationInfoOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnApplicationInfoOperator.scala
@@ -22,24 +22,24 @@ import org.apache.linkis.computation.client.operator.OnceJobOperator
 import org.apache.linkis.ujes.client.exception.UJESJobException
 
 
-class ApplicationInfoOperator extends OnceJobOperator[ApplicationInfo] {
+class EngineConnApplicationInfoOperator extends OnceJobOperator[ApplicationInfo] {
 
-  override def getName: String = ApplicationInfoOperator.OPERATOR_NAME
+  override def getName: String = EngineConnApplicationInfoOperator.OPERATOR_NAME
 
   override protected def resultToObject(result: EngineConnOperateResult): ApplicationInfo = {
     ApplicationInfo(
-      result.getAs("applicationId")
+      result.getAsOption("applicationId")
         .getOrElse(throw new UJESJobException(20300, s"Cannot get applicationId from EngineConn $getServiceInstance.")),
-      result.getAs("applicationUrl")
+      result.getAsOption("applicationUrl")
         .getOrElse(throw new UJESJobException(20300, s"Cannot get applicationUrl from EngineConn $getServiceInstance.")),
-      result.getAs("queue").getOrElse("")
+      result.getAs("queue")
     )
   }
 
 }
 
-object ApplicationInfoOperator {
-  val OPERATOR_NAME = "application"
+object EngineConnApplicationInfoOperator {
+  val OPERATOR_NAME = "engineConnYarnApplication"
 }
 
 case class ApplicationInfo(applicationId: String, applicationUrl: String, queue: String)

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnCommonOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnCommonOperator.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.operator.impl
+
+import java.util
+
+import org.apache.linkis.computation.client.once.action.EngineConnOperateAction
+import org.apache.linkis.computation.client.once.result.EngineConnOperateResult
+import org.apache.linkis.computation.client.operator.OnceJobOperator
+import org.apache.linkis.ujes.client.exception.UJESJobException
+
+class EngineConnCommonOperator extends OnceJobOperator[util.Map[String, Any]] {
+
+  private var operatorName: String = _
+  private val parameters: util.Map[String, Any] = new util.HashMap[String, Any]
+
+  def setRealOperatorName(operatorName: String): Unit = this.operatorName = operatorName
+
+  def addParameter(key: String, value: Any): Unit = parameters.put(key, value)
+
+  override protected def resultToObject(result: EngineConnOperateResult): util.Map[String, Any] = result.getResult
+
+  override protected def addParameters(builder: EngineConnOperateAction.Builder): Unit = {
+    if(operatorName == null) throw new UJESJobException(20310, "realOperatorName must be set!")
+    builder.operatorName(operatorName)
+    if(!parameters.isEmpty) builder.setParameters(parameters)
+  }
+
+  override def getName: String = EngineConnCommonOperator.OPERATOR_NAME
+
+}
+object EngineConnCommonOperator {
+  val OPERATOR_NAME = "engineConnCommon"
+}

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnDiagnosisOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnDiagnosisOperator.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.operator.impl
+
+import java.util
+
+import org.apache.linkis.computation.client.once.result.EngineConnOperateResult
+import org.apache.linkis.computation.client.operator.OnceJobOperator
+
+class EngineConnDiagnosisOperator extends OnceJobOperator[util.Map[String, Object]] {
+  override protected def resultToObject(result: EngineConnOperateResult): util.Map[String, Object] =
+    result.getAs("diagnosis")
+
+  override def getName: String = EngineConnDiagnosisOperator.OPERATOR_NAME
+}
+object EngineConnDiagnosisOperator {
+  val OPERATOR_NAME = "engineConnDiagnosis"
+}

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnLogOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnLogOperator.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.operator.impl
+
+import java.util
+
+import org.apache.commons.lang.StringUtils
+import org.apache.linkis.computation.client.once.action.EngineConnOperateAction
+import org.apache.linkis.computation.client.once.result.EngineConnOperateResult
+import org.apache.linkis.computation.client.operator.OnceJobOperator
+
+
+class EngineConnLogOperator extends OnceJobOperator[EngineConnLogs]  {
+
+  private var pageSize = 100
+  private var fromLine = 1
+  private var ignoreKeywords: String = _
+  private var onlyKeywords: String = _
+  private var lastRows = 0
+
+  def setPageSize(pageSize: Int): Unit = this.pageSize = pageSize
+
+  def setFromLine(fromLine: Int): Unit = this.fromLine = fromLine
+
+  def setIgnoreKeywords(ignoreKeywords: String): Unit = this.ignoreKeywords = ignoreKeywords
+
+  def setOnlyKeywords(onlyKeywords: String): Unit = this.onlyKeywords = onlyKeywords
+
+  def setLastRows(lastRows: Int): Unit = this.lastRows = lastRows
+
+  override protected def addParameters(builder: EngineConnOperateAction.Builder): Unit = {
+    builder.addParameter("pageSize", pageSize)
+    builder.addParameter("fromLine", fromLine)
+    if(StringUtils.isNotEmpty(ignoreKeywords))
+      builder.addParameter("ignoreKeywords", ignoreKeywords)
+    if(StringUtils.isNotEmpty(onlyKeywords))
+      builder.addParameter("onlyKeywords", onlyKeywords)
+    if(lastRows > 0)
+      builder.addParameter("lastRows", lastRows)
+  }
+
+  override protected def resultToObject(result: EngineConnOperateResult): EngineConnLogs = {
+    val rows: Int = result.getAs("rows")
+    fromLine += rows
+    EngineConnLogs(result.getAs("logPath"), result.getAs("logs"),  rows)
+  }
+
+  override def getName: String = EngineConnLogOperator.OPERATOR_NAME
+
+}
+
+object EngineConnLogOperator {
+  val OPERATOR_NAME = "engineConnLog"
+}
+
+case class EngineConnLogs(logPath: String, logs: util.ArrayList[String], rows: Int)

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnMetricsOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnMetricsOperator.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.operator.impl
+
+import java.util
+
+import org.apache.linkis.computation.client.once.result.EngineConnOperateResult
+import org.apache.linkis.computation.client.operator.OnceJobOperator
+
+class EngineConnMetricsOperator extends OnceJobOperator[util.Map[String, Object]] {
+  override protected def resultToObject(result: EngineConnOperateResult): util.Map[String, Object] = {
+    result.getAs("metrics")
+  }
+
+  override def getName: String = EngineConnMetricsOperator.OPERATOR_NAME
+}
+object EngineConnMetricsOperator {
+  val OPERATOR_NAME = "engineConnMetrics"
+}

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnProgressOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/impl/EngineConnProgressOperator.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.computation.client.operator.impl
+
+import java.util
+
+import org.apache.linkis.computation.client.once.result.EngineConnOperateResult
+import org.apache.linkis.computation.client.operator.OnceJobOperator
+import org.apache.linkis.protocol.engine.JobProgressInfo
+
+import scala.collection.JavaConverters._
+
+
+class EngineConnProgressOperator extends OnceJobOperator[EngineConnProgressInfo] {
+
+  override def getName: String = EngineConnProgressOperator.OPERATOR_NAME
+
+  override protected def resultToObject(result: EngineConnOperateResult): EngineConnProgressInfo = {
+    val progressInfoList: util.ArrayList[util.Map[String, Object]] = result.getAs("progressInfo")
+    val progressInfo = progressInfoList.asScala.map(map => JobProgressInfo(map.get("id").asInstanceOf[String], map.get("totalTasks").asInstanceOf[Int],
+      map.get("runningTasks").asInstanceOf[Int], map.get("failedTasks").asInstanceOf[Int],
+      map.get("succeedTasks").asInstanceOf[Int])).toArray
+    EngineConnProgressInfo(result.getAs("progress"), progressInfo)
+  }
+
+}
+object EngineConnProgressOperator {
+  val OPERATOR_NAME = "engineConnProgress"
+}
+case class EngineConnProgressInfo(progress: Float, progressInfo: Array[JobProgressInfo])

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/OperableOnceExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/OperableOnceExecutor.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.once.executor
+
+import org.apache.linkis.protocol.engine.JobProgressInfo
+
+
+trait OperableOnceExecutor extends OnceExecutor {
+
+  def getProgress: Float
+
+  def getProgressInfo: Array[JobProgressInfo]
+
+  def getMetrics: java.util.Map[String, Any]
+
+  def getDiagnosis: java.util.Map[String, Any]
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/operator/OperableOnceEngineConnOperator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/operator/OperableOnceEngineConnOperator.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.once.executor.operator
+
+import org.apache.linkis.engineconn.acessible.executor.operator.{Operator, OperatorFactory}
+import org.apache.linkis.engineconn.common.exception.EngineConnException
+import org.apache.linkis.engineconn.once.executor.OperableOnceExecutor
+import org.apache.linkis.engineconn.once.executor.creation.OnceExecutorManager
+
+
+class OperableOnceEngineConnOperator extends Operator {
+
+  import OperableOnceEngineConnOperator._
+
+  override def getNames: Array[String] = Array(PROGRESS_OPERATOR_NAME, METRICS_OPERATOR_NAME, DIAGNOSIS_OPERATOR_NAME)
+
+  override def apply(implicit parameters: Map[String, Any]): Map[String, Any] = {
+    val operatorName = OperatorFactory().getOperatorName(parameters)
+    OnceExecutorManager.getInstance.getReportExecutor match {
+      case operableOnceExecutor: OperableOnceExecutor =>
+        operatorName match {
+          case PROGRESS_OPERATOR_NAME =>
+            Map("progress" -> operableOnceExecutor.getProgress, "progressInfo" -> operableOnceExecutor.getProgressInfo)
+          case METRICS_OPERATOR_NAME =>
+            Map("metrics" -> operableOnceExecutor.getMetrics)
+          case DIAGNOSIS_OPERATOR_NAME =>
+            Map("diagnosis" -> operableOnceExecutor.getDiagnosis)
+          case _ =>
+            throw EngineConnException(20308, s"This engineConn don't support $operatorName operator.")
+        }
+      case _ => throw EngineConnException(20308, s"This engineConn don't support $operatorName operator.")
+    }
+  }
+
+}
+object OperableOnceEngineConnOperator {
+  val PROGRESS_OPERATOR_NAME = "engineConnProgress"
+  val METRICS_OPERATOR_NAME = "engineConnMetrics"
+  val DIAGNOSIS_OPERATOR_NAME = "engineConnDiagnosis"
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/Operator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/Operator.scala
@@ -17,14 +17,10 @@
 
 package org.apache.linkis.engineconn.acessible.executor.operator
 
-import org.apache.linkis.manager.common.protocol.engine.EngineOperateResponse
-
 trait Operator {
 
   def getName: String
 
-  def init(properties: Map[String, Any])
-
-  def apply(): EngineOperateResponse
+  def apply(parameters: Map[String, Any]): Map[String, Any]
 
 }

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/Operator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/Operator.scala
@@ -17,10 +17,19 @@
 
 package org.apache.linkis.engineconn.acessible.executor.operator
 
+import org.apache.linkis.engineconn.common.exception.EngineConnException
+
 trait Operator {
 
-  def getName: String
+  def getNames: Array[String]
 
-  def apply(parameters: Map[String, Any]): Map[String, Any]
+  def apply(implicit parameters: Map[String, Any]): Map[String, Any]
+
+  protected def getAs[T](key: String, defaultVal: T)(implicit parameters: Map[String, Any]): T =
+    parameters.getOrElse(key, defaultVal) match {
+      case t: T => t
+      case null => null.asInstanceOf[T]
+      case v => throw EngineConnException(20305, s"Unknown $v for key $key.")
+    }
 
 }

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/OperatorFactory.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/OperatorFactory.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineconn.acessible.executor.operator
 
 import org.apache.linkis.common.exception.WarnException
-import org.apache.linkis.common.utils.ClassUtils
+import org.apache.linkis.common.utils.{ClassUtils, Logging}
 import org.apache.linkis.manager.common.protocol.engine.EngineOperateRequest
 
 trait OperatorFactory {
@@ -36,20 +36,21 @@ object OperatorFactory {
 }
 
 import scala.collection.convert.WrapAsScala._
-class OperatorFactoryImpl extends OperatorFactory {
+class OperatorFactoryImpl extends OperatorFactory with Logging {
 
-  private val operatorClasses: Map[String, Class[_ <: Operator]] = ClassUtils.reflections.getSubTypesOf(classOf[Operator])
+  private val operators: Map[String, _ <: Operator] = ClassUtils.reflections.getSubTypesOf(classOf[Operator])
     .filterNot(ClassUtils.isInterfaceOrAbstract).map { clazz =>
-      clazz.newInstance().getName -> clazz
+      val operator = clazz.newInstance()
+    operator.getName -> operator
     }.toMap
+  info("Launched operators list => " + operators)
 
   override def createOperatorRequest(request: EngineOperateRequest): Operator = {
-    request.properties.getOrElse(EngineOperateRequest.OPERATOR_NAME_KEY, null) match {
-      case operatorName: String if operatorClasses.contains(operatorName) =>
-        val operator = operatorClasses.get(operatorName).get.newInstance()
-        operator.init(request.properties)
-        operator
-      case _ => throw new WarnException(-1, s"Cannot find operator.")
+    request.parameters.getOrElse(EngineOperateRequest.OPERATOR_NAME_KEY,
+      throw new WarnException(20031, s"${EngineOperateRequest.OPERATOR_NAME_KEY} is not exists.")) match {
+      case operatorName: String if operators.contains(operatorName) =>
+        operators(operatorName)
+      case operatorName => throw new WarnException(20030, s"Cannot find operator named $operatorName.")
     }
   }
 

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/ApplicationInfoOperator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/ApplicationInfoOperator.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.acessible.executor.operator.impl
+
+import org.apache.linkis.engineconn.acessible.executor.operator.Operator
+import org.apache.linkis.engineconn.common.exception.EngineConnException
+import org.apache.linkis.engineconn.core.executor.ExecutorManager
+import org.apache.linkis.engineconn.executor.entity.YarnExecutor
+
+
+class ApplicationInfoOperator extends Operator {
+
+  override def getName: String = ApplicationInfoOperator.OPERATOR_NAME
+
+  override def apply(parameters: Map[String, Any]): Map[String, Any] = {
+    ExecutorManager.getInstance.getReportExecutor match {
+      case yarnExecutor: YarnExecutor =>
+        Map("applicationId" -> yarnExecutor.getApplicationId, "applicationUrl" -> yarnExecutor.getApplicationURL,
+          "queue" -> yarnExecutor.getQueue, "yarnMode" -> yarnExecutor.getYarnMode)
+      case _ => throw EngineConnException(20301, "EngineConn is not a yarn application, cannot fetch applicaiton info.")
+    }
+  }
+
+}
+object ApplicationInfoOperator {
+  val OPERATOR_NAME = "application"
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/EngineConnApplicationInfoOperator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/EngineConnApplicationInfoOperator.scala
@@ -23,11 +23,11 @@ import org.apache.linkis.engineconn.core.executor.ExecutorManager
 import org.apache.linkis.engineconn.executor.entity.YarnExecutor
 
 
-class ApplicationInfoOperator extends Operator {
+class EngineConnApplicationInfoOperator extends Operator {
 
-  override def getName: String = ApplicationInfoOperator.OPERATOR_NAME
+  override def getNames: Array[String] = Array(EngineConnApplicationInfoOperator.OPERATOR_NAME)
 
-  override def apply(parameters: Map[String, Any]): Map[String, Any] = {
+  override def apply(implicit parameters: Map[String, Any]): Map[String, Any] = {
     ExecutorManager.getInstance.getReportExecutor match {
       case yarnExecutor: YarnExecutor =>
         Map("applicationId" -> yarnExecutor.getApplicationId, "applicationUrl" -> yarnExecutor.getApplicationURL,
@@ -37,6 +37,6 @@ class ApplicationInfoOperator extends Operator {
   }
 
 }
-object ApplicationInfoOperator {
-  val OPERATOR_NAME = "application"
+object EngineConnApplicationInfoOperator {
+  val OPERATOR_NAME = "engineConnYarnApplication"
 }

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/EngineConnLogOperator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/EngineConnLogOperator.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.acessible.executor.operator.impl
+
+import java.io.{File, RandomAccessFile}
+import java.util
+
+import org.apache.commons.io.IOUtils
+import org.apache.commons.lang.StringUtils
+import org.apache.linkis.common.conf.CommonVars
+import org.apache.linkis.common.utils.{Logging, Utils}
+import org.apache.linkis.engineconn.acessible.executor.operator.Operator
+import org.apache.linkis.engineconn.common.conf.EngineConnConf
+import org.apache.linkis.engineconn.common.exception.EngineConnException
+
+class EngineConnLogOperator extends Operator with Logging {
+
+  private val logPath = new File(EngineConnConf.getLogDir, EngineConnLogOperator.LOG_FILE_NAME.getValue)
+  info(s"Try to fetch EngineConn logs from ${logPath.getPath}.")
+
+  override def getNames: Array[String] = Array(EngineConnLogOperator.OPERATOR_NAME)
+
+  override def apply(implicit parameters: Map[String, Any]): Map[String, Any] = {
+    val lastRows = getAs("lastRows", 0)
+    if(lastRows > EngineConnLogOperator.MAX_LOG_FETCH_SIZE.getValue)
+      throw EngineConnException(20305, s"Cannot fetch more than ${EngineConnLogOperator.MAX_LOG_FETCH_SIZE.getValue} lines of logs.")
+    else if(lastRows > 0) {
+      val logs = Utils.exec(Array("tail", "-f", logPath.getPath), 5000).split("\n")
+      return Map("logs" -> logs, "rows" -> logs.length)
+    }
+    val pageSize = getAs("pageSize", 100)
+    val fromLine = getAs("fromLine", 1)
+    val ignoreKeywords = getAs("ignoreKeywords", "")
+    val ignoreKeywordList = if(StringUtils.isNotEmpty(ignoreKeywords)) ignoreKeywords.split(",") else Array.empty
+    val onlyKeywords = getAs("onlyKeywords", "")
+    val onlyKeywordList = if(StringUtils.isNotEmpty(onlyKeywords)) onlyKeywords.split(",") else Array.empty
+    val reader = new RandomAccessFile(logPath, "r")
+    val logs = new util.ArrayList[String](pageSize)
+    var readLine, skippedLine = 0
+    Utils.tryFinally {
+      var line = reader.readLine()
+      while (readLine < pageSize && line != null) {
+        if(skippedLine < fromLine) {
+          skippedLine += 1
+        } else if(onlyKeywordList.nonEmpty && onlyKeywordList.exists(line.contains)) {
+          logs.add(line)
+          readLine += 1
+        } else if(ignoreKeywordList.nonEmpty && !ignoreKeywordList.exists(line.contains)) {
+          logs.add(line)
+          readLine += 1
+        } else if(onlyKeywordList.isEmpty && ignoreKeywordList.isEmpty) {
+          logs.add(line)
+          readLine += 1
+        }
+        line = reader.readLine
+      }
+    }(IOUtils.closeQuietly(reader))
+    Map("logPath" -> logPath.getPath, "logs" -> logs, "rows" -> readLine)
+  }
+}
+object EngineConnLogOperator {
+  val OPERATOR_NAME = "engineConnLog"
+  val LOG_FILE_NAME = CommonVars("linkis.engineconn.log.filename", "stdout")
+  val MAX_LOG_FETCH_SIZE = CommonVars("linkis.engineconn.log.fetch.lines.max", 5000)
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/DefaultOperateService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/DefaultOperateService.scala
@@ -28,13 +28,13 @@ class DefaultOperateService extends OperateService with Logging {
 
   @Receiver
   override def executeOperation(engineOperateRequest: EngineOperateRequest): EngineOperateResponse = {
-    val operator = Utils.tryCatch(OperatorFactory().createOperatorRequest(engineOperateRequest)){t =>
+    val operator = Utils.tryCatch(OperatorFactory().getOperatorRequest(engineOperateRequest)){ t =>
       error(s"Get operator failed, parameters is ${engineOperateRequest.parameters}.", t)
       return EngineOperateResponse(Map.empty, true, ExceptionUtils.getRootCauseMessage(t))
     }
-    info(s"Try to execute operate ${operator.getName} with parameters ${engineOperateRequest.parameters}.")
+    info(s"Try to execute operator ${operator.getClass.getSimpleName} with parameters ${engineOperateRequest.parameters}.")
     val result = Utils.tryCatch(operator(engineOperateRequest.parameters)) {t =>
-      error(s"Execute ${operator.getName} failed.", t)
+      error(s"Execute ${operator.getClass.getSimpleName} failed.", t)
       return EngineOperateResponse(Map.empty, true, ExceptionUtils.getRootCauseMessage(t))
     }
     EngineOperateResponse(result)

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/DefaultOperateService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/DefaultOperateService.scala
@@ -16,17 +16,27 @@
  */
 
 package org.apache.linkis.engineconn.acessible.executor.service
+import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.linkis.common.utils.{Logging, Utils}
 import org.apache.linkis.engineconn.acessible.executor.operator.OperatorFactory
 import org.apache.linkis.manager.common.protocol.engine.{EngineOperateRequest, EngineOperateResponse}
 import org.apache.linkis.message.annotation.Receiver
 import org.springframework.stereotype.Service
 
 @Service
-class DefaultOperateService extends OperateService {
+class DefaultOperateService extends OperateService with Logging {
 
   @Receiver
   override def executeOperation(engineOperateRequest: EngineOperateRequest): EngineOperateResponse = {
-    val operator = OperatorFactory().createOperatorRequest(engineOperateRequest)
-    operator()
+    val operator = Utils.tryCatch(OperatorFactory().createOperatorRequest(engineOperateRequest)){t =>
+      error(s"Get operator failed, parameters is ${engineOperateRequest.parameters}.", t)
+      return EngineOperateResponse(Map.empty, true, ExceptionUtils.getRootCauseMessage(t))
+    }
+    info(s"Try to execute operate ${operator.getName} with parameters ${engineOperateRequest.parameters}.")
+    val result = Utils.tryCatch(operator(engineOperateRequest.parameters)) {t =>
+      error(s"Execute ${operator.getName} failed.", t)
+      return EngineOperateResponse(Map.empty, true, ExceptionUtils.getRootCauseMessage(t))
+    }
+    EngineOperateResponse(result)
   }
 }

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateRequest.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateRequest.scala
@@ -21,11 +21,11 @@ import org.apache.linkis.common.ServiceInstance
 import org.apache.linkis.protocol.message.RequestProtocol
 
 case class EngineOperateRequest(user: String,
-                           properties: Map[String, Any]) extends RequestProtocol
+                                parameters: Map[String, Any]) extends RequestProtocol
 
 
 case class EngineOperateRequestWithService(user: String, serviceInstance: ServiceInstance,
-                           properties: Map[String, Any]) extends RequestProtocol
+                                           parameters: Map[String, Any]) extends RequestProtocol
 
 object EngineOperateRequest {
 

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateResponse.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/org/apache/linkis/manager/common/protocol/engine/EngineOperateResponse.scala
@@ -19,4 +19,4 @@ package org.apache.linkis.manager.common.protocol.engine
 
 import org.apache.linkis.protocol.message.RequestProtocol
 
-case class EngineOperateResponse(result: Map[String, Any], status: Boolean = true, msg: String = "") extends RequestProtocol
+case class EngineOperateResponse(result: Map[String, Any], isError: Boolean = false, errorMsg: String = "") extends RequestProtocol

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/context/ExecutionContext.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/context/ExecutionContext.java
@@ -130,6 +130,9 @@ public class ExecutionContext {
 		clusterClientFactory = new LinkisYarnClusterClientFactory();
 	}
 
+	public StreamExecutionEnvironment getStreamExecutionEnvironment() {
+		return streamExecEnv;
+	}
 
 	public void setString(String key, String value) {
 		this.flinkConfig.setString(key, value);

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
@@ -38,7 +38,13 @@ object FlinkEnvConfiguration {
   val FLINK_SHIP_DIRECTORIES = CommonVars("flink.yarn.ship-directories", "")
 
 
+  val FLINK_CHECK_POINT_ENABLE = CommonVars("flink.app.checkpoint.enable", false)
+  val FLINK_CHECK_POINT_INTERVAL = CommonVars("flink.app.checkpoint.interval", 3000)
+  val FLINK_CHECK_POINT_MODE = CommonVars("flink.app.checkpoint.mode", "EXACTLY_ONCE")
+  val FLINK_CHECK_POINT_TIMEOUT = CommonVars("flink.app.checkpoint.timeout", 60000)
+  val FLINK_CHECK_POINT_MIN_PAUSE = CommonVars("flink.app.checkpoint.minPause", FLINK_CHECK_POINT_INTERVAL.getValue)
   val FLINK_SAVE_POINT_PATH = CommonVars("flink.app.savePointPath", "")
+
   val FLINK_APP_ALLOW_NON_RESTORED_STATUS = CommonVars("flink.app.allowNonRestoredStatus", "false")
   val FLINK_SQL_PLANNER = CommonVars("flink.sql.planner", ExecutionEntry.EXECUTION_PLANNER_VALUE_BLINK)
   val FLINK_SQL_EXECUTION_TYPE = CommonVars("flink.sql.executionType", ExecutionEntry.EXECUTION_TYPE_VALUE_STREAMING)


### PR DESCRIPTION
### What is the purpose of the change
Add the support of EngineConn common operators and OnceEngineConn common operators.

### Brief change log
(for example:)
- Optimize the architecture of LinkisClient EngineConn Operator.
- Optimize the architecture of EngineConn Operator in accessible executor and add support of yarn ApplicationInfoOperator.
- Optimize the setter method of EngineConnOperateResult.
- Optimize flink engineConn, support checkpoint.
- Optimize the architecture of EngineConn Operator in accessible executor.
- Add the support of yarn ApplicationInfoOperator and EngineConnLogOperator.
- Add the support of OperableOperator for OnceEngineConn.
- Optimize some codes of computation client.
- Add the support of fetching logs of EngineConn.
- Add the support of execute common operator of EngineConn.
- Add the support of diagnosis, metrics, progress operator of OnceEngineConn

