### PR TITLE
Revert "[ISSUE#1089 ]bugfix:local file permission"

### DIFF
--- a/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/LocalFileSystem.java
+++ b/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/LocalFileSystem.java
@@ -196,7 +196,20 @@ public class LocalFileSystem extends FileSystem {
 
     @Override
     public boolean setPermission(FsPath dest, String permission) throws IOException {
+        if (!StorageUtils.isIOProxy()){
+            LOG.info("io not proxy, setPermission as parent.");
+            try {
+                PosixFileAttributes attr  = Files.readAttributes(Paths.get(dest.getParent().getPath()), PosixFileAttributes.class);
+                LOG.debug("parent permissions: attr: " + attr);
+                Files.setPosixFilePermissions(Paths.get(dest.getPath()), attr.permissions());
 
+            }catch (NoSuchFileException e){
+                LOG.error("File or folder does not exist or file name is garbled(文件或者文件夹不存在或者文件名乱码)",e);
+                throw new StorageWarnException(51001,e.getMessage());
+            }
+            return true;
+
+        }
         String path = dest.getPath();
         if(StringUtils.isNumeric(permission)) {
             permission = FsPath.permissionFormatted(permission);


### PR DESCRIPTION
### What is the purpose of the change
revert #1089 
it will be affect other function!

1. engineConnExec.sh default --rw-r--r-- permission, it is default  executed  by "sudo su - user -c "sh /app/linkis/tmp/ods/workDir/28225ed5-0e8b-48c5-8b90-07676b343f6e/engineConnExec.sh"" ,so it just need execute permission.
2.  workDir write permmision. you can change workDir's parent directory permission. can set 775, delte workDir,  and it will be created ,the permission will be as  same as parent.