### PR TITLE
Fix the issue that the tasks queued by orchestrator cannot be killed

### DIFF
--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
@@ -54,11 +54,20 @@ object OrchestratorConfiguration {
 
   val RETRY_TASK_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.retry.wait.time", 10000)
 
+  val SCHEDULER_RETRY_TASK_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.scheduler.retry.wait.time", 100000)
+
   val TASK_SCHEDULER_THREAD_POOL = CommonVars("wds.linkis.orchestrator.task.scheduler.thread.pool", 200)
 
-  val ORCHESTRATOR_EXECUTION_FACTORY = CommonVars("wds.linkis.orchestrator.execution.factory.class", "org.apache.linkis.orchestrator.code.plans.execution.CodeExecutionFactory")
+  val ORCHESTRATOR_EXECUTION_FACTORY = CommonVars("wds.linkis.orchestrator.execution.factory.class", "com.webank.wedatasphere.linkis.orchestrator.code.plans.execution.CodeExecutionFactory")
 
   val TASK_CONSUMER_WAIT = CommonVars("wds.linkis.orchestrator.task.consumer.wait", 500)
 
   val ORCHESTRATOR_USER_MAX_RUNNING = CommonVars("wds.linkis.task.user.max.running", 5)
+
+  val SCHEDULIS_CREATOR = CommonVars("wds.linkis.orchestrator.task.schedulis.creator", "schedulis")
+
+  val ORCHESTRATOR_METRIC_LOG = CommonVars("wds.linkis.orchestrator.metric.log.enable", true)
+
+  val ORCHESTRATOR_METRIC_LOG_TIME = CommonVars("wds.linkis.orchestrator.metric.log.time", new TimeType("1h"))
+
 }

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
@@ -58,7 +58,7 @@ object OrchestratorConfiguration {
 
   val TASK_SCHEDULER_THREAD_POOL = CommonVars("wds.linkis.orchestrator.task.scheduler.thread.pool", 200)
 
-  val ORCHESTRATOR_EXECUTION_FACTORY = CommonVars("wds.linkis.orchestrator.execution.factory.class", "com.webank.wedatasphere.linkis.orchestrator.code.plans.execution.CodeExecutionFactory")
+  val ORCHESTRATOR_EXECUTION_FACTORY = CommonVars("wds.linkis.orchestrator.execution.factory.class", "org.apache.linkis.orchestrator.code.plans.execution.CodeExecutionFactory")
 
   val TASK_CONSUMER_WAIT = CommonVars("wds.linkis.orchestrator.task.consumer.wait", 500)
 

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/execution/impl/ExecutionImpl.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/execution/impl/ExecutionImpl.scala
@@ -67,9 +67,16 @@ class ExecutionImpl(override val taskScheduler: TaskScheduler,
   }
 
   override def onKillRootExecTaskEvent(killRootExecTaskEvent: KillRootExecTaskEvent): Unit = {
-    info(s"receive killRootExecTaskEvent ${killRootExecTaskEvent.execTask.getIDInfo}")
-    taskManager.getRunningTask(killRootExecTaskEvent.execTask).foreach {
-      taskScheduler.cancelTask(_, true)
+    val execTask = killRootExecTaskEvent.execTask
+    info(s"receive killRootExecTaskEvent ${execTask.getIDInfo}")
+    val runners = taskManager.getRunningTask(execTask)
+    if (null != runners && runners.nonEmpty) {
+      runners.foreach {
+        taskScheduler.cancelTask(_, true)
+      }
+    } else {
+      info(s"${execTask.getIDInfo()} running task is null, now to mark ExecutionTask Failed ")
+      execTask.getPhysicalContext.markFailed("Execution Task is cancelled", null)
     }
   }
 }

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/execution/impl/NotifyTaskConsumer.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/execution/impl/NotifyTaskConsumer.scala
@@ -51,6 +51,8 @@ abstract class NotifyTaskConsumer extends TaskConsumer with OrchestratorAsyncLis
           notifyLock.wait(getWaitTime)
         }
       }("Consumer error")
+    logger.error("Consumer exit, now exit process")
+    System.exit(1)
   }
 
   override def onEvent(event: OrchestratorAsyncEvent): Unit = event match {

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/physical/PhysicalContextImpl.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/physical/PhysicalContextImpl.scala
@@ -59,8 +59,6 @@ class PhysicalContextImpl(private var rootTask: ExecTask,private var leafTasks: 
     this.executionNodeStatus = ExecutionNodeStatus.Failed
     val failedResponse = new DefaultFailedTaskResponse(errorMsg, OrchestratorErrorCodeSummary.EXECUTION_ERROR_CODE, cause)
     this.response = failedResponse
-    val event = TaskLogEvent(getRootTask, LogUtils.generateERROR(errorMsg))
-    pushLog(event)
     syncListenerBus.postToAll(RootTaskResponseEvent(getRootTask, failedResponse))
   }
 

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/reheater/AbstractReheater.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/reheater/AbstractReheater.scala
@@ -34,24 +34,24 @@ abstract class AbstractReheater extends Reheater with Logging {
       var changed = false
       Utils.tryCatch(Option(reheaterTransforms).foreach { transforms =>
         Option(execTask.getChildren).map(_.map{ child =>
-          val newChild = transforms.foldLeft(child)((node, transform) => transform.apply(node, execTask.getPhysicalContext).asInstanceOf[ExecTask])
-          if(!child.theSame(newChild)) {
+          val newChild = transforms.foldLeft(child)((node, transform) => transform.apply(node, execTask.getPhysicalContext))
+          if (!child.theSame(newChild)) {
             changed = true
             newChild.relateParents(child)
             newChild
           } else child
         }).foreach { children =>
-          if(changed) {
+          if (changed) {
             execTask.withNewChildren(children)
           }
         }
       }) { t =>
-        error(s"Reheat ${execTask.getIDInfo()} failed, now mark it failed!", t)
-        execTask.getPhysicalContext.markFailed(s"Reheat ${execTask.getIDInfo()} failed, now mark it failed!", t)
+        logger.error(s" Reheat ${execTask.getIDInfo()} failed, now mark it failed!", t)
+        execTask.getPhysicalContext.markFailed(s" Reheat ${execTask.getIDInfo()} failed, now mark it failed!", t)
       }
       reheat.setReheated()
-      if(changed) {
-        info(s"${execTask.getIDInfo()} reheated. The physicalTree has been changed. The new tree is ${execTask.simpleString}." )
+      if (changed) {
+        logger.info(s"${execTask.getIDInfo()} reheated. The physicalTree has been changed. The new tree is ${execTask.simpleString}.")
       }
     case _ =>
   }

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/reheater/ReheaterNotifyTaskConsumer.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/reheater/ReheaterNotifyTaskConsumer.scala
@@ -32,6 +32,7 @@ abstract class ReheaterNotifyTaskConsumer extends NotifyTaskConsumer {
     def compareAndSet(lastRunning: String): Unit = {
       val thisRunning = getExecution.taskManager.getCompletedTasks(execTask).map(_.task.getId).mkString(",")
       if(thisRunning != lastRunning) {
+        logger.debug(s"${execTask.getIDInfo()} Try to reheat this $thisRunning. lastRunning: $lastRunning")
         reheater.reheat(execTask)
         execTask.getPhysicalContext.set(key, thisRunning)
       }

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/strategy/async/AsyncExecTaskRunnerImpl.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/strategy/async/AsyncExecTaskRunnerImpl.scala
@@ -65,29 +65,29 @@ class AsyncExecTaskRunnerImpl(override val task: ExecTask) extends AsyncExecTask
       case async: AsyncTaskResponse =>
         transientStatus(ExecutionNodeStatus.Running)
       case succeed: SucceedTaskResponse =>
-        info(s"Succeed to execute ExecTask(${task.getIDInfo})")
+        logger.info(s"Succeed to execute ExecTask(${task.getIDInfo})")
         transientStatus(ExecutionNodeStatus.Succeed)
       case failedTaskResponse: FailedTaskResponse =>
-        info(s"Failed to execute ExecTask(${task.getIDInfo})")
+        logger.info(s"Failed to execute ExecTask(${task.getIDInfo})")
         transientStatus(ExecutionNodeStatus.Failed)
       case retry: RetryTaskResponse =>
-        warn(s"ExecTask(${task.getIDInfo}) need to retry")
+        logger.warn(s"ExecTask(${task.getIDInfo}) need to retry")
         transientStatus(ExecutionNodeStatus.WaitForRetry)
     }
   } catch {
     case e: Throwable =>
-      error(s"Failed to execute task ${task.getIDInfo}", e)
+      logger.error(s"Failed to execute task ${task.getIDInfo}", e)
       this.taskResponse = new DefaultFailedTaskResponse(e.getMessage, OrchestratorErrorCodeSummary.EXECUTION_ERROR_CODE, e)
       transientStatus(ExecutionNodeStatus.Failed)
   }
 
   override def transientStatus(status: ExecutionNodeStatus): Unit = {
     if (status.ordinal() < this.status.ordinal() && status != ExecutionNodeStatus.WaitForRetry) {
-      info(s"Task${task.getIDInfo()} status flip error! Cause: Failed to flip from ${this.status} to $status.")
+      logger.info(s"Task${task.getIDInfo()} status flip error! Cause: Failed to flip from ${this.status} to $status.")
       return
     }
       //throw new OrchestratorErrorException(OrchestratorErrorCodeSummary.EXECUTION_FOR_EXECUTION_ERROR_CODE, s"Task status flip error! Cause: Failed to flip from ${this.status} to $status.") //抛异常
-    info(s"${task.getIDInfo} change status ${this.status} => $status.")
+    logger.info(s"${task.getIDInfo} change status ${this.status} => $status.")
     beforeStatusChanged(this.status, status)
     val oldStatus = this.status
     this.status = status


### PR DESCRIPTION
### What is the purpose of the change
Fix the issue that the tasks queued by orchestrator cannot be killed close #1182

### Brief change log
- update ExecutionImpl to support killed queued task;