### PR TITLE
disable wiki and protected_branches for dev-*

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,13 @@
 #
 
 github:
+  features:
+    # Enable issue management
+    issues: true
+    # Enable wiki for documentation
+    wiki: false
+    # Enable projects for project management boards
+    projects: true
   description: Linkis helps easily connect to various back-end computation/storage engines(Spark, Python, TiDB...), exposes various interfaces(REST, JDBC, Java ...), with multi-tenancy, high performance, and resource control.
   homepage: https://linkis.apache.org/
   labels:
@@ -50,7 +57,7 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 2
-    dev-1.0.3:
+    dev-*:
       required_status_checks:
         strict: true
       required_pull_request_reviews:


### PR DESCRIPTION
### What is the purpose of the change
The content of the wiki will be migrated to the official website(https://linkis.apache.org/) soon.
modify asf.yaml 
- disbale wiki 
- protected_branches for dev-*
