### PR TITLE
Use current user to read result file, and abstract the file permission in filesystem

### DIFF
--- a/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/FileSystem.java
+++ b/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/FileSystem.java
@@ -27,8 +27,16 @@ import java.io.IOException;
 
 public abstract class FileSystem implements Fs{
 
-    protected  String user;
+    protected String user;
+    private String defaultFilePerm = "rwxr-----"; //740
+    private String defaultFolderPerm = "rwxr-x---"; //750
 
+    public String getDefaultFilePerm() {
+        return defaultFilePerm;
+    }
+    public String getDefaultFolderPerm() {
+        return defaultFolderPerm;
+    }
 
     public abstract String listRoot() throws IOException;
 

--- a/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/HDFSFileSystem.java
+++ b/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/HDFSFileSystem.java
@@ -27,6 +27,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
@@ -111,7 +112,9 @@ public class HDFSFileSystem extends FileSystem {
         if (!canExecute(getParentPath(path))) {
             throw new IOException("You have not permission to access path " + path);
         }
-        return fs.mkdirs(new Path(path));
+        boolean result = fs.mkdirs(new Path(path));
+        this.setPermission(new FsPath(path), this.getDefaultFolderPerm());
+        return result;
     }
 
     @Override
@@ -124,7 +127,9 @@ public class HDFSFileSystem extends FileSystem {
         if (!canExecute(parentPath)) {
             throw new IOException("You have not permission to access path " + path);
         }
-        return fs.mkdirs(new Path(path));
+        boolean result = fs.mkdirs(new Path(path));
+        this.setPermission(new FsPath(path), this.getDefaultFolderPerm());
+        return result;
     }
 
 
@@ -237,7 +242,9 @@ public class HDFSFileSystem extends FileSystem {
         if (!overwrite) {
             return fs.append(new Path(path));
         } else {
-            return fs.create(new Path(path), true);
+            FSDataOutputStream out = fs.create(new Path(path), true);
+            this.setPermission(dest, this.getDefaultFilePerm());
+            return out;
         }
     }
 
@@ -246,7 +253,9 @@ public class HDFSFileSystem extends FileSystem {
         if (!canExecute(getParentPath(dest))) {
             throw new IOException("You have not permission to access path " + dest);
         }
-        return fs.createNewFile(new Path(checkHDFSPath(dest)));
+        boolean result = fs.createNewFile(new Path(checkHDFSPath(dest)));
+        this.setPermission(new FsPath(dest), this.getDefaultFilePerm());
+        return result;
     }
 
     @Override
@@ -254,7 +263,9 @@ public class HDFSFileSystem extends FileSystem {
         if (!canExecute(getParentPath(dest))) {
             throw new IOException("You have not permission to access path " + dest);
         }
-        return FileUtil.copy(fs, new Path(checkHDFSPath(origin)), fs, new Path(checkHDFSPath(dest)), false, true, fs.getConf());
+        boolean res = FileUtil.copy(fs, new Path(checkHDFSPath(origin)), fs, new Path(checkHDFSPath(dest)), false, true, fs.getConf());
+        this.setPermission(new FsPath(dest), this.getDefaultFilePerm());
+        return res;
     }
 
     @Override

--- a/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/LocalFileSystem.java
+++ b/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/LocalFileSystem.java
@@ -150,7 +150,7 @@ public class LocalFileSystem extends FileSystem {
                 if(!user.equals(getOwner(dirToMake.getAbsolutePath()))) {
                     setOwner(new FsPath(dirToMake.getAbsolutePath()), user, null);
                 }
-                setPermission(new FsPath(dirToMake.getAbsolutePath()), "rwxr-x---");
+                setPermission(new FsPath(dirToMake.getAbsolutePath()), this.getDefaultFolderPerm());
             } else {
                 return false;
             }
@@ -179,7 +179,7 @@ public class LocalFileSystem extends FileSystem {
         }
         FileUtils.copyFile(new File(origin), file);
         try {
-            setPermission(new FsPath(dest), "rwxr-----");
+            setPermission(new FsPath(dest), this.getDefaultFilePerm());
             if(!user.equals(getOwner(dest))) {
                 setOwner(new FsPath(dest), user, null);
             }
@@ -335,7 +335,7 @@ public class LocalFileSystem extends FileSystem {
         }
         file.createNewFile();
         try {
-            setPermission(new FsPath(dest), "rwxr-----");
+            setPermission(new FsPath(dest), this.getDefaultFilePerm());
             if(!user.equals(getOwner(dest))) {
                 setOwner(new FsPath(dest), user, null);
             }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/DefaultResultSetFactory.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/DefaultResultSetFactory.scala
@@ -5,22 +5,22 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.storage.resultset
 
 import java.util
 
 import org.apache.linkis.common.io.resultset.ResultSet
-import org.apache.linkis.common.io.{FsPath, MetaData, Record}
+import org.apache.linkis.common.io.{Fs, FsPath, MetaData, Record}
 import org.apache.linkis.common.utils.{Logging, Utils}
 import org.apache.linkis.storage.FSFactory
 import org.apache.linkis.storage.domain.Dolphin
@@ -64,6 +64,15 @@ class DefaultResultSetFactory extends ResultSetFactory with Logging{
   override def getResultSet(output: String): ResultSet[_ <: MetaData, _ <: Record] = getResultSet(output,StorageUtils.getJvmUser)
 
   override def getResultSetType:Array[String] = resultTypes
+
+  override def getResultSetByPath(fsPath: FsPath, fs: Fs): ResultSet[_ <: MetaData, _ <: Record] = {
+    val inputStream = fs.read(fsPath)
+    val resultSetType = Dolphin.getType(inputStream)
+    if (StringUtils.isEmpty(resultSetType)) throw new StorageWarnException(51000, s"The file (${fsPath.getPath}) is empty(文件(${fsPath.getPath}) 为空)")
+    Utils.tryQuietly(inputStream.close())
+    //Utils.tryQuietly(fs.close())
+    getResultSetByType(resultSetType)
+  }
 
   override def getResultSetByPath(fsPath: FsPath, proxyUser: String): ResultSet[_ <: MetaData, _ <: Record] = {
     if(fsPath == null ) return null

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/ResultSetFactory.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/ResultSetFactory.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.storage.resultset
 
 import org.apache.linkis.common.io.resultset.ResultSet
-import org.apache.linkis.common.io.{FsPath, MetaData, Record}
+import org.apache.linkis.common.io.{Fs, FsPath, MetaData, Record}
 
 import scala.collection.mutable
 
@@ -27,6 +27,7 @@ import scala.collection.mutable
 trait ResultSetFactory extends scala.AnyRef {
   def getResultSetByType(resultSetType : scala.Predef.String) :ResultSet[_ <: MetaData, _ <: Record]
   def getResultSetByPath(fsPath : FsPath) : ResultSet[_ <: MetaData, _ <: Record]
+  def getResultSetByPath(fsPath: FsPath, fs: Fs) : ResultSet[_ <: MetaData, _ <: Record]
   def getResultSetByContent(content : scala.Predef.String) : ResultSet[_ <: MetaData, _ <: Record]
   def exists(resultSetType : scala.Predef.String) : scala.Boolean
   def isResultSetPath(path : scala.Predef.String) : scala.Boolean


### PR DESCRIPTION
### What is the purpose of the change
For now, the file permission of the generated result set in HDFS or local file system is not specified in one place globally, and followed the default value (744), and JVM user is used to read those result file instead of current login user.
It causes two issues:

1) The result set is transparent to all hdfs users;
2) JVM user cannot read current login user's result set when the permission of file is changed to more strict value(like 740).

### Brief change log
- Specify the permission value in FileSystem (740 for file and 750 for folder) , and apply it in in local file system and hdfs;
- Use current login user to read result file instead of JVM user.

### Verifying this change
(Please pick either of the following options)  
This change added tests and can be verified as follows:  
- Submit any type of task normally, and check whether of permission value of results set or log in the hdfs is 740, and it's expected to be available to current login user.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)