### PR TITLE
The engine has no exists bug fix

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-manager-monitor/src/main/scala/com/webank/wedatasphere/linkis/manager/monitor/node/NodeHeartbeatMonitor.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-monitor/src/main/scala/com/webank/wedatasphere/linkis/manager/monitor/node/NodeHeartbeatMonitor.scala
@@ -1,8 +1,5 @@
 package com.webank.wedatasphere.linkis.manager.monitor.node
 
-import java.util
-import java.util.concurrent.{ExecutorService, TimeUnit, TimeoutException}
-
 import com.webank.wedatasphere.linkis.common.ServiceInstance
 import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
 import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
@@ -11,7 +8,7 @@ import com.webank.wedatasphere.linkis.manager.common.entity.metrics.{NodeHealthy
 import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeEntity
 import com.webank.wedatasphere.linkis.manager.common.monitor.ManagerMonitor
 import com.webank.wedatasphere.linkis.manager.common.protocol.em.StopEMRequest
-import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineInfoClearRequest, EngineStopRequest, EngineSuicideRequest}
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineStopRequest, EngineSuicideRequest}
 import com.webank.wedatasphere.linkis.manager.common.protocol.node.{NodeHeartbeatMsg, NodeHeartbeatRequest}
 import com.webank.wedatasphere.linkis.manager.common.utils.ManagerUtils
 import com.webank.wedatasphere.linkis.manager.monitor.conf.ManagerMonitorConf
@@ -24,6 +21,9 @@ import com.webank.wedatasphere.linkis.rpc.exception.NoInstanceExistsException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.lang.reflect.UndeclaredThrowableException
+import java.util
+import java.util.concurrent.{ExecutorService, TimeUnit}
 import scala.collection.JavaConversions._
 
 @Component
@@ -82,8 +82,8 @@ class NodeHeartbeatMonitor extends ManagerMonitor with Logging {
       return
     }
 
-    Utils.tryAndWarnMsg{
-      metricList.foreach(nodeMetric => if(NodeStatus.isCompleted(NodeStatus.values()(nodeMetric.getStatus))){
+    Utils.tryAndWarnMsg {
+      metricList.foreach(nodeMetric => if (NodeStatus.isCompleted(NodeStatus.values()(nodeMetric.getStatus))) {
         clearEngineNode(nodeMetric.getServiceInstance)
       })
     }("Monitor----failed to check completed engines and clear them ")
@@ -136,16 +136,30 @@ class NodeHeartbeatMonitor extends ManagerMonitor with Logging {
             }
           case _ =>
             updateMetricHealthy(nodeMetric, NodeHealthy.UnHealthy, "找不到对应的服务，获取的sender为空")
-        }){
-          case e: TimeoutException => {
-            warn(s"引擎发送RPC请求失败，找不到引擎实例：${nodeMetric.getServiceInstance}，开始发送请求停止该引擎!")
-            clearEngineNode(nodeMetric.getServiceInstance)
-          }
-          case exception: Exception => {
+        }) {
+          case e: UndeclaredThrowableException =>
+            dealMetricUpdateTimeOut(nodeMetric, e)
+
+          case exception: Exception =>
             warn(s"发送引擎心跳RPC请求失败,但不是由于超时引起的，不会强制停止该引擎，引擎实例：${nodeMetric.getServiceInstance}", exception)
-          }
         }
       }
+    }
+  }
+
+  /**
+   * 当找不到引擎的时候,发送消息会抛出 UndeclaredThrowableException 异常
+   * 这个时候需要强行删除
+   *
+   * @param nodeMetric
+   * @param e
+   */
+  private def dealMetricUpdateTimeOut(nodeMetric: NodeMetrics, e: UndeclaredThrowableException) = {
+    val maxInterval = ManagerMonitorConf.NODE_HEARTBEAT_MAX_UPDATE_TIME.getValue.toLong
+    val timeout = System.currentTimeMillis() - nodeMetric.getUpdateTime.getTime > maxInterval
+    if (timeout) {
+      warn(s"引擎发送RPC请求失败，找不到引擎实例：${nodeMetric.getServiceInstance}，开始发送请求停止该引擎!", e)
+      triggerEMToStopEngine(nodeMetric.getServiceInstance)
     }
   }
 


### PR DESCRIPTION
### What is the purpose of the change

NodeHeartbeatMonitor 

INFO Need a ServiceInstance(linkis-cg-engineconn, k8s-master-1.:36955), but cannot find in DiscoveryClient refresh list.

报错:  发送引擎心跳RPC请求失败,但不是由于超时引起的，不会强制停止该引擎，引擎实例
java.lang.reflect.UndeclaredThrowableException: null


### Brief change log
- 去除了 TimeoutException 避免将 引擎误杀
- 新加了 UndeclaredThrowableException 异常拦截， 强制清空无效的引擎数据

