### PR TITLE
Fix the bug when ticketId starts with number, the engineConnId cannot be parsed successful.

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
@@ -38,7 +38,7 @@ trait SimpleOnceJob extends OnceJob {
   override def getId: String = wrapperEC(engineConnId)
 
   override def isCompleted: Boolean = wrapperEC {
-    if(finalEngineConnState != null) return true
+    if (finalEngineConnState != null) return true
     lastNodeInfo = getNodeInfo
     lastEngineConnState = getStatus(lastNodeInfo)
     isCompleted(lastEngineConnState)
@@ -50,7 +50,7 @@ trait SimpleOnceJob extends OnceJob {
       getJobListeners.foreach(_.onJobFinished(this))
       true
     case "unlock" | "running" | "idle" | "busy" =>
-      if(!isRunning) {
+      if (!isRunning) {
         isRunning = true
         getJobListeners.foreach(_.onJobRunning(this))
       }
@@ -68,8 +68,7 @@ trait SimpleOnceJob extends OnceJob {
   }
 
   protected def transformToId(): Unit = {
-    engineConnId = ticketId.length + "_" + serviceInstance.getApplicationName.length +
-      ticketId + serviceInstance.getApplicationName + serviceInstance.getInstance
+    engineConnId = s"${ticketId.length}_${serviceInstance.getApplicationName.length}_${ticketId}${serviceInstance.getApplicationName}${serviceInstance.getInstance}"
   }
 
   protected def transformToServiceInstance(): Unit = engineConnId match {
@@ -132,7 +131,7 @@ class ExistingSimpleOnceJob(protected override val linkisManagerClient: LinkisMa
 
 object SimpleOnceJob {
 
-  private val ENGINE_CONN_ID_REGEX = "(\\d+)_(\\d+)(.+)".r
+  private val ENGINE_CONN_ID_REGEX = "(\\d+)_(\\d+)_(.+)".r
 
   def builder(): SimpleOnceJobBuilder = new SimpleOnceJobBuilder
 


### PR DESCRIPTION
### What is the purpose of the change
Fix the bug when ticketId starts with number, the engineConnId cannot be parsed successful

### Brief change log
- Fix the bug when ticketId starts with number, the engineConnId cannot be parsed successful.