### PR TITLE
 linkis. ldap. proxy.Usernameformat  Missing In the links-mg-gateway…

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis-mg-gateway.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis-mg-gateway.properties
@@ -28,6 +28,7 @@ wds.linkis.login_encrypt.enable=false
 ##LDAP
 wds.linkis.ldap.proxy.url=
 wds.linkis.ldap.proxy.baseDN=
+wds.linkis.ldap.proxy.userNameFormat=
 wds.linkis.admin.user=hadoop
 #wds.linkis.admin.password=
 ##Spring


### PR DESCRIPTION
linkis. ldap. proxy.Usernameformat  Missing In the links-mg-gateway.properties
