### PR TITLE
Support Python Matplotlib to display pictures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,18 @@ assembly-combined-package/target/
 
 linkis-extensions/linkis-io-file-client/target/
 
+linkis-commons/target/
+linkis-computation-governance/linkis-client/linkis-cli/target/
+linkis-computation-governance/linkis-engineconn-manager/target/
+linkis-computation-governance/linkis-engineconn/target/
+linkis-computation-governance/linkis-manager/target/
+linkis-computation-governance/target/
+linkis-engineconn-plugins/target/
+linkis-extensions/target/
+linkis-orchestrator/target/
+linkis-public-enhancements/linkis-bml/target/
+linkis-public-enhancements/linkis-context-service/target/
+linkis-public-enhancements/linkis-publicservice/linkis-error-code/target/
+linkis-public-enhancements/target/
+linkis-spring-cloud-services/linkis-service-gateway/target/
+linkis-spring-cloud-services/target/

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ImagePanel.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ImagePanel.java
@@ -1,0 +1,21 @@
+package org.apache.linkis.ujes.client.response.image;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+public class ImagePanel extends JPanel {
+    BufferedImage image;
+
+    public ImagePanel(Image image) {
+        this.image = new BufferedImage(image.getWidth(null), image.getHeight(null),
+                BufferedImage.TYPE_4BYTE_ABGR);
+        Graphics g = this.image.getGraphics();
+        g.drawImage(image, 0, 0, null);
+    }
+
+    public void paintComponent(Graphics g) {
+        g.drawImage(image, 0, 0, null);
+    }
+}
+

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ImagePanel.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ImagePanel.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.ujes.client.response.image;
 
 import javax.swing.*;

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ShowImage.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ShowImage.scala
@@ -1,0 +1,84 @@
+package org.apache.linkis.ujes.client.response.image
+
+import java.util
+import java.util.Base64
+import javax.swing.{ImageIcon, JFrame}
+import scala.collection.mutable.ArrayBuffer
+
+object ShowImage {
+
+  def showImage(fileContents: Object, width: Int = 1000, height: Int = 1000): Unit = {
+    new ShowImages(fileContents).showImage(width, height)
+  }
+
+  private class ShowImages(fileContents: Object) {
+
+    private def checkIsValidData: Boolean = fileContents.isInstanceOf[util.ArrayList[Object]]
+
+    private def getArrayList: util.ArrayList[AnyRef] = fileContents.asInstanceOf[util.ArrayList[AnyRef]]
+
+    private def getBase64Data(o: Object): String = {
+      val imgData: String = o.toString
+      if (imgData.contains(CONTAINS_DATA)) {
+        return imgData.split(CONTAINS_DATA)(1).replace(REPLACE_STR, "").split(" ")(0)
+      }
+      null
+    }
+
+    private def putBytes(o: Object, images: ArrayBuffer[Array[Byte]]): Unit = {
+      val base64Data = getBase64Data(o)
+      if (null != base64Data) {
+        val bytes = Base64.getDecoder.decode(base64Data)
+        images += bytes
+      }
+    }
+
+    private def getImageData: ArrayBuffer[Array[Byte]] = {
+      val images = new ArrayBuffer[Array[Byte]]()
+      if (!checkIsValidData) {
+        return images
+      }
+
+      for (o <- getArrayList.toArray()) {
+        putBytes(o, images)
+      }
+      images
+    }
+
+    def showImage(width: Int, height: Int): Unit = {
+      for (img <- getImageData) {
+        Image.showImage(img, width, height)
+      }
+    }
+
+    val CONTAINS_DATA: String = "<img src=data:image/png;base64,"
+    val REPLACE_STR: String = "]";
+
+  }
+
+
+  private object Image {
+
+    def showImage(data: Array[Byte], width: Int, height: Int): Unit = {
+
+      val frame = new JFrame
+      frame.setContentPane(new ImagePanel(new ImageIcon(data).getImage))
+      frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE)
+      frame.setBounds(100, 100, width, height)
+      frame.setVisible(true)
+
+      new Thread(new Runnable() {
+        override def run(): Unit = {
+          Thread.sleep(5000)
+          frame.repaint()
+        }
+      }).start()
+
+    }
+  }
+}
+
+
+
+
+

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ShowImage.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/image/ShowImage.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.ujes.client.response.image
 
 import java.util

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/ujes/client/PythonImageJavaClientTest.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/ujes/client/PythonImageJavaClientTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.ujes.client;
 
 

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/ujes/client/PythonImageJavaClientTest.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/ujes/client/PythonImageJavaClientTest.java
@@ -23,7 +23,7 @@ public class PythonImageJavaClientTest {
     public static void main(String[] args) {
 
         String user = "hadoop";
-        String gatewayIp = "你的 linkis 网关地址";
+        String gatewayIp = "127.0.0.1";
         String password = "hadoop";
 
         /**

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/ujes/client/PythonImageJavaClientTest.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/ujes/client/PythonImageJavaClientTest.java
@@ -1,0 +1,146 @@
+package org.apache.linkis.ujes.client;
+
+
+import org.apache.commons.io.IOUtils;
+import org.apache.linkis.common.utils.Utils;
+import org.apache.linkis.httpclient.dws.authentication.StaticAuthenticationStrategy;
+import org.apache.linkis.httpclient.dws.config.DWSClientConfig;
+import org.apache.linkis.httpclient.dws.config.DWSClientConfigBuilder;
+import org.apache.linkis.manager.label.constant.LabelKeyConstant;
+import org.apache.linkis.protocol.constants.TaskConstant;
+import org.apache.linkis.ujes.client.request.JobSubmitAction;
+import org.apache.linkis.ujes.client.request.ResultSetAction;
+import org.apache.linkis.ujes.client.response.JobExecuteResult;
+import org.apache.linkis.ujes.client.response.JobInfoResult;
+import org.apache.linkis.ujes.client.response.JobProgressResult;
+import org.apache.linkis.ujes.client.response.image.ShowImage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class PythonImageJavaClientTest {
+    public static void main(String[] args) {
+
+        String user = "hadoop";
+        String gatewayIp = "你的 linkis 网关地址";
+        String password = "hadoop";
+
+        /**
+         * python matplotlib 画图样例
+         */
+        String executeCode = "import numpy as np\n" +
+                "import matplotlib.pyplot as plt\n" +
+                "from matplotlib.font_manager import FontProperties\n" +
+                "plt.figure(1)\n" +
+                "plt.figure(2)\n" +
+                "ax1 = plt.subplot(211)\n" +
+                "ax2 = plt.subplot(212)\n" +
+                "ax1.set_title(u\"helloworld\")\n" +
+                "x = np.linspace(0, 3, 100)\n" +
+                "for i in range(5):\n" +
+                "    plt.figure(1)\n" +
+                "    plt.plot(x, np.exp(i*x/3))\n" +
+                "    plt.sca(ax1)\n" +
+                "    plt.plot(x, np.sin(i*x))\n" +
+                "    plt.sca(ax2)\n" +
+                "    plt.plot(x, np.cos(i*x))\n" +
+                "\n" +
+                "show.show_matplotlib(plt)";
+
+        /**
+         * pyspark 代码样例
+         */
+        String pysparkExecuteCode = "from pyspark.sql import Row\n" +
+                "from pyspark.sql import HiveContext\n" +
+                "import pyspark\n" +
+                "import matplotlib.pyplot as plt\n" +
+                "\n" +
+                "plt.rcParams[\"figure.figsize\"] = [7.50, 3.50]\n" +
+                "plt.rcParams[\"figure.autolayout\"] = True\n" +
+                "\n" +
+                "sqlContext = HiveContext(sc)\n" +
+                "\n" +
+                "test_list = [(1, 'John'), (2, 'James'), (3, 'Jack'), (4, 'Joe')]\n" +
+                "rdd = sc.parallelize(test_list)\n" +
+                "people = rdd.map(lambda x: Row(id=int(x[0]), name=x[1]))\n" +
+                "schemaPeople = sqlContext.createDataFrame(people)\n" +
+                "sqlContext.registerDataFrameAsTable(schemaPeople, \"my_table\")\n" +
+                "\n" +
+                "df = sqlContext.sql(\"Select * from my_table\")\n" +
+                "df = df.toPandas()\n" +
+                "df.set_index('name').plot()\n" +
+                "\n" +
+                "show_matplotlib(plt)";
+
+
+
+        // 1. 配置ClientBuilder，获取ClientConfig
+        DWSClientConfig clientConfig = ((DWSClientConfigBuilder) (DWSClientConfigBuilder.newBuilder()
+                .addServerUrl("http://" + gatewayIp + ":9001")  //指定ServerUrl，linkis服务器端网关的地址,如http://{ip}:{port}
+                .connectionTimeout(30000)   //connectionTimeOut 客户端连接超时时间
+                .discoveryEnabled(false).discoveryFrequency(1, TimeUnit.MINUTES)  //是否启用注册发现，如果启用，会自动发现新启动的Gateway
+                .loadbalancerEnabled(true)  // 是否启用负载均衡，如果不启用注册发现，则负载均衡没有意义
+                .maxConnectionSize(5)   //指定最大连接数，即最大并发数
+                .retryEnabled(false).readTimeout(30000)   //执行失败，是否允许重试
+                .setAuthenticationStrategy(new StaticAuthenticationStrategy())   //AuthenticationStrategy Linkis认证方式
+                .setAuthTokenKey(user).setAuthTokenValue(password)))  //认证key，一般为用户名;  认证value，一般为用户名对应的密码
+                .setDWSVersion("v1").build();  //linkis后台协议的版本，当前版本为v1
+
+        // 2. 通过DWSClientConfig获取一个UJESClient
+        UJESClient client = new UJESClientImpl(clientConfig);
+
+        try {
+            // 3. 开始执行代码
+            System.out.println("user : " + user + ", code : [" + executeCode + "]");
+            Map<String, Object> startupMap = new HashMap<String, Object>();
+            // 在startupMap可以存放多种启动参数，参见linkis管理台配置
+            startupMap.put("wds.linkis.yarnqueue", "q02");
+            //指定Label
+            Map<String, Object> labels = new HashMap<String, Object>();
+            //添加本次执行所依赖的的标签:EngineTypeLabel/UserCreatorLabel/EngineRunTypeLabel
+            labels.put(LabelKeyConstant.ENGINE_TYPE_KEY, "python-python2");
+            labels.put(LabelKeyConstant.USER_CREATOR_TYPE_KEY, user + "-IDE");
+            labels.put(LabelKeyConstant.CODE_TYPE_KEY, "python");
+            //指定source
+            Map<String, Object> source = new HashMap<String, Object>();
+            source.put(TaskConstant.SCRIPTPATH, "LinkisClient-test");
+            JobExecuteResult jobExecuteResult = client.submit(JobSubmitAction.builder()
+                    .addExecuteCode(executeCode)
+                    .setStartupParams(startupMap)
+                    .setUser(user)//Job提交用户
+                    .addExecuteUser(user)//实际执行用户
+                    .setLabels(labels)
+                    .setSource(source)
+                    .build()
+            );
+            System.out.println("execId: " + jobExecuteResult.getExecID() + ", taskId: " + jobExecuteResult.taskID());
+
+            // 4. 获取脚本的执行状态
+            JobInfoResult jobInfoResult = client.getJobInfo(jobExecuteResult);
+            int sleepTimeMills = 1000;
+            while (!jobInfoResult.isCompleted()) {
+                // 5. 获取脚本的执行进度
+                JobProgressResult progress = client.progress(jobExecuteResult);
+                Utils.sleepQuietly(sleepTimeMills);
+                jobInfoResult = client.getJobInfo(jobExecuteResult);
+            }
+
+            // 6. 获取脚本的Job信息
+            JobInfoResult jobInfo = client.getJobInfo(jobExecuteResult);
+            // 7. 获取结果集列表（如果用户一次提交多个SQL，会产生多个结果集）
+            String resultSet = jobInfo.getResultSetList(client)[0];
+            // 8. 通过一个结果集信息，获取具体的结果集
+            Object fileContents = client.resultSet(ResultSetAction.builder().setPath(resultSet).setUser(jobExecuteResult.getUser()).build()).getFileContent();
+            System.out.println("fileContents: " + fileContents);
+
+            // 将 fileContents 中的图片打印出来
+            ShowImage.showImage(fileContents, 1000, 1000);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            IOUtils.closeQuietly(client);
+        }
+        IOUtils.closeQuietly(client);
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change
1. For the content returned by UJESClient, support the Matplotlib returned by Python engine and pyspark engine

   Display the pictures in the result in IDEA

2. Add a python test example, including two grammars of Python and Pyspark engine using matplotlib

3. .gitignore ignores some targets Added



1. 对 UJESClient 返回的内容，支持将 python 引擎 和 pyspark引擎返回的 matplotlib
在idea中对结果中的图片进行展示

2. 添加了一个python的测试例子,包含 pyspark和python俩种使用 matplotlib 的语法

3. .gitignore 忽略某些target
