### PR TITLE
Solve the problem that the new user does not have a workspace directory

### DIFF
--- a/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -127,6 +127,10 @@ public class FsRestfulApi {
         FsPath fsPath = new FsPath(path);
         FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
         if (!fileSystem.exists(fsPath)) {
+            fileSystem.mkdirs(fsPath);
+//            throw WorkspaceExceptionManager.createException(80003);
+        }
+        if(!fileSystem.exists(fsPath)){
             throw WorkspaceExceptionManager.createException(80003);
         }
         return Message.ok().data(String.format("user%sRootPath", returnType), path);
@@ -264,7 +268,8 @@ public class FsRestfulApi {
         FsPath fsPath = new FsPath(path);
         FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
         if (!fileSystem.exists(fsPath)) {
-            return Message.ok().data("dirFileTrees", null);
+            fileSystem.mkdirs(fsPath);
+            // return Message.ok().data("dirFileTrees", null);
         }
         DirFileTree dirFileTree = new DirFileTree();
         dirFileTree.setPath(fsPath.getSchemaPath());


### PR DESCRIPTION
When an LDAP user adds a new user, the corresponding user does not add a workspace directory. As a result, the new user cannot obtain his own workspace directory after logging in. I found that if there is no corresponding directory, he will create his own workspace directory for the corresponding user