### PR TITLE
[LINKIS #1170] Make the mysql-connector-java dependency scope to test.

### DIFF
--- a/linkis-commons/linkis-module/pom.xml
+++ b/linkis-commons/linkis-module/pom.xml
@@ -306,6 +306,11 @@
         </dependency>
 
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <spring.security.cryto.version>5.3.6.RELEASE</spring.security.cryto.version>
         <reflections.version>0.9.10</reflections.version>
         <mybatis-plus.boot.starter.version>3.4.1</mybatis-plus.boot.starter.version>
+        <mysql.connector.version>5.1.49</mysql.connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javassist.version>3.19.0-GA</javassist.version>
         <commons-collections.version>3.2.2</commons-collections.version>
@@ -218,6 +219,13 @@
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>${commons-collections.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql.connector.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### What is the purpose of the change

Make the mysql-connector-java dependency scope to test. Related issues: #1170.

Will revert this commit : https://github.com/apache/incubator-linkis/commit/4b1152ff3469faf9c5a23c2ff460eb3ce04e11eb

### Brief change log

no

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency):  yes
- Anything that affects deployment:  no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.:  no

### Documentation
- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented?  not applicable 