### PR TITLE
The python engine does not use pandas. Delete this module

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/python/src/main/resources/python/python.py
+++ b/linkis-engineconn-plugins/engineconn-plugins/python/src/main/resources/python/python.py
@@ -32,7 +32,6 @@ import traceback
 import warnings
 import signal
 import base64
-import pandas as pd
 from py4j.java_gateway import JavaGateway
 from io import BytesIO
 try:


### PR DESCRIPTION
The python engine does not use pandas. if you not intsall  pandas in you ststem, they will accident   errCode: 60003 ,desc: Python process is not alive，so Delete this module
