### PR TITLE
Fix some bug of Flink EC and optimize the computation OnceJob.

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
@@ -38,7 +38,7 @@ trait SimpleOnceJob extends OnceJob {
   override def getId: String = wrapperEC(engineConnId)
 
   override def isCompleted: Boolean = wrapperEC {
-    if(finalEngineConnState != null) return true
+    if (finalEngineConnState != null) return true
     lastNodeInfo = getNodeInfo
     lastEngineConnState = getStatus(lastNodeInfo)
     isCompleted(lastEngineConnState)
@@ -50,7 +50,7 @@ trait SimpleOnceJob extends OnceJob {
       getJobListeners.foreach(_.onJobFinished(this))
       true
     case "unlock" | "running" | "idle" | "busy" =>
-      if(!isRunning) {
+      if (!isRunning) {
         isRunning = true
         getJobListeners.foreach(_.onJobRunning(this))
       }
@@ -68,8 +68,7 @@ trait SimpleOnceJob extends OnceJob {
   }
 
   protected def transformToId(): Unit = {
-    engineConnId = ticketId.length + "_" + serviceInstance.getApplicationName.length +
-      ticketId + serviceInstance.getApplicationName + serviceInstance.getInstance
+    engineConnId = s"${ticketId.length}_${serviceInstance.getApplicationName.length}_${ticketId}${serviceInstance.getApplicationName}${serviceInstance.getInstance}"
   }
 
   protected def transformToServiceInstance(): Unit = engineConnId match {
@@ -132,7 +131,7 @@ class ExistingSimpleOnceJob(protected override val linkisManagerClient: LinkisMa
 
 object SimpleOnceJob {
 
-  private val ENGINE_CONN_ID_REGEX = "(\\d+)_(\\d+)(.+)".r
+  private val ENGINE_CONN_ID_REGEX = "(\\d+)_(\\d+)_(.+)".r
 
   def builder(): SimpleOnceJobBuilder = new SimpleOnceJobBuilder
 

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
@@ -207,6 +207,11 @@
             <artifactId>libfb303</artifactId>
             <version>0.9.3</version>
         </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>minlog</artifactId>
+            <version>1.3.0</version>
+        </dependency>
         <!-- flink end-->
 
         <dependency>

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/context/ExecutionContext.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/context/ExecutionContext.java
@@ -17,23 +17,7 @@
  
 package org.apache.linkis.engineconnplugin.flink.client.context;
 
-import org.apache.linkis.engineconnplugin.flink.client.config.Environment;
-import org.apache.linkis.engineconnplugin.flink.client.factory.LinkisYarnClusterClientFactory;
-import org.apache.linkis.engineconnplugin.flink.exception.SqlExecutionException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.StreamContextEnvironment;
@@ -54,40 +38,33 @@ import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
-import org.apache.flink.table.client.config.entries.ExecutionEntry;
-import org.apache.flink.table.client.config.entries.SinkTableEntry;
-import org.apache.flink.table.client.config.entries.SourceSinkTableEntry;
-import org.apache.flink.table.client.config.entries.SourceTableEntry;
-import org.apache.flink.table.client.config.entries.TableEntry;
-import org.apache.flink.table.client.config.entries.TemporalTableEntry;
-import org.apache.flink.table.client.config.entries.ViewEntry;
+import org.apache.flink.table.client.config.entries.*;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.ExecutorFactory;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.delegation.PlannerFactory;
 import org.apache.flink.table.descriptors.CoreModuleDescriptorValidator;
-import org.apache.flink.table.factories.BatchTableSinkFactory;
-import org.apache.flink.table.factories.BatchTableSourceFactory;
-import org.apache.flink.table.factories.CatalogFactory;
-import org.apache.flink.table.factories.ComponentFactoryService;
-import org.apache.flink.table.factories.ModuleFactory;
-import org.apache.flink.table.factories.TableFactoryService;
-import org.apache.flink.table.factories.TableSinkFactory;
-import org.apache.flink.table.factories.TableSourceFactory;
-import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.functions.FunctionDefinition;
-import org.apache.flink.table.functions.FunctionService;
-import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.flink.table.functions.TableFunction;
-import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.factories.*;
+import org.apache.flink.table.functions.*;
 import org.apache.flink.table.module.Module;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.util.TemporaryClassLoaderContext;
 import org.apache.flink.yarn.YarnClusterDescriptor;
+import org.apache.linkis.engineconnplugin.flink.client.config.Environment;
+import org.apache.linkis.engineconnplugin.flink.client.factory.LinkisYarnClusterClientFactory;
+import org.apache.linkis.engineconnplugin.flink.exception.SqlExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class ExecutionContext {
 
@@ -97,7 +74,7 @@ public class ExecutionContext {
 	private final ClassLoader classLoader;
 
 	private final Configuration flinkConfig;
-	private final LinkisYarnClusterClientFactory clusterClientFactory;
+	private LinkisYarnClusterClientFactory clusterClientFactory;
 
 	private TableEnvironmentInternal tableEnv;
 	private ExecutionEnvironment execEnv;
@@ -112,6 +89,15 @@ public class ExecutionContext {
 			@Nullable SessionState sessionState,
 			List<URL> dependencies,
 			Configuration flinkConfig) {
+		this(environment, sessionState, dependencies, flinkConfig, new LinkisYarnClusterClientFactory());
+	}
+
+	private ExecutionContext(
+			Environment environment,
+			@Nullable SessionState sessionState,
+			List<URL> dependencies,
+			Configuration flinkConfig,
+			LinkisYarnClusterClientFactory clusterClientFactory) {
 		this.environment = environment;
 		this.flinkConfig = flinkConfig;
 		this.sessionState = sessionState;
@@ -126,7 +112,7 @@ public class ExecutionContext {
 			flinkConfig);
 		LOG.debug("Deployment descriptor: {}", environment.getDeployment());
 		LOG.info("flinkConfig config: {}", flinkConfig);
-		clusterClientFactory = new LinkisYarnClusterClientFactory();
+		this.clusterClientFactory = clusterClientFactory;
 	}
 
 	public StreamExecutionEnvironment getStreamExecutionEnvironment() {
@@ -216,19 +202,6 @@ public class ExecutionContext {
 	public LinkisYarnClusterClientFactory getClusterClientFactory() {
 		return clusterClientFactory;
 	}
-
-	public Pipeline createPipeline(String name) {
-		return wrapClassLoader(() -> {
-			if (streamExecEnv != null) {
-				StreamTableEnvironmentImpl streamTableEnv = (StreamTableEnvironmentImpl) tableEnv;
-				return streamTableEnv.getPipeline(name);
-			} else {
-				BatchTableEnvironmentImpl batchTableEnv = (BatchTableEnvironmentImpl) tableEnv;
-				return batchTableEnv.getPipeline(name);
-			}
-		});
-	}
-
 
 	/** Returns a builder for this {@link ExecutionContext}. */
 	public static Builder builder(
@@ -586,6 +559,17 @@ public class ExecutionContext {
 		}
 	}
 
+	public ExecutionContext cloneExecutionContext(Builder builder) {
+		ExecutionContext newExecutionContext = builder.clusterClientFactory(clusterClientFactory).build();
+		if(this.tableEnv != null) {
+			newExecutionContext.tableEnv = tableEnv;
+			newExecutionContext.execEnv = execEnv;
+			newExecutionContext.streamExecEnv = streamExecEnv;
+			newExecutionContext.executor = executor;
+		}
+		return newExecutionContext;
+	}
+
 	//~ Inner Class -------------------------------------------------------------------------------
 
 	/** Builder for {@link ExecutionContext}. */
@@ -596,6 +580,7 @@ public class ExecutionContext {
 		private final Configuration configuration;
 		private Environment defaultEnv;
 		private Environment currentEnv;
+		private LinkisYarnClusterClientFactory clusterClientFactory;
 
 		// Optional members.
 		@Nullable
@@ -622,21 +607,32 @@ public class ExecutionContext {
 			return this;
 		}
 
-		public ExecutionContext build() throws SqlExecutionException {
+		Builder clusterClientFactory(LinkisYarnClusterClientFactory clusterClientFactory) {
+			this.clusterClientFactory = clusterClientFactory;
+			return this;
+		}
+
+		public ExecutionContext build() {
 			if(sessionEnv == null){
 				this.currentEnv = defaultEnv;
 			}
-			try {
+			if(clusterClientFactory == null) {
 				return new ExecutionContext(
-					this.currentEnv == null ? Environment.merge(defaultEnv, sessionEnv) : this.currentEnv,
-					this.sessionState,
-					this.dependencies,
-					this.configuration);
-			} catch (Exception t) {
-				// catch everything such that a configuration does not crash the executor
-				throw new SqlExecutionException("Could not create execution context.", t);
+						this.currentEnv == null ? Environment.merge(defaultEnv, sessionEnv) : this.currentEnv,
+						this.sessionState,
+						this.dependencies,
+						this.configuration);
+			} else {
+				return new ExecutionContext(
+						this.currentEnv == null ? Environment.merge(defaultEnv, sessionEnv) : this.currentEnv,
+						this.sessionState,
+						this.dependencies,
+						this.configuration,
+						this.clusterClientFactory);
 			}
 		}
+
+
 	}
 
 	/** Represents the state that should be reused in one session. **/

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/DropViewOperation.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/DropViewOperation.java
@@ -60,12 +60,11 @@ public class DropViewOperation implements NonJobOperation {
 			ExecutionContext oldExecutionContext = context.getExecutionContext();
 			oldExecutionContext.wrapClassLoader(tableEnv -> tableEnv.dropTemporaryView(viewName));
 			// Renew the ExecutionContext.
-			ExecutionContext newExecutionContext = context
+			ExecutionContext.Builder builder = context
 				.newExecutionContextBuilder(context.getEnvironmentContext().getDefaultEnv())
 				.env(newEnv)
-				.sessionState(context.getExecutionContext().getSessionState())
-				.build();
-			context.setExecutionContext(newExecutionContext);
+				.sessionState(context.getExecutionContext().getSessionState());
+			context.setExecutionContext(context.getExecutionContext().cloneExecutionContext(builder));
 		}
 
 		return OperationUtil.OK;

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/ResetOperation.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/ResetOperation.java
@@ -40,11 +40,10 @@ public class ResetOperation implements NonJobOperation {
 		// Renew the ExecutionContext by merging the default environment with original session context.
 		// Book keep all the session states of current ExecutionContext then
 		// re-register them into the new one.
-		ExecutionContext newExecutionContext = context
+		ExecutionContext.Builder builder = context
 			.newExecutionContextBuilder(context.getEnvironmentContext().getDefaultEnv())
-			.sessionState(executionContext.getSessionState())
-			.build();
-		context.setExecutionContext(newExecutionContext);
+			.sessionState(executionContext.getSessionState());
+		context.setExecutionContext(executionContext.cloneExecutionContext(builder));
 
 		return OperationUtil.OK;
 	}

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/SetOperation.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/SetOperation.java
@@ -17,6 +17,10 @@
  
 package org.apache.linkis.engineconnplugin.flink.client.sql.operation.impl;
 
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.Row;
 import org.apache.linkis.engineconnplugin.flink.client.config.Environment;
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.NonJobOperation;
@@ -27,13 +31,10 @@ import org.apache.linkis.engineconnplugin.flink.client.sql.operation.result.Resu
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.result.ResultSet;
 import org.apache.linkis.engineconnplugin.flink.context.FlinkEngineConnContext;
 import org.apache.linkis.engineconnplugin.flink.exception.SqlExecutionException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
-import org.apache.flink.table.types.logical.VarCharType;
-import org.apache.flink.types.Row;
 
 /**
  * Operation for SET command.
@@ -82,12 +83,11 @@ public class SetOperation implements NonJobOperation {
 			// Renew the ExecutionContext by new environment.
 			// Book keep all the session states of current ExecutionContext then
 			// re-register them into the new one.
-			ExecutionContext newExecutionContext = context
+			ExecutionContext.Builder builder = context
 				.newExecutionContextBuilder(context.getEnvironmentContext().getDefaultEnv())
 				.env(newEnv)
-				.sessionState(sessionState)
-				.build();
-			context.setExecutionContext(newExecutionContext);
+				.sessionState(sessionState);
+			context.setExecutionContext(executionContext.cloneExecutionContext(builder));
 
 			return OperationUtil.OK;
 		}

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkSQLComputationExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkSQLComputationExecutor.scala
@@ -151,7 +151,7 @@ class FlinkSQLComputationExecutor(id: Long,
 
   override def close(): Unit = {
     if (operation != null) {
-      operation.cancelJob()
+      Utils.tryQuietly(operation.cancelJob()) // ignore this exception since the application will be stopped.
     }
     flinkEngineConnContext.getExecutionContext.createClusterDescriptor().close()
     flinkEngineConnContext.getExecutionContext.getClusterClientFactory.close()

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkSQLComputationExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkSQLComputationExecutor.scala
@@ -20,6 +20,7 @@ package org.apache.linkis.engineconnplugin.flink.executor
 import java.io.Closeable
 import java.util
 import java.util.concurrent.TimeUnit
+
 import org.apache.calcite.rel.metadata.{JaninoRelMetadataProvider, RelMetadataQueryBase}
 import org.apache.flink.api.common.JobStatus._
 import org.apache.flink.table.planner.plan.metadata.FlinkDefaultRelMetadataProvider
@@ -37,11 +38,12 @@ import org.apache.linkis.engineconnplugin.flink.context.FlinkEngineConnContext
 import org.apache.linkis.engineconnplugin.flink.exception.{ExecutorInitException, SqlParseException}
 import org.apache.linkis.engineconnplugin.flink.listener.RowsType.RowsType
 import org.apache.linkis.engineconnplugin.flink.listener.{FlinkStreamingResultSetListener, InteractiveFlinkStatusListener}
+import org.apache.linkis.governance.common.paser.SQLCodeParser
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.scheduler.executer.{ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
 import org.apache.linkis.storage.resultset.ResultSetFactory
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 
 class FlinkSQLComputationExecutor(id: Long,
@@ -51,6 +53,7 @@ class FlinkSQLComputationExecutor(id: Long,
   private var clusterDescriptor: YarnSessionClusterDescriptorAdapter = _
 
   override def init(): Unit = {
+    setCodeParser(new SQLCodeParser)
     ClusterDescriptorAdapterFactory.create(flinkEngineConnContext.getExecutionContext) match {
       case adapter: YarnSessionClusterDescriptorAdapter => clusterDescriptor = adapter
       case adapter if adapter != null => throw new ExecutorInitException(s"Not support ${adapter.getClass.getSimpleName} for FlinkSQLComputationExecutor.")
@@ -78,11 +81,11 @@ class FlinkSQLComputationExecutor(id: Long,
         this.operation = jobOperation
         jobOperation.addFlinkListener(new FlinkSQLStatusListener(jobOperation, engineExecutionContext))
         jobOperation.addFlinkListener(new FlinkSQLStreamingResultSetListener(jobOperation, engineExecutionContext))
-        val properties: util.Map[String, String] = engineExecutionContext.getProperties.map {
+        val properties: util.Map[String, String] = engineExecutionContext.getProperties.asScala.map {
           case (k, v: String) => (k, v)
           case (k, v) if v != null => (k, v.toString)
           case (k, _) => (k, null)
-        }
+        }.asJava
         jobOperation.addFlinkListener(new DevFlinkSQLStreamingListener(jobOperation, properties))
       case _ =>
     }
@@ -114,7 +117,7 @@ class FlinkSQLComputationExecutor(id: Long,
               case _ =>
             }
           case jobOperation: JobOperation =>
-            jobOperation.getFlinkListeners.find(_.isInstanceOf[FlinkSQLStatusListener]).foreach { case listener: FlinkSQLStatusListener =>
+            jobOperation.getFlinkListeners.asScala.find(_.isInstanceOf[FlinkSQLStatusListener]).foreach { case listener: FlinkSQLStatusListener =>
               listener.waitForCompleted()
               return listener.getResponse
             }
@@ -130,7 +133,7 @@ class FlinkSQLComputationExecutor(id: Long,
   }
 
   //TODO wait for completed.
-  override def progress(taskID: String): Float = if(operation == null) 0 else operation.getJobStatus match {
+  override def progress(taskID: String): Float = if (operation == null) 0 else operation.getJobStatus match {
     case jobState if jobState.isGloballyTerminalState => 1
     case RUNNING => 0.5f
     case _ => 0
@@ -144,10 +147,10 @@ class FlinkSQLComputationExecutor(id: Long,
     super.killTask(taskId)
   }
 
-  override def getId: String = "FlinkComputationSQL_"+ id
+  override def getId: String = "FlinkComputationSQL_" + id
 
   override def close(): Unit = {
-    if(operation != null) {
+    if (operation != null) {
       operation.cancelJob()
     }
     flinkEngineConnContext.getExecutionContext.createClusterDescriptor().close()
@@ -165,11 +168,11 @@ class FlinkSQLStatusListener(jobOperation: JobOperation, engineExecutionContext:
     // Only success need to close.
     val executeCostTime = ByteTimeUtils.msDurationToString(System.currentTimeMillis - startTime)
     info(s"Time taken: $executeCostTime, $rowsType $rows row(s), wait resultSet to be stored.")
-    Utils.tryCatch(jobOperation.getFlinkListeners.foreach {
+    Utils.tryCatch(jobOperation.getFlinkListeners.asScala.foreach {
       case listener: Closeable =>
         listener.close()
       case _ =>
-    }){t =>
+    }) {t =>
       onFailed("Failed to close Listeners", t, rowsType)
       return
     }
@@ -188,7 +191,7 @@ class FlinkSQLStatusListener(jobOperation: JobOperation, engineExecutionContext:
   def getResponse: ExecuteResponse = resp
 
   def waitForCompleted(maxWaitTime: Long): Unit = synchronized {
-    if(maxWaitTime < 0) wait() else wait(maxWaitTime)
+    if (maxWaitTime < 0) wait() else wait(maxWaitTime)
   }
 
   def waitForCompleted(): Unit = waitForCompleted(-1)
@@ -238,7 +241,7 @@ class DevFlinkSQLStreamingListener(jobOperation: JobOperation,
   }
 
   private val future = Utils.defaultScheduler.scheduleAtFixedRate(new Runnable {
-    override def run(): Unit = if(System.currentTimeMillis - lastPulledTime > maxWaitForResultTime) {
+    override def run(): Unit = if (System.currentTimeMillis - lastPulledTime > maxWaitForResultTime) {
       warn(s"Job killed since reached the max time ${ByteTimeUtils.msDurationToString(maxWaitForResultTime)} of waiting for resultSet. Notice: only the dev environment will touch off the automatic kill.")
       stopJobOperation()
     }
@@ -246,7 +249,7 @@ class DevFlinkSQLStreamingListener(jobOperation: JobOperation,
 
   def stopJobOperation(): Unit = {
     future.cancel(false)
-    jobOperation.getFlinkListeners.foreach {
+    jobOperation.getFlinkListeners.asScala.foreach {
       case listener: InteractiveFlinkStatusListener => listener.markSuccess(writtenLines)
       case _ =>
     }


### PR DESCRIPTION
### What is the purpose of the change
Fix some bug of Flink EC and optimize the computation OnceJob.

### Brief change log
- Fix the bug when ticketId starts with number, the engineConnId cannot be parsed successful.
- Fix the bug that flink sql cannot support multi-sql and optimize some code formats.
- Fix the bug that when use set, rest, drop grammar, the checkpoint will invalid.
- Fix the bug that when operator is failed and the job is not instanced , will cause the flink yarn application stop failed when engineconn exits .
- Add the necessary dependency of minlog in flink EngineConn.

