### PR TITLE
fix issue 1148 yarn default should not open kerberos

### DIFF
--- a/db/linkis_dml.sql
+++ b/db/linkis_dml.sql
@@ -23,6 +23,7 @@ SET @HIVE_LABEL="hive-2.3.3";
 SET @PYTHON_LABEL="python-python2";
 SET @PIPELINE_LABEL="pipeline-*";
 SET @JDBC_LABEL="jdbc-4";
+set @KERBEROS_ENABLE=false;
 
 -- 衍生变量：
 SET @SPARK_ALL=CONCAT('*-*,',@SPARK_LABEL);

--- a/db/linkis_dml.sql
+++ b/db/linkis_dml.sql
@@ -23,7 +23,6 @@ SET @HIVE_LABEL="hive-2.3.3";
 SET @PYTHON_LABEL="python-python2";
 SET @PIPELINE_LABEL="pipeline-*";
 SET @JDBC_LABEL="jdbc-4";
-set @KERBEROS_ENABLE=false;
 
 -- 衍生变量：
 SET @SPARK_ALL=CONCAT('*-*,',@SPARK_LABEL);

--- a/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
@@ -212,29 +212,29 @@ class YarnResourceRequester extends ExternalResourceRequester with Logging {
   private def getResponseByUrl(url: String, rmWebAddress: String) = {
     val httpGet = new HttpGet(rmWebAddress + "/ws/v1/cluster/" + url)
     httpGet.addHeader("Accept", "application/json")
-    val authorEnable=this.provider.getConfigMap.get("authorEnable");
+    val authorEnable:Any = this.provider.getConfigMap.get("authorEnable");
     var httpResponse: HttpResponse = null
     authorEnable match {
-      case Boolean =>
-        if(authorEnable.asInstanceOf[Boolean]){
+      case  flag: Boolean =>
+        if(flag){
           httpGet.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + getAuthorizationStr)
         }
       case _ =>
     }
-    val kerberosEnable =this.provider.getConfigMap.get("kerberosEnable");
+    val kerberosEnable:Any =this.provider.getConfigMap.get("kerberosEnable");
     kerberosEnable match {
-      case Boolean =>
-        if(kerberosEnable.asInstanceOf[Boolean]){
-          val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
-          val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
-          val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
-          val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
-          val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
-          httpResponse = response;
-        }else{
-          val response = YarnResourceRequester.httpClient.execute(httpGet)
-          httpResponse = response
-        }
+      case flag: Boolean =>
+          if(flag){
+            val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
+            val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
+            val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
+            val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
+            val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
+            httpResponse = response;
+          }else{
+            val response = YarnResourceRequester.httpClient.execute(httpGet)
+            httpResponse = response
+          }
       case _ =>
         val response = YarnResourceRequester.httpClient.execute(httpGet)
         httpResponse = response

--- a/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/external/yarn/YarnResourceRequester.scala
@@ -212,20 +212,32 @@ class YarnResourceRequester extends ExternalResourceRequester with Logging {
   private def getResponseByUrl(url: String, rmWebAddress: String) = {
     val httpGet = new HttpGet(rmWebAddress + "/ws/v1/cluster/" + url)
     httpGet.addHeader("Accept", "application/json")
-    if (this.provider.getConfigMap.get("authorEnable").asInstanceOf[Boolean])
-      httpGet.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + getAuthorizationStr)
+    val authorEnable=this.provider.getConfigMap.get("authorEnable");
     var httpResponse: HttpResponse = null
-    if(this.provider.getConfigMap.get("kerberosEnable") != null
-      && this.provider.getConfigMap.get("kerberosEnable").asInstanceOf[Boolean]){
-      val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
-      val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
-      val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
-      val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
-      val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
-      httpResponse = response
-    }else {
-      val response = YarnResourceRequester.httpClient.execute(httpGet)
-      httpResponse = response
+    authorEnable match {
+      case Boolean =>
+        if(authorEnable.asInstanceOf[Boolean]){
+          httpGet.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + getAuthorizationStr)
+        }
+      case _ =>
+    }
+    val kerberosEnable =this.provider.getConfigMap.get("kerberosEnable");
+    kerberosEnable match {
+      case Boolean =>
+        if(kerberosEnable.asInstanceOf[Boolean]){
+          val principalName = this.provider.getConfigMap.get("principalName").asInstanceOf[String]
+          val keytabPath = this.provider.getConfigMap.get("keytabPath").asInstanceOf[String]
+          val krb5Path = this.provider.getConfigMap.get("krb5Path").asInstanceOf[String]
+          val requestKuu = new RequestKerberosUrlUtils(principalName,keytabPath,krb5Path,false)
+          val response = requestKuu.callRestUrl(rmWebAddress + "/ws/v1/cluster/" + url,principalName)
+          httpResponse = response;
+        }else{
+          val response = YarnResourceRequester.httpClient.execute(httpGet)
+          httpResponse = response
+        }
+      case _ =>
+        val response = YarnResourceRequester.httpClient.execute(httpGet)
+        httpResponse = response
     }
     parse(EntityUtils.toString(httpResponse.getEntity()))
   }


### PR DESCRIPTION
fix issue 1148 yarn default should not open kerberos,but sql script not have KERBEROS_ENABLE default value
Related issues: [#1148](https://github.com/apache/incubator-linkis/issues/1148). )