### PR TITLE
[ISSUS#1080] bugfix:build dist ignore empty directory of 'python' after upgrade maven-assembly-plugin 2.3 to 3.2.0

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/python/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/python/src/main/assembly/distribution.xml
@@ -49,6 +49,9 @@
             <includes>
                 <include>*</include>
             </includes>
+            <excludes>
+                <exclude>python</exclude>
+            </excludes>
             <fileMode>0777</fileMode>
             <outputDirectory>/dist/v${python.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>

--- a/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/assembly/distribution.xml
@@ -49,6 +49,9 @@
             <includes>
                 <include>*</include>
             </includes>
+            <excludes>
+                <exclude>python</exclude>
+            </excludes>
             <fileMode>0777</fileMode>
             <directoryMode>0755</directoryMode>
             <outputDirectory>/dist/v${spark.version}/conf</outputDirectory>


### PR DESCRIPTION
### What is the purpose of the change
Bugfix:build dist ignore empty directory of 'python' after upgrade maven-assembly-plugin 2.3 to 3.2.0
Related issues: #1080. )

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? ( no)