### PR TITLE
asf.yaml enable_merge_button:enable merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,8 +40,8 @@ github:
     - context-service
     - scriptis
   enabled_merge_buttons:
+    merge:  true
     squash: true
-    merge:  false
     rebase: false
   protected_branches:
     master:


### PR DESCRIPTION
### What is the purpose of the change

Because the current default branch master is not a development branch, the commit record needs to be kept.
