### PR TITLE
Modify the weak password problem of the default test account of linkis

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis-mg-gateway.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis-mg-gateway.properties
@@ -29,5 +29,6 @@ wds.linkis.login_encrypt.enable=false
 wds.linkis.ldap.proxy.url=
 wds.linkis.ldap.proxy.baseDN=
 wds.linkis.admin.user=hadoop
+#wds.linkis.admin.password=
 ##Spring
 spring.server.port=9001

--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -318,10 +318,12 @@ sed -i ${txt}  "s#wds.linkis.filesystem.hdfs.root.path.*#wds.linkis.filesystem.h
 ##gateway
 gateway_conf=$LINKIS_HOME/conf/linkis-mg-gateway.properties
 echo "update conf $gateway_conf"
+defaultPwd=`date +%s%N | md5sum |cut -c 1-9`
 sed -i ${txt}  "s#wds.linkis.ldap.proxy.url.*#wds.linkis.ldap.proxy.url=$LDAP_URL#g" $gateway_conf
 sed -i ${txt}  "s#wds.linkis.ldap.proxy.baseDN.*#wds.linkis.ldap.proxy.baseDN=$LDAP_BASEDN#g" $gateway_conf
 sed -i ${txt}  "s#wds.linkis.ldap.proxy.userNameFormat.*#wds.linkis.ldap.proxy.userNameFormat=$LDAP_USER_NAME_FORMAT#g" $gateway_conf
 sed -i ${txt}  "s#wds.linkis.admin.user.*#wds.linkis.admin.user=$deployUser#g" $gateway_conf
+sed -i ${txt}  "s#\#wds.linkis.admin.password.*#wds.linkis.admin.password=$defaultPwd#g" $gateway_conf
 if [ "$GATEWAY_PORT" != "" ]
 then
   sed -i ${txt}  "s#spring.server.port.*#spring.server.port=$GATEWAY_PORT#g" $gateway_conf
@@ -400,3 +402,4 @@ fi
 
 
 echo "Congratulations! You have installed Linkis $LINKIS_VERSION successfully, please use sbin/linkis-start-all.sh to start it!"
+echo "Your default account password is$deployUser/$defaultPwd"


### PR DESCRIPTION
### What is the purpose of the change
Giving a random password after installation, no longer use the deployment user as the password for the trial

### Brief change log
- update install.sh，Giving a random password a;

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: (yes)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)

### Documentation
- Does this pull request introduce a new feature? (yno)