### PR TITLE
add  module Linkis Metadata Manager Common 

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>org.apache.linkis</groupId>
+        <version>1.0.3</version>
+        <relativePath>../../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-metadata-manager-common</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/pom.xml
@@ -6,15 +6,63 @@
         <artifactId>linkis</artifactId>
         <groupId>org.apache.linkis</groupId>
         <version>1.0.3</version>
-        <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>linkis-metadata-manager-common</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <scope>provided</scope>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>asm</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!--rpc-->
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-rpc</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-datasource-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
 </project>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/MdmConfiguration.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/MdmConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.common;
+
+import org.apache.linkis.common.conf.CommonVars;
+
+public class MdmConfiguration {
+
+    public static CommonVars<String> METADATA_SERVICE_APPLICATION =
+            CommonVars.apply("wds.linkis.server.mdm.service.app.name", "linkis-ps-metadatamanager");
+
+    public static CommonVars<String> DATA_SOURCE_SERVICE_APPLICATION =
+            CommonVars.apply("wds.linkis.server.dsm.app.name", "linkis-ps-data-source-manager");
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/cache/CacheConfiguration.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/cache/CacheConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.cache;
+
+import org.apache.linkis.common.conf.CommonVars;
+
+public class CacheConfiguration {
+
+    public static CommonVars<Long> CACHE_MAX_SIZE =
+            CommonVars.apply("wds.linkis.server.mdm.service.cache.max-size", 1000L);
+
+    public static CommonVars<Long> CACHE_EXPIRE_TIME =
+            CommonVars.apply("wds.linkis.server.mdm.service.cache.expire", 600L);
+
+    /**
+     * Make a pool for each cache element
+     */
+    public static final CommonVars<Integer> CACHE_IN_POOL_SIZE = CommonVars
+            .apply("wds.linkis.server.mdm.service.cache.in-pool.size", 5);
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/cache/CacheManager.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/cache/CacheManager.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.cache;
+
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+
+public interface CacheManager {
+    /**
+     * build simple cache
+     * @param cacheId
+     * @param removalListener
+     * @return
+     */
+    <V> Cache<String, V> buildCache(String cacheId, RemovalListener<String, V> removalListener);
+
+    /**
+     * build loading cache
+     * @param cacheId
+     * @param loader
+     * @param removalListener
+     * @return
+     */
+    <V> LoadingCache<String, V> buildCache(String cacheId, CacheLoader<String, V> loader, RemovalListener<String, V> removalListener);
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/cache/ConnCacheManager.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/cache/ConnCacheManager.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.cache;
+
+import com.google.common.cache.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class ConnCacheManager implements CacheManager {
+    private ConcurrentHashMap<String, Cache> cacheStore = new ConcurrentHashMap<>();
+    private static CacheManager manager;
+    private ConnCacheManager(){
+
+    }
+
+    public static CacheManager custom(){
+        if (null == manager){
+            synchronized (ConnCacheManager.class){
+                if (null == manager){
+                    manager = new ConnCacheManager();
+                }
+            }
+        }
+        return manager;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V> Cache<String, V> buildCache(String cacheId, RemovalListener<String, V> removalListener) {
+        return cacheStore.computeIfAbsent(cacheId, id -> CacheBuilder.newBuilder()
+            .maximumSize(CacheConfiguration.CACHE_MAX_SIZE.getValue())
+            .expireAfterWrite(CacheConfiguration.CACHE_EXPIRE_TIME.getValue(), TimeUnit.SECONDS)
+            .removalListener(removalListener)
+            .build());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V> LoadingCache<String, V> buildCache(String cacheId, CacheLoader<String, V> loader,
+                                                  RemovalListener<String, V> removalListener) {
+        return (LoadingCache<String, V>)cacheStore.computeIfAbsent(cacheId,  id -> CacheBuilder.newBuilder()
+                .maximumSize(CacheConfiguration.CACHE_MAX_SIZE.getValue())
+                .expireAfterWrite(CacheConfiguration.CACHE_EXPIRE_TIME.getValue(), TimeUnit.SECONDS)
+                .removalListener(removalListener)
+                .build(loader));
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/domain/MetaColumnInfo.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/domain/MetaColumnInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.common.domain;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+import java.io.Serializable;
+
+/**
+ * The meta information of field
+ */
+@JsonSerialize(include= JsonSerialize.Inclusion.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MetaColumnInfo implements Serializable {
+    private int  index = -1;
+    private boolean primaryKey;
+    private String name;
+    private String type;
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public boolean isPrimaryKey() {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(boolean primaryKey) {
+        this.primaryKey = primaryKey;
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/domain/MetaPartitionInfo.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/domain/MetaPartitionInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.domain;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The meta information of partition
+ */
+@JsonSerialize(include= JsonSerialize.Inclusion.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MetaPartitionInfo implements Serializable {
+    private List<String> partKeys = new ArrayList<>();
+
+    private String name;
+    /**
+     * Partition tree
+     */
+    private PartitionNode root;
+
+    @JsonSerialize(include= JsonSerialize.Inclusion.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PartitionNode{
+        /**
+         * Node name
+         */
+        private String name;
+        /**
+         * Key: partition value
+         * Value: child partition node
+         */
+        private Map<String, PartitionNode> partitions = new HashMap<>();
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Map<String, PartitionNode> getPartitions() {
+            return partitions;
+        }
+
+        public void setPartitions(Map<String, PartitionNode> partitions) {
+            this.partitions = partitions;
+        }
+    }
+
+    public List<String> getPartKeys() {
+        return partKeys;
+    }
+
+    public void setPartKeys(List<String> partKeys) {
+        this.partKeys = partKeys;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public PartitionNode getRoot() {
+        return root;
+    }
+
+    public void setRoot(PartitionNode root) {
+        this.root = root;
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/exception/MetaMethodInvokeException.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/exception/MetaMethodInvokeException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.common.exception;
+
+import org.apache.linkis.common.exception.ErrorException;
+
+/**
+ * Exception in invoking metadata service
+ */
+public class MetaMethodInvokeException extends ErrorException {
+    public MetaMethodInvokeException(int errCode, String desc, Throwable t) {
+        super(errCode, desc);
+        super.initCause(t);
+    }
+
+    public MetaMethodInvokeException(String method, Object[] args, int errCode, String desc, Throwable t) {
+        this(errCode, desc, t);
+        this.method = method;
+        this.args = args;
+    }
+
+    private String method;
+
+    private Object[] args;
+
+    public String getMethod() {
+        return method;
+    }
+
+    public Object[] getArgs() {
+        return args;
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/exception/MetaRuntimeException.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/exception/MetaRuntimeException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.exception;
+
+import org.apache.linkis.common.exception.WarnException;
+
+public class MetaRuntimeException extends WarnException {
+    private static final int ERROR_CODE = 99900;
+    public MetaRuntimeException(String desc, Throwable t) {
+        super(ERROR_CODE, desc);
+        super.initCause(t);
+    }
+
+    public MetaRuntimeException(String desc, String ip, int port, String serviceKind) {
+        super(ERROR_CODE, desc, ip, port, serviceKind);
+    }
+
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.service;
+
+import com.google.common.cache.Cache;
+import org.apache.commons.lang.StringUtils;
+import org.apache.linkis.common.exception.WarnException;
+import org.apache.linkis.datasourcemanager.common.util.json.Json;
+import org.apache.linkis.metadatamanager.common.cache.CacheConfiguration;
+import org.apache.linkis.metadatamanager.common.cache.CacheManager;
+import org.apache.linkis.metadatamanager.common.cache.ConnCacheManager;
+import org.apache.linkis.metadatamanager.common.domain.MetaColumnInfo;
+import org.apache.linkis.metadatamanager.common.domain.MetaPartitionInfo;
+import org.apache.linkis.metadatamanager.common.exception.MetaRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+public abstract class AbstractMetaService<C extends Closeable> implements MetadataService {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractMetaService.class);
+    private static final String CONN_CACHE_REQ = "_STORED";
+
+    private CacheManager connCacheManager;
+
+    /**
+     * Caching connections which built by connect parameters requested with
+     */
+    protected Cache<String, MetadataConnection<C>> reqCache;
+
+    @PostConstruct
+    public void init(){
+        connCacheManager = ConnCacheManager.custom();
+        initCache(connCacheManager);
+    }
+    /**
+     * If want to use cache component, you should invoke this in constructor method
+     * @param cacheManager
+     */
+    protected void initCache(CacheManager cacheManager){
+        String prefix = this.getClass().getSimpleName();
+        reqCache = cacheManager.buildCache(prefix + CONN_CACHE_REQ, notification ->{
+            assert notification.getValue() != null;
+            close(notification.getValue().getConnection());
+        });
+    }
+
+    @Override
+    public abstract MetadataConnection<C> getConnection(String operator, Map<String, Object> params) throws Exception;
+
+    @Override
+    public List<String> getDatabases(String operator, Map<String, Object> params) {
+        return this.getConnAndRun(operator, params, this::queryDatabases);
+    }
+
+    @Override
+    public List<String> getTables(String operator, Map<String, Object> params, String database) {
+        return this.getConnAndRun(operator, params, conn -> this.queryTables(conn, database));
+    }
+
+    @Override
+    public Map<String, String> getTableProps(String operator, Map<String, Object> params, String database, String table) {
+        return this.getConnAndRun(operator, params, conn -> this.queryTableProps(conn, database, table));
+    }
+
+    @Override
+    public MetaPartitionInfo getPartitions(String operator, Map<String, Object> params, String database, String table) {
+        return this.getConnAndRun(operator, params, conn -> this.queryPartitions(conn, database, table));
+    }
+
+    @Override
+    public List<MetaColumnInfo> getColumns(String operator, Map<String, Object> params, String database, String table) {
+        return this.getConnAndRun(operator, params, conn -> this.queryColumns(conn, database, table));
+    }
+
+    /**
+     * Get database list by connection
+     * @param connection metadata connection
+     * @return
+     */
+    public List<String> queryDatabases(C connection){
+        throw new WarnException(-1, "This method is no supported");
+    }
+
+    /**
+     * Get table list by connection and database
+     * @param connection metadata connection
+     * @param database database
+     * @return
+     */
+    public List<String> queryTables(C connection, String database){
+        throw new WarnException(-1, "This method is no supported");
+    }
+
+    /**
+     * Get partitions by connection, database and table
+     * @param connection metadata connection
+     * @param database database
+     * @param table table
+     * @return
+     */
+    public MetaPartitionInfo queryPartitions(C connection, String database, String table){
+        throw new WarnException(-1, "This method is no supported");
+    }
+
+    /**
+     * Get columns by connection, database and table
+     * @param connection metadata connection
+     * @param database database
+     * @param table table
+     * @return
+     */
+    public List<MetaColumnInfo> queryColumns(C connection, String database, String table){
+        throw new WarnException(-1, "This method is no supported");
+    }
+
+    /**
+     * Get table properties
+     * @param connection metadata connection
+     * @param database database
+     * @param table table
+     * @return
+     */
+    public Map<String, String> queryTableProps(C connection, String database, String table){
+        throw new WarnException(-1, "This method is no supported");
+    }
+
+    public void close(C connection){
+        try {
+            connection.close();
+        } catch (IOException e) {
+            throw new MetaRuntimeException("Fail to close connection[关闭连接失败], [" + e.getMessage() + "]", e);
+        }
+    }
+
+    protected <R>R getConnAndRun(String operator, Map<String, Object> params, Function<C, R> action) {
+        String cacheKey = "";
+        MetadataConnection<C> connection = null;
+        try{
+            cacheKey = md5String(Json.toJson(params, null), "", 2);
+            if(null != reqCache) {
+                ConnectionCache<C> connectionCache = getConnectionInCache(reqCache, cacheKey, () -> getConnection(operator, params));
+                connection = connectionCache.connection;
+                // Update the actually cache key
+                cacheKey = connectionCache.cacheKey;
+            }else{
+                connection = getConnection(operator, params);
+            }
+            return run(connection, action);
+        }catch(Exception e){
+            LOG.error("Error to invoke meta service", e);
+            if(StringUtils.isNotBlank(cacheKey) && Objects.nonNull(reqCache)){
+                reqCache.invalidate(cacheKey);
+            }
+            throw new MetaRuntimeException(e.getMessage(), e);
+        }finally{
+            if (Objects.nonNull(connection) && connection.isLock() &&
+                    connection.getLock().isHeldByCurrentThread()){
+                connection.getLock().unlock();
+            }
+        }
+    }
+    private <R>R run(MetadataConnection<C> connection, Function<C, R> action){
+        if(connection.isLock()){
+            if (!connection.getLock().isHeldByCurrentThread()){
+                connection.getLock().lock();
+                try{
+                    return action.apply(connection.getConnection());
+                }finally{
+                    connection.getLock().unlock();
+                }
+            } else {
+                return action.apply(connection.getConnection());
+            }
+        }else{
+            return action.apply(connection.getConnection());
+        }
+    }
+
+    /**
+     * Get connection cache element
+     * @param cache cache entity
+     * @param cacheKey  cache key
+     * @param callable callable function
+     * @return connection cache
+     * @throws ExecutionException exception in caching
+     */
+    private ConnectionCache<C> getConnectionInCache(Cache<String, MetadataConnection<C>> cache,
+                                                       String cacheKey, Callable<? extends MetadataConnection<C>> callable) throws ExecutionException {
+        int poolSize = CacheConfiguration.CACHE_IN_POOL_SIZE.getValue();
+        if (poolSize <= 0){
+            poolSize = 1;
+        }
+        MetadataConnection<C> connection = null;
+        String cacheKeyInPool = cacheKey + "_0";
+        for (int i = 0; i < poolSize; i ++) {
+            connection = cache.get(cacheKeyInPool, callable);
+            if (!connection.isLock() || connection.getLock().tryLock()){
+                break;
+            }
+            cacheKeyInPool = cacheKey + "_" + i;
+            LOG.info("The connection cache: [" + cacheKeyInPool + "] has been occupied, now to find the other in pool");
+        }
+        return new ConnectionCache<>(cacheKeyInPool, connection);
+    }
+
+    private String md5String(String source, String salt, int iterator){
+        StringBuilder token = new StringBuilder();
+        try{
+            MessageDigest digest = MessageDigest.getInstance("md5");
+            if(StringUtils.isNotEmpty(salt)){
+                digest.update(salt.getBytes(StandardCharsets.UTF_8));
+            }
+            byte[] result = digest.digest(source.getBytes());
+            for(int i = 0; i < iterator - 1; i++){
+                digest.reset();
+                result = digest.digest(result);
+            }
+            for (byte aResult : result) {
+                int temp = aResult & 0xFF;
+                if (temp <= 0xF) {
+                    token.append("0");
+                }
+                token.append(Integer.toHexString(temp));
+            }
+        }catch(Exception e){
+            throw new RuntimeException(e.getMessage());
+        }
+        return token.toString();
+    }
+
+    /**
+     * Cache element
+     */
+    private static class ConnectionCache<C>{
+
+        public ConnectionCache(String cacheKey, MetadataConnection<C> connection){
+            this.cacheKey = cacheKey;
+            this.connection = connection;
+        }
+        /**
+         * Connection
+         */
+        MetadataConnection<C> connection;
+
+        /**
+         * Actual cacheKey
+         */
+        String cacheKey;
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/BaseMetadataService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/BaseMetadataService.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.service;
+
+
+import java.io.Closeable;
+import java.util.Map;
+
+public interface BaseMetadataService {
+
+    /**
+     * Get connection
+     * @param params connect params
+     * @return
+     */
+    MetadataConnection<? extends Closeable> getConnection(String operator, Map<String, Object> params) throws Exception;
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataConnection.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.service;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Connection for metadata
+ */
+public class MetadataConnection<C> {
+    /***
+     * Avoid complication when different threads calling connection API
+     */
+    private ReentrantLock lock = new ReentrantLock();
+
+    private boolean isLock = true;
+
+    private C connection;
+
+    public MetadataConnection(C connection){
+        this.connection = connection;
+    }
+
+    public MetadataConnection(C connection, boolean isLock){
+        this.connection = connection;
+        this.isLock = isLock;
+    }
+    public ReentrantLock getLock() {
+        return lock;
+    }
+
+    public C getConnection() {
+        return connection;
+    }
+
+    public boolean isLock() {
+        return isLock;
+    }
+
+    public void setLock(boolean lock) {
+        isLock = lock;
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.service;
+
+import org.apache.linkis.metadatamanager.common.domain.MetaColumnInfo;
+import org.apache.linkis.metadatamanager.common.domain.MetaPartitionInfo;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MetadataDbService extends BaseMetadataService {
+
+    /**
+     * Get all databases
+     * @param params connect params
+     * @return
+     */
+    List<String> getDatabases(String operator, Map<String, Object> params);
+
+    /**
+     * Get all tables from database specified
+     * @param params params
+     * @param database database name
+     * @return
+     */
+    List<String> getTables(String operator, Map<String, Object> params, String database);
+
+    /**
+     * Get table properties from database specified
+     * @param params params
+     * @param database database name
+     * @return
+     */
+    Map<String, String> getTableProps(String operator, Map<String, Object> params, String database, String table);
+    /**
+     * Get all partitions from table specified
+     * @param params params
+     * @param database
+     * @param table
+     * @return
+     */
+    MetaPartitionInfo getPartitions(String operator, Map<String, Object> params, String database, String table);
+
+    /**
+     * Get all field information from table specified
+     * @param params
+     * @param database
+     * @param table
+     * @return
+     */
+    List<MetaColumnInfo> getColumns(String operator, Map<String, Object> params, String database, String table);
+
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataService.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.service;
+
+public interface MetadataService extends MetadataDbService {
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/scala/org/apache/linkis/metadatamanager/common/protocol/MetadataOperateProtocol.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/scala/org/apache/linkis/metadatamanager/common/protocol/MetadataOperateProtocol.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.protocol
+
+import java.util
+
+trait MetadataOperateProtocol {
+
+}
+
+/**
+   * Request to do connect
+   * @param version
+   * @param params
+ */
+case class MetadataConnect(dataSourceType: String, operator: String, params: util.Map[String, Object], version: String) extends MetadataOperateProtocol

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/scala/org/apache/linkis/metadatamanager/common/protocol/MetadataProtocol.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/scala/org/apache/linkis/metadatamanager/common/protocol/MetadataProtocol.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.protocol
+
+trait MetadataProtocol {
+
+}
+
+case class MetadataResponse(status: Boolean, data: String) extends MetadataProtocol

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/scala/org/apache/linkis/metadatamanager/common/protocol/MetadataQueryProtocol.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/scala/org/apache/linkis/metadatamanager/common/protocol/MetadataQueryProtocol.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.common.protocol
+
+import java.util
+
+trait MetadataQueryProtocol {
+
+}
+
+/**
+   * Request to get database list
+   * @param params
+ */
+case class MetaGetDatabases(params: util.Map[String, Object], operator: String) extends MetadataQueryProtocol
+
+/**
+   * Request to get table list
+   * @param params
+ */
+case class MetaGetTables(params: util.Map[String, Object], database: String, operator: String) extends MetadataQueryProtocol
+
+/**
+   * Request to get table properties
+   * @param params
+   * @param database
+   * @param table
+ */
+case class MetaGetTableProps(params: util.Map[String, Object], database: String, table: String, operator: String) extends MetadataQueryProtocol
+
+/**
+   * Request to get partition list
+   * @param params
+   * @param database
+   * @param table
+ */
+case class MetaGetPartitions(params: util.Map[String, Object], database: String, table: String, operator: String) extends MetadataQueryProtocol
+
+/**
+   * Request to get column list
+   * @param params
+   * @param database
+   * @param table
+ */
+case class MetaGetColumns(params: util.Map[String, Object], database: String, table: String, operator: String) extends MetadataQueryProtocol
+

--- a/linkis-public-enhancements/linkis-datasource/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>org.apache.linkis</groupId>
+        <version>1.0.3</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-datasource</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>linkis-datasource-manager/common</module>
+        <module>linkis-metadata-manager/common</module>
+    </modules>
+</project>

--- a/linkis-public-enhancements/pom.xml
+++ b/linkis-public-enhancements/pom.xml
@@ -34,6 +34,7 @@
         <module>linkis-bml</module>
         <module>linkis-context-service</module>
         <module>linkis-datasource/linkis-metadata</module>
+        <module>linkis-datasource</module>
         <module>linkis-publicservice</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,7 @@
         <module>linkis-engineconn-plugins</module>
         <module>linkis-extensions</module>
         <module>assembly-combined-package</module>
-        <module>linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server</module>
     </modules>
-
     <properties>
         <linkis.version>1.0.3</linkis.version>
         <hadoop.version>2.7.2</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <module>linkis-engineconn-plugins</module>
         <module>linkis-extensions</module>
         <module>assembly-combined-package</module>
+        <module>linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
module:linkis-metadata-manager-common 
issue:1338

### What is the purpose of the change
The Feature Is better to support Linkis Datasource

### Brief change log
(for example:)
- add linkis-metadata-manager-common module structure
- defline cache manager
- add self define exception
- add meta column info and partiton info
- add metadata manager config
- add metadata service interface
- add metadata related protocol
- add linkis-datasource module

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)