### PR TITLE
support flinksql create and drop hive catalog

### DIFF
--- a/db/linkis_dml.sql
+++ b/db/linkis_dml.sql
@@ -23,7 +23,7 @@ SET @HIVE_LABEL="hive-2.3.3";
 SET @PYTHON_LABEL="python-python2";
 SET @PIPELINE_LABEL="pipeline-*";
 SET @JDBC_LABEL="jdbc-4";
-
+set @KERBEROS_ENABLE=false;
 -- 衍生变量：
 SET @SPARK_ALL=CONCAT('*-*,',@SPARK_LABEL);
 SET @SPARK_IDE=CONCAT('*-IDE,',@SPARK_LABEL);

--- a/db/linkis_dml.sql
+++ b/db/linkis_dml.sql
@@ -23,7 +23,7 @@ SET @HIVE_LABEL="hive-2.3.3";
 SET @PYTHON_LABEL="python-python2";
 SET @PIPELINE_LABEL="pipeline-*";
 SET @JDBC_LABEL="jdbc-4";
-set @KERBEROS_ENABLE=false;
+
 -- 衍生变量：
 SET @SPARK_ALL=CONCAT('*-*,',@SPARK_LABEL);
 SET @SPARK_IDE=CONCAT('*-IDE,',@SPARK_LABEL);

--- a/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
@@ -212,20 +212,32 @@ class YarnResourceRequester extends ExternalResourceRequester with Logging {
   private def getResponseByUrl(url: String, rmWebAddress: String) = {
     val httpGet = new HttpGet(rmWebAddress + "/ws/v1/cluster/" + url)
     httpGet.addHeader("Accept", "application/json")
-    if (this.provider.getConfigMap.get("authorEnable").asInstanceOf[Boolean])
-      httpGet.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + getAuthorizationStr)
+    val authorEnable=this.provider.getConfigMap.get("authorEnable");
     var httpResponse: HttpResponse = null
-    if(this.provider.getConfigMap.get("kerberosEnable") != null
-      && this.provider.getConfigMap.get("kerberosEnable").asInstanceOf[Boolean]){
-      val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
-      val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
-      val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
-      val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
-      val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
-      httpResponse = response
-    }else {
-      val response = YarnResourceRequester.httpClient.execute(httpGet)
-      httpResponse = response
+    authorEnable match {
+      case Boolean =>
+        if(authorEnable.asInstanceOf[Boolean]){
+          httpGet.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + getAuthorizationStr)
+        }
+      case _ =>
+    }
+    val kerberosEnable =this.provider.getConfigMap.get("kerberosEnable");
+    kerberosEnable match {
+      case Boolean =>
+        if(kerberosEnable.asInstanceOf[Boolean]){
+          val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
+          val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
+          val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
+          val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
+          val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
+          httpResponse = response;
+        }else{
+          val response = YarnResourceRequester.httpClient.execute(httpGet)
+          httpResponse = response
+        }
+      case _ =>
+        val response = YarnResourceRequester.httpClient.execute(httpGet)
+        httpResponse = response
     }
     parse(EntityUtils.toString(httpResponse.getEntity()))
   }

--- a/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
@@ -212,32 +212,20 @@ class YarnResourceRequester extends ExternalResourceRequester with Logging {
   private def getResponseByUrl(url: String, rmWebAddress: String) = {
     val httpGet = new HttpGet(rmWebAddress + "/ws/v1/cluster/" + url)
     httpGet.addHeader("Accept", "application/json")
-    val authorEnable=this.provider.getConfigMap.get("authorEnable");
+    if (this.provider.getConfigMap.get("authorEnable").asInstanceOf[Boolean])
+      httpGet.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + getAuthorizationStr)
     var httpResponse: HttpResponse = null
-    authorEnable match {
-      case Boolean =>
-        if(authorEnable.asInstanceOf[Boolean]){
-          httpGet.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + getAuthorizationStr)
-        }
-      case _ =>
-    }
-    val kerberosEnable =this.provider.getConfigMap.get("kerberosEnable");
-    kerberosEnable match {
-      case Boolean =>
-        if(kerberosEnable.asInstanceOf[Boolean]){
-          val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
-          val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
-          val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
-          val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
-          val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
-          httpResponse = response;
-        }else{
-          val response = YarnResourceRequester.httpClient.execute(httpGet)
-          httpResponse = response
-        }
-      case _ =>
-        val response = YarnResourceRequester.httpClient.execute(httpGet)
-        httpResponse = response
+    if(this.provider.getConfigMap.get("kerberosEnable") != null
+      && this.provider.getConfigMap.get("kerberosEnable").asInstanceOf[Boolean]){
+      val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
+      val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
+      val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
+      val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
+      val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
+      httpResponse = response
+    }else {
+      val response = YarnResourceRequester.httpClient.execute(httpGet)
+      httpResponse = response
     }
     parse(EntityUtils.toString(httpResponse.getEntity()))
   }

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
@@ -125,6 +125,11 @@
             <artifactId>flink-shaded-jackson</artifactId>
             <version>2.10.1-9.0</version>
         </dependency>
+		  <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libfb303</artifactId>
+            <version>0.9.3</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-yarn_${scala.binary.version}</artifactId>

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/OperationFactoryImpl.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/OperationFactoryImpl.java
@@ -5,16 +5,16 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.engineconnplugin.flink.client.sql.operation;
 
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.impl.*;
@@ -43,6 +43,8 @@ public class OperationFactoryImpl implements OperationFactory {
                 operation = new DropViewOperation(context, call.operands[0], Boolean.parseBoolean(call.operands[1]));
                 break;
             case CREATE_TABLE:
+            case CREATE_CATALOG:
+            case DROP_CATALOG:
             case DROP_TABLE:
             case ALTER_TABLE:
             case CREATE_DATABASE:

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/DDLOperation.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/DDLOperation.java
@@ -5,16 +5,16 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.engineconnplugin.flink.client.sql.operation.impl;
 
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
@@ -59,6 +59,12 @@ public class DDLOperation implements NonJobOperation {
 		switch (command) {
 			case CREATE_TABLE:
 				actionMsg = "create a table";
+				break;
+			case CREATE_CATALOG:
+				actionMsg = "create a catalog";
+				break;
+			case DROP_CATALOG:
+				actionMsg = "drop a catalog";
 				break;
 			case CREATE_DATABASE:
 				actionMsg = "create a database";

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommand.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommand.java
@@ -5,16 +5,16 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.engineconnplugin.flink.client.sql.parser;
 
 import java.util.Optional;
@@ -33,9 +33,13 @@ public enum SqlCommand {
 
     CREATE_TABLE,
 
+    CREATE_CATALOG,
+
     ALTER_TABLE,
 
     DROP_TABLE,
+
+    DROP_CATALOG,
 
     CREATE_VIEW,
 

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommandParserImpl.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommandParserImpl.java
@@ -5,16 +5,16 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.engineconnplugin.flink.client.sql.parser;
 
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.OperationFactory;
@@ -97,6 +97,12 @@ public class SqlCommandParserImpl implements SqlCommandParser {
             operands = new String[0];
         } else if (node instanceof SqlCreateTable) {
             cmd = SqlCommand.CREATE_TABLE;
+            operands = new String[]{stmt};
+        } else if (node instanceof SqlCreateCatalog) {
+            cmd = SqlCommand.CREATE_CATALOG;
+            operands = new String[] { stmt };
+        } else if (node instanceof SqlDropCatalog) {
+            cmd = SqlCommand.DROP_CATALOG;
             operands = new String[] { stmt };
         } else if (node instanceof SqlDropTable) {
             cmd = SqlCommand.DROP_TABLE;


### PR DESCRIPTION
You can create and drop catalog through flinksql, specify the corresponding hiveconf directory, customize catalog , and  ‘USE CATALOG’ to switch catalog
eg：
CREATE CATALOG myhive WITH (
    'type' = 'hive',
    'default-database' = 'mydatabase',
    'hive-conf-dir' = '/opt/hive-conf'
);
`------------------------------------`
USE CATALOG myhive;
`------------------------------------`
DROP CATALOG  myhive;