### PR TITLE
Dev 1.1.0 linkis hive atlas

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/hive/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/pom.xml
@@ -273,6 +273,29 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>hive-bridge</artifactId>
+            <version>1.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>hive-bridge-shim</artifactId>
+            <version>1.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>


### PR DESCRIPTION
### What is the purpose of the change
Atlas Hive hooks register with Hive to listen for create/update/delete operations, and update the metadata in Atlas through Kafka notifications to obtain changes in Hive
The collected actions are stored in hbase and then displayed.

### Brief change log
1.hive hive-site.xml 
 \<property\>
        <name>hive.exec.post.hooks</name>
        <value>org.apache.atlas.hive.hook.HiveHook</value>
 \</property\>

2. linkis hive change
3. atlas(1.2) deployment 

Fixes #1253
