### PR TITLE
Optimize the close logic of OnceExecutor and fix some bugs of Flink EngineConn.

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/result/EngineConnOperateResult.scala
@@ -37,6 +37,8 @@ class EngineConnOperateResult extends LinkisManagerResult {
 
   def setError(isError: Boolean): Unit = this.isError = isError
 
+  def setIsError(isError: Boolean): Unit = this.isError = isError
+
   def getResult: util.Map[String, Any] = if(isError) throw new UJESJobException(20301, errorMsg) else result
 
   def getAsOption[T](key: String): Option[T] = Option(getAs(key))

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/OnceJobOperator.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/operator/OnceJobOperator.scala
@@ -18,6 +18,7 @@
 package org.apache.linkis.computation.client.operator
 
 import org.apache.linkis.common.ServiceInstance
+import org.apache.linkis.common.conf.CommonVars
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.computation.client.once.LinkisManagerClient
 import org.apache.linkis.computation.client.once.action.EngineConnOperateAction
@@ -57,14 +58,23 @@ trait OnceJobOperator[T] extends Operator[T] with Logging {
       .setInstance(serviceInstance.getInstance)
     addParameters(builder)
     val engineConnOperateAction = builder.build()
-    info(s"$getUser try to ask EngineConn($serviceInstance) to execute $getName operation, parameters is ${engineConnOperateAction.getRequestPayload}.")
+    if(OnceJobOperator.ONCE_JOB_OPERATOR_LOG_ENABLE.getValue)
+      info(s"$getUser try to ask EngineConn($serviceInstance) to execute $getName operation, parameters is ${engineConnOperateAction.getRequestPayload}.")
     val result = linkisManagerClient.executeEngineConnOperation(engineConnOperateAction)
-    info(s"$getUser asked EngineConn($serviceInstance) to execute $getName operation, results is ${result.getResult}.")
+    val resultStr = String.valueOf(result.getResult)
+    if(OnceJobOperator.ONCE_JOB_OPERATOR_LOG_ENABLE.getValue)
+      info(s"$getUser asked EngineConn($serviceInstance) to execute $getName operation, results is ${if(resultStr.length <= 250) resultStr else resultStr.substring(0, 250) + "..."} .")
     resultToObject(result)
   }
 
   protected def addParameters(builder: EngineConnOperateAction.Builder): Unit = {}
 
   protected def resultToObject(result: EngineConnOperateResult): T
+
+}
+
+object OnceJobOperator {
+
+  val ONCE_JOB_OPERATOR_LOG_ENABLE = CommonVars("linkis.client.operator.once.log.enable", true)
 
 }

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/OnceExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/org/apache/linkis/engineconn/once/executor/OnceExecutor.scala
@@ -142,16 +142,22 @@ trait ManageableOnceExecutor extends AccessibleExecutor with OnceExecutor with R
   override def tryShutdown(): Boolean = tryFailed()
 
   def tryFailed(): Boolean = {
-    if(!isClosed) close()
+    if(isClosed) return true
     error(s"$getId has failed with old status $getStatus, now stop it.")
-    Utils.tryFinally(this.ensureAvailable(transition(NodeStatus.Failed)))(ShutdownHook.getShutdownHook.notifyStop())
+    Utils.tryFinally {
+      this.ensureAvailable(transition(NodeStatus.Failed))
+      close()
+    }(ShutdownHook.getShutdownHook.notifyStop())
     true
   }
 
   def trySucceed(): Boolean = {
-    if(!isClosed) close()
+    if(isClosed)  return true
     warn(s"$getId has succeed with old status $getStatus, now stop it.")
-    Utils.tryFinally(this.ensureAvailable(transition(NodeStatus.Success)))(ShutdownHook.getShutdownHook.notifyStop())
+    Utils.tryFinally {
+      this.ensureAvailable(transition(NodeStatus.Success))
+      close()
+    } (ShutdownHook.getShutdownHook.notifyStop())
     true
   }
 

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/EngineConnLogOperator.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/operator/impl/EngineConnLogOperator.scala
@@ -47,9 +47,9 @@ class EngineConnLogOperator extends Operator with Logging {
     val pageSize = getAs("pageSize", 100)
     val fromLine = getAs("fromLine", 1)
     val ignoreKeywords = getAs("ignoreKeywords", "")
-    val ignoreKeywordList = if(StringUtils.isNotEmpty(ignoreKeywords)) ignoreKeywords.split(",") else Array.empty
+    val ignoreKeywordList = if(StringUtils.isNotEmpty(ignoreKeywords)) ignoreKeywords.split(",") else Array.empty[String]
     val onlyKeywords = getAs("onlyKeywords", "")
-    val onlyKeywordList = if(StringUtils.isNotEmpty(onlyKeywords)) onlyKeywords.split(",") else Array.empty
+    val onlyKeywordList = if(StringUtils.isNotEmpty(onlyKeywords)) onlyKeywords.split(",") else Array.empty[String]
     val reader = new RandomAccessFile(logPath, "r")
     val logs = new util.ArrayList[String](pageSize)
     var readLine, skippedLine = 0

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkCodeOnceExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkCodeOnceExecutor.scala
@@ -66,12 +66,10 @@ class FlinkCodeOnceExecutor(override val id: Long,
           error("Run code failed!", t)
           setResponse(ErrorExecuteResponse("Run code failed!", t))
           tryFailed()
-          close()
           return
         }
         info("All codes completed, now stop FlinkEngineConn.")
         trySucceed()
-        close()
       }
     })
     this synchronized wait()

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/factory/FlinkEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/factory/FlinkEngineConnFactory.scala
@@ -190,6 +190,7 @@ class FlinkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
       val checkpointTimeout = FLINK_CHECK_POINT_TIMEOUT.getValue(options)
       val checkpointMinPause = FLINK_CHECK_POINT_MIN_PAUSE.getValue(options)
       info(s"checkpoint is enabled, checkpointInterval is $checkpointInterval, checkpointMode is $checkpointMode, checkpointTimeout is $checkpointTimeout.")
+      executionContext.getTableEnvironment  // This line is need to initialize the StreamExecutionEnvironment.
       executionContext.getStreamExecutionEnvironment.enableCheckpointing(checkpointInterval)
       val checkpointConfig = executionContext.getStreamExecutionEnvironment.getCheckpointConfig
       checkpointMode match {


### PR DESCRIPTION
### What is the purpose of the change
Optimize the close logic of OnceExecutor and fix some bugs of Flink EngineConn.

### Brief change log
- Optimize the print log of OnceJobOperator.
- Resolve the initialization NPE of StreamExecutionEnvironment.
- Resolve the cast bug of EngineConnLogOperator.
- Optimize the close logic of OnceExecutor.
