### PR TITLE
modify ’wds.linkis.entrance.skip.auth‘ default false change to true

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/conf/EntranceConfiguration.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/conf/EntranceConfiguration.scala
@@ -125,7 +125,7 @@ object EntranceConfiguration {
   val SCHEDULER_CREATOR = CommonVars("wds.linkis.entrance.scheduler.creator", "scheduler")
 
 
-  val SKIP_AUTH = CommonVars("wds.linkis.entrance.skip.auth", false)
+  val SKIP_AUTH = CommonVars("wds.linkis.entrance.skip.auth", true)
 
   val PROGRESS_PUSH = CommonVars[String]("wds.linkis.entrance.push.progress", "false")
 


### PR DESCRIPTION
when I use python moudle  os and sys ,then report error 'can not use sys module' and ’can not use os module‘，so we modified  ’wds.linkis.entrance.skip.auth‘ default false change to true