### PR TITLE
streamExecEnv is not initialized, resulting in null pointer exception

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/context/ExecutionContext.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/context/ExecutionContext.java
@@ -128,11 +128,12 @@ public class ExecutionContext {
 		LOG.info("flinkConfig config: {}", flinkConfig);
 		clusterClientFactory = new LinkisYarnClusterClientFactory();
 	}
-
-	public StreamExecutionEnvironment getStreamExecutionEnvironment() {
+	public StreamExecutionEnvironment getStreamExecutionEnvironment() throws SqlExecutionException{
+		if(streamExecEnv == null) {
+			getTableEnvironment();
+		}
 		return streamExecEnv;
 	}
-
 	public void setString(String key, String value) {
 		this.flinkConfig.setString(key, value);
 	}


### PR DESCRIPTION
in class ClusterDescriptorAdapter ，this line on
configuration = (Configuration) method.invoke(executionContext.getStreamExecutionEnvironment()) ，this code ’executionContext.getStreamExecutionEnvironment()‘ return null，beacause streamExecEnv is not initialized, resulting in null pointer exception
![image](https://user-images.githubusercontent.com/19589632/148064554-f442cbfe-6e1a-4416-837b-65266c175016.png)
