### PR TITLE
Pyspark  support CDH and HDP versions

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkPythonExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkPythonExecutor.scala
@@ -161,7 +161,7 @@ class SparkPythonExecutor(val sparkEngineSession: SparkEngineSession, val id: In
     val cmd = CommandLine.parse(pythonExec)
     cmd.addArgument(createFakeShell(pythonScriptPath).getAbsolutePath, false)
     cmd.addArgument(port.toString, false)
-    cmd.addArgument(EngineUtils.sparkSubmitVersion().replaceAll("\\.", ""), false)
+    cmd.addArgument(EngineUtils.sparkSubmitVersion().substring(0,5).replaceAll("\\.", ""), false)
     cmd.addArgument(py4jToken, false)
     cmd.addArgument(pythonClasspath.toString(), false)
     cmd.addArgument(pyFiles, false)


### PR DESCRIPTION
Because pyspark obtains the spark version number through ‘spark submit -- version’, and converts the version number into an integer. For example, spark-2.4.1 has a version number of 241, but the spark version of CDH is 2.4.1-cdh6 3.2 this type cannot be converted to integer. The spark version of HDP is 2.3.2.3.1.4.0-315. After conversion, it is 2.3.2.3.1.4.0-315, and then an error will be reported。
Therefore, I withdraw the top five digits of the version number, such as 2.4.1-cdh6 3.2, take 2.4.1 as the version number, which is similar to HDP and can meet the requirements。

![9a9a2142e4266c274bb1f53c18ce691](https://user-images.githubusercontent.com/19589632/147847534-cf83cfdd-6023-49a0-9346-2a438b35574b.png)

![d9482a1ee0081564bf6a8a424442173](https://user-images.githubusercontent.com/19589632/147847436-d9f312ed-32a6-463c-9102-a67729ff7746.jpg)

