### PR TITLE
Get protocol from current request, remove hard code of 'http'

### DIFF
--- a/web/src/common/service/api.js
+++ b/web/src/common/service/api.js
@@ -50,7 +50,7 @@ let cutReq = (config) => {
 };
 
 const instance = axios.create({
-  baseURL: process.env.VUE_APP_MN_CONFIG_PREFIX || `http://${window.location.host}/api/rest_j/v1/`,
+  baseURL: process.env.VUE_APP_MN_CONFIG_PREFIX || `${window.location.protocol}//${window.location.host}/api/rest_j/v1/`,
   timeout: 600000,
   withCredentials: true,
   headers: { 'Content-Type': 'application/json;charset=UTF-8' },


### PR DESCRIPTION
### What is the purpose of the change
Given that there is an another outer Nginx, which enables HTTPS and forward request to Linkis Nginx, when Linkis front end calls the backend API, using the address from the ${window.location.host}, the protocol also need to align with the current request protocol, which can be gotten from ${window.location.protocol}. Otherwise, there will be a CORS error on broswer side as using https to request front end resources while using http to access backend API.  

### Brief change log
- In front end file api.js, change the protocol from 'http' to current request protocol.

### Verifying this change
(Please pick either of the following options)  
This change added tests and can be verified as follows:  
- Setup an outer Nginx, that enabled HTTPS, and forward requests to the Linkis Nginx, that just support HTTP. See whether request can reach the backend from broswer.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)