### PR TITLE
Exclude  io.github.x-stream:mxparser

### DIFF
--- a/linkis-commons/linkis-module/pom.xml
+++ b/linkis-commons/linkis-module/pom.xml
@@ -105,6 +105,10 @@
                     <artifactId>jackson-databind</artifactId>
                     <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.github.x-stream</groupId>
+                    <artifactId>mxparser</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
@@ -55,12 +55,14 @@
                     <artifactId>jackson-databind</artifactId>
                     <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
-
                 <exclusion>
                     <artifactId>servlet-api</artifactId>
                     <groupId>javax.servlet</groupId>
                 </exclusion>
-
+                <exclusion>
+                    <groupId>io.github.x-stream</groupId>
+                    <artifactId>mxparser</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What is the purpose of the change
The basic function does not use this dependency，so exclude io.github.x-stream:mxparser from project
Related issues:
- #1289 

### Brief change log
Exclude io.github.x-stream:mxparser

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes)
