### PR TITLE
adjust pom for apache release

### DIFF
--- a/assembly-combined-package/assembly-combined/pom.xml
+++ b/assembly-combined-package/assembly-combined/pom.xml
@@ -66,7 +66,7 @@
                         </goals>
                         <configuration>
                             <skipAssembly>false</skipAssembly>
-                            <finalName>apache-linkis-${linkis.version}-combined-dist</finalName>
+                            <finalName>apache-linkis-${linkis.version}-incubating-dist</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <attach>false</attach>
                             <descriptors>

--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -211,7 +211,7 @@ echo "create dir LINKIS_HOME: $LINKIS_HOME"
 sudo mkdir -p $LINKIS_HOME;sudo chown -R $deployUser:$deployUser $LINKIS_HOME
 isSuccess "Create the dir of  $LINKIS_HOME"
 
-LINKIS_PACKAGE=${workDir}/apache-linkis-${LINKIS_VERSION}-combined-dist.tar.gz
+LINKIS_PACKAGE=${workDir}/apache-linkis-${LINKIS_VERSION}-incubating-dist.tar.gz
 
 if ! test -e ${LINKIS_PACKAGE}; then
     echo "**********Error: please put ${LINKIS_PACKAGE} in $workDir! "

--- a/assembly-combined-package/pom.xml
+++ b/assembly-combined-package/pom.xml
@@ -66,7 +66,7 @@
                         </goals>
                         <configuration>
                             <skipAssembly>false</skipAssembly>
-                            <finalName>apache-linkis-${linkis.version}-combined-package-dist</finalName>
+                            <finalName>apache-linkis-${linkis.version}-incubating-bin</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <attach>false</attach>
                             <descriptors>

--- a/assembly-combined-package/src/main/assembly/assembly.xml
+++ b/assembly-combined-package/src/main/assembly/assembly.xml
@@ -55,7 +55,7 @@
           </directory>
           <outputDirectory></outputDirectory>
           <includes>
-              <include>apache-linkis-${linkis.version}-combined-dist.tar.gz</include>
+              <include>apache-linkis-${linkis.version}-incubating-dist.tar.gz</include>
           </includes>
           <fileMode>0777</fileMode>
       </fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -266,10 +266,13 @@
                         <artifactId>maven-deploy-plugin</artifactId>
                         <version>3.0.0-M1</version>
                     </plugin>
-                    <!--<plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.0.1</version>
+                       <configuration>
+                           <doclint>none</doclint>
+                       </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -278,7 +281,7 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>-->
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
@@ -410,13 +413,6 @@
                             <phase>process-test-resources</phase>
                             <goals>
                                 <goal>testCompile</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>attach-scaladocs</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>doc-jar</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
### What is the purpose of the change
add tool script for apache release

### Brief change log
maven-javadoc: add doclint  configuration to ignore check error
add tool shell script  for apache release