### PR TITLE
Adjust email  notifications and protected_branches #1318

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -75,7 +75,18 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
-
+    dev-1.1.0-datasource:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
+    dev-1.1.0-datax:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
 notifications:
   commits: commits@linkis.apache.org
   issues: commits@linkis.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -57,9 +57,26 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 2
-    dev-*:
+    dev-1.1.0:
       required_status_checks:
         strict: true
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
+    dev-1.1.1:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
+    dev-1.2.0:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
+
+notifications:
+  commits: commits@linkis.apache.org
+  issues: commits@linkis.apache.org
+  pullrequests: commits@linkis.apache.org


### PR DESCRIPTION
### What is the purpose of the change
Adjust email  notifications Related issues: #1318
Fixed: branch protection rules cannot be fuzzy matched 
### Brief change log
Adjust email  notifications
Branch protection rules cannot be fuzzy matched,more detail info:https://github.com/apache/infrastructure-puppet/pull/1678

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)