### PR TITLE
VarSubstitutionInterceptor get code type bug fix

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/VarSubstitutionInterceptor.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/VarSubstitutionInterceptor.scala
@@ -37,8 +37,8 @@ class VarSubstitutionInterceptor extends EntranceInterceptor {
       case jobRequest: JobRequest =>
         Utils.tryThrow {
           logAppender.append(LogUtils.generateInfo("Program is substituting variables for you") + "\n")
-          val engineType = LabelUtil.getEngineType(jobRequest.getLabels)
-          val (result, code) = CustomVariableUtils.replaceCustomVar(jobRequest, engineType)
+          val codeType = LabelUtil.getCodeType(jobRequest.getLabels)
+          val (result, code) = CustomVariableUtils.replaceCustomVar(jobRequest, codeType)
           if (result) jobRequest.setExecutionCode(code)
           logAppender.append(LogUtils.generateInfo("Variables substitution ended successfully") + "\n")
           jobRequest


### PR DESCRIPTION
### What is the purpose of the change

-          val engineType = LabelUtil.getEngineType(jobRequest.getLabels)
-          val (result, code) = CustomVariableUtils.replaceCustomVar(jobRequest, engineType)

val codeType = LabelUtil.getCodeType(jobRequest.getLabels)
val (result, code) = CustomVariableUtils.replaceCustomVar(jobRequest, codeType)

CustomVariableUtils.replaceCustomVar(jobRequest, codeType) 

替换变量时，没有拿到code类型，拿到的是引擎类型，造成逻辑永远不成功