### PR TITLE
Release 1.0.3 rc1

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/application-linkis.yml
+++ b/assembly-combined-package/assembly-combined/conf/application-linkis.yml
@@ -36,3 +36,13 @@ pagehelper:
 #ribbon:
 #  ReadTimeout: 10000
 #  ConnectTimeout: 10000
+
+#  enable for knife4j used by all micro services except gateway and eureka
+#knife4j:
+#  enable: true
+#  basic:
+#    enable: false
+#    # Basic认证用户名
+#    username: test
+#    # Basic认证密码
+#    password: 123

--- a/assembly-combined-package/assembly-combined/conf/linkis.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis.properties
@@ -14,7 +14,7 @@
 #
 
 #
-##
+##enable this test mode for knife4j
 #wds.linkis.test.mode=true
 wds.linkis.server.version=v1
 ##spring conf

--- a/linkis-commons/linkis-module/pom.xml
+++ b/linkis-commons/linkis-module/pom.xml
@@ -23,12 +23,21 @@
         <artifactId>linkis</artifactId>
         <groupId>org.apache.linkis</groupId>
         <version>1.0.3</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>linkis-module</artifactId>
 
     <dependencies>
+        <!--add knif2 dependency-->
+        <dependency>
+              <groupId>com.github.xiaoymin</groupId>
+              <artifactId>knife4j-spring-boot-starter</artifactId>
+              <version>${knife4j.version}</version>
+        </dependency>
+
+
         <dependency>
             <groupId>org.apache.linkis</groupId>
             <artifactId>linkis-common</artifactId>

--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/Knife4jConfig.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/Knife4jConfig.scala
@@ -16,6 +16,12 @@ import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spring.web.plugins.Docket
 import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc
 
+/**
+- 启动knife的apidoc的步骤很简单
+- 1,打开application-linkis.yml,配置knife4j.enable=true
+- 2,打开linkis.properties，配置ds.linkis.test.mode=true
+- 3，启动服务之后，通过微服务地址http://ip:port/api/rest_j/v1/doc.html访问
+ */
 @EnableSwagger2WebMvc
 @EnableKnife4j
 @Configuration

--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/Knife4jConfig.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/Knife4jConfig.scala
@@ -1,0 +1,64 @@
+package org.apache.linkis.server.conf
+
+import org.springframework.context.annotation.Bean
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import springfox.documentation.builders.ApiInfoBuilder
+import springfox.documentation.builders.PathSelectors
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.service.ApiInfo
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc
+
+@EnableSwagger2WebMvc
+@EnableKnife4j
+@Configuration
+class Knife4jConfig extends WebMvcConfigurer {
+
+
+
+  import org.springframework.beans.factory.annotation.Value
+
+  @Value("${spring.application.name}") private val appName = "linkis service"
+
+  @Bean(Array("defaultApi2"))
+  def  defaultApi2() : Docket = {
+     val docket = new Docket(DocumentationType.SWAGGER_2)
+      .apiInfo(apiInfo())
+      //分组名称
+      .groupName("RESTAPI")
+      .select()
+      //这里指定Controller扫描包路径
+      .apis(RequestHandlerSelectors.basePackage("org.apache.linkis"))
+      .paths(PathSelectors.any())
+      .build()
+    docket
+  }
+
+  def  apiInfo() : ApiInfo ={
+    val apiInfo = new ApiInfoBuilder()
+      .title(appName)
+      .description("Linkis micro service RESTful APIs")
+      .version("v1")
+      .build()
+    apiInfo
+  }
+
+  override def addResourceHandlers( registry : ResourceHandlerRegistry): Unit  =  {
+    registry.addResourceHandler("/api/rest_j/v1/doc.html**").addResourceLocations("classpath:/META-INF/resources/doc.html")
+    registry.addResourceHandler("/api/rest_j/v1/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/")
+  }
+
+  override def addViewControllers(registry : ViewControllerRegistry ) : Unit = {
+    registry.addRedirectViewController("/api/rest_j/v1/v2/api-docs", "/v2/api-docs")
+    registry.addRedirectViewController("/api/rest_j/v1/swagger-resources/configuration/ui", "/swagger-resources/configuration/ui")
+    registry.addRedirectViewController("/api/rest_j/v1/swagger-resources/configuration/security", "/swagger-resources/configuration/security")
+    registry.addRedirectViewController("/api/rest_j/v1/swagger-resources", "/swagger-resources")
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j2.version>2.17.0</log4j2.version>
+        <knife4j.version>2.0.9</knife4j.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### What is the purpose of the change
集成knife4j以提供apidoc，除了eureka和gateway服务之外，其他的服务都可通过http://ip:port/api/rest_j/v1/doc.html访问apidoc
add knife4j support to linkis to supply api document for all micro services except eureka and gateway

### Brief change log
1，在模块linkis-module增加knife4j的配置类knife4jConfig
2. 在模块linkis-module增加必要的maven依赖
3. 选择了相对稳定的knife4j 2.0.9版本，此版本还是依赖于swagger2实现
1,add knife4jConfig to module: linkis-module
2,add necessary maven dpendencies for knife4j
3,use knife4j 2.0.9 which is based on swagger2 

### Verifying this change
(Please pick either of the following options)  
没有写testcase，但是在测试环境测试过
This change is a trivial rework / code cleanup without any test coverage.  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): 是的，增加了knife4j的相关依赖
- Anything that affects deployment: (yes / no / don't know) 没有
- The MGS(Microservice Governance Services), 不是

### Documentation
- Does this pull request introduce a new feature? (yes / no)  不是
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) 还没有
- 需要提供使用文档，步骤很简单
- 1,打开application-linkis.yml,配置knife4j.enable=true
- 2,打开linkis.properties，配置ds.linkis.test.mode=true
- 启动服务之后，通过微服务地址http://ip:port/api/rest_j/v1/doc.html访问