### PR TITLE
support flinksql create and drop hive catalog

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
@@ -202,6 +202,11 @@
             <artifactId>flink-json</artifactId>
             <version>${flink.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libfb303</artifactId>
+            <version>0.9.3</version>
+        </dependency>
         <!-- flink end-->
 
         <dependency>

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/OperationFactoryImpl.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/OperationFactoryImpl.java
@@ -45,6 +45,8 @@ public class OperationFactoryImpl implements OperationFactory {
             case CREATE_TABLE:
             case DROP_TABLE:
             case ALTER_TABLE:
+            case CREATE_CATALOG:
+            case DROP_CATALOG:
             case CREATE_DATABASE:
             case DROP_DATABASE:
             case ALTER_DATABASE:

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/DDLOperation.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/DDLOperation.java
@@ -69,6 +69,12 @@ public class DDLOperation implements NonJobOperation {
 			case DROP_DATABASE:
 				actionMsg = "drop a database";
 				break;
+			case CREATE_CATALOG:
+				actionMsg = "create a catalog";
+				break;
+			case DROP_CATALOG:
+				actionMsg = "drop a catalog";
+				break;
 			case ALTER_TABLE:
 				actionMsg = "alter a table";
 				break;

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommand.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommand.java
@@ -37,6 +37,10 @@ public enum SqlCommand {
 
     DROP_TABLE,
 
+    CREATE_CATALOG,
+
+    DROP_CATALOG,
+
     CREATE_VIEW,
 
     DROP_VIEW,

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommandParserImpl.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/parser/SqlCommandParserImpl.java
@@ -101,6 +101,12 @@ public class SqlCommandParserImpl implements SqlCommandParser {
         } else if (node instanceof SqlDropTable) {
             cmd = SqlCommand.DROP_TABLE;
             operands = new String[] { stmt };
+        } else if (node instanceof SqlCreateCatalog) {
+            cmd = SqlCommand.CREATE_CATALOG;
+            operands = new String[] { stmt };
+        } else if (node instanceof SqlDropCatalog) {
+            cmd = SqlCommand.DROP_CATALOG;
+            operands = new String[] { stmt };
         } else if (node instanceof SqlAlterTable) {
             cmd = SqlCommand.ALTER_TABLE;
             operands = new String[] { stmt };


### PR DESCRIPTION
You can create and drop catalog through flinksql, specify the corresponding hiveconf directory, customize catalog , and ‘USE CATALOG’ to switch catalog
eg：
CREATE CATALOG myhive WITH (
'type' = 'hive',
'default-database' = 'mydatabase',
'hive-conf-dir' = '/opt/hive-conf'
);
`------------------------------------`
USE CATALOG myhive;
`------------------------------------`
DROP CATALOG myhive;·

### What is the purpose of the change
(For example: EngineConn-Core defines the the abstractions and interfaces of the EngineConn core functions.
The Engine Service in Linkis 0.x is refactored, EngineConn will handle the engine connection and session management.
Related issues: #590. )

### Brief change log
(for example:)
- Define the core abstraction and interfaces of the EngineConn Factory;
- Define the core abstraction and interfaces of Executor Manager.

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  
(or)  
This change is already covered by existing tests, such as (please describe tests).  
(or)  
This change added tests and can be verified as follows:  
(example:)  
- Added tests for submit and execute all kinds of jobs to go through and verify the lifecycles of different EngineConns.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes / no)
- Anything that affects deployment: (yes / no / don't know)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes / no)

### Documentation
- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)