### PR TITLE
Dev 1.0.3 bugfix passauthuri add judgement of whether it is empty

### DIFF
--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/SecurityFilter.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/SecurityFilter.scala
@@ -71,7 +71,7 @@ class SecurityFilter extends Filter {
       false
     } else if(request.getRequestURI == ServerConfiguration.BDP_SERVER_RESTFUL_LOGIN_URI.getValue) {
       true
-    } else if( ServerConfiguration.BDP_SERVER_RESTFUL_PASS_AUTH_REQUEST_URI.exists(request.getRequestURI.startsWith)) {
+    } else if( ServerConfiguration.BDP_SERVER_RESTFUL_PASS_AUTH_REQUEST_URI.exists(r => !r.equals("") && request.getRequestURI.startsWith(r))) {
       SecurityFilter.info("pass auth uri: " + request.getRequestURI)
       true
     }else {

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/SecurityFilter.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/SecurityFilter.scala
@@ -85,7 +85,7 @@ object SecurityFilter extends Logging {
           return false
       }
     }
-    val isPassAuthRequest = GatewayConfiguration.PASS_AUTH_REQUEST_URI.exists(gatewayContext.getRequest.getRequestURI.startsWith)
+    val isPassAuthRequest = GatewayConfiguration.PASS_AUTH_REQUEST_URI.exists(r => !r.equals("") && gatewayContext.getRequest.getRequestURI.startsWith(r))
     if(gatewayContext.getRequest.getRequestURI.startsWith(ServerConfiguration.BDP_SERVER_USER_URI.getValue)) {
       Utils.tryCatch(userRestful.doUserRequest(gatewayContext)){ t =>
         val message = t match {


### PR DESCRIPTION
### What is the purpose of the change
bugfix:
if the pass auth url set value “”, the method ".getRequestURI.startsWith" will always return true, it is not the result that we wanted, it can be a security risk.

### Brief change log
(for example:)
-  Add  judgement of whether it is empty

### Verifying this change
This change added tests and can be verified as follows:  
-  1. set wds.linkis.gateway.conf.url.pass.auth=""  in linkis-mg-gateway.properties, the restart gateway.
-  2. set wds.linkis.server.user.restful.uri.pass.auth="" in linkis-ps-publicservice.properties, the restart publicservice.
-  3. curl http://${gateway}/api/rest_j/v1/configuration/getCategory, if return "need login in" will be right.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: ( no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)