### PR TITLE
upgrade commons-io due to CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <javassist.version>3.19.0-GA</javassist.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <druid.version>1.1.22</druid.version>
         <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
         <assembly.package.rootpath>${basedir}</assembly.package.rootpath>

--- a/tool/dependencies/known-dependencies.txt
+++ b/tool/dependencies/known-dependencies.txt
@@ -57,7 +57,7 @@ commons-digester-1.8.jar
 commons-exec-1.3.jar
 commons-fileupload-1.4.jar
 commons-httpclient-3.1.jar
-commons-io-2.4.jar
+commons-io-2.11.0.jar
 commons-jxpath-1.3.jar
 commons-lang-2.6.jar
 commons-lang3-3.1.jar

--- a/tool/dependencies/third-party-dependencies.txt
+++ b/tool/dependencies/third-party-dependencies.txt
@@ -57,7 +57,7 @@ commons-digester-1.8.jar
 commons-exec-1.3.jar
 commons-fileupload-1.4.jar
 commons-httpclient-3.1.jar
-commons-io-2.4.jar
+commons-io-2.11.0.jar
 commons-jxpath-1.3.jar
 commons-lang-2.6.jar
 commons-lang3-3.1.jar


### PR DESCRIPTION
### What is the purpose of the change
upgrade commons-io version to 2.11.0 due to CVE (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425)

### Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (yes)
Anything that affects deployment: (no)
The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)