### PR TITLE
create resultSet path by jvmuser,fix issue 1314

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
@@ -26,6 +26,7 @@ import org.apache.linkis.entrance.execute.EntranceJob;
 import org.apache.linkis.entrance.execute.EntranceJob$;
 import org.apache.linkis.entrance.log.*;
 import org.apache.linkis.entrance.persistence.PersistenceManager;
+import org.apache.linkis.entrance.utils.CommonLogPathUtils;
 import org.apache.linkis.governance.common.conf.GovernanceCommonConf;
 import org.apache.linkis.governance.common.entity.job.SubJobDetail;
 import org.apache.linkis.governance.common.entity.job.SubJobInfo;
@@ -221,6 +222,8 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
             }
         }
         String resultSetPathRoot = GovernanceCommonConf.RESULT_SET_STORE_PATH().getValue(runtimeMapTmp);
+        //issue 1314, create the resultSetStorePath by jvmuser with privilege 770
+        CommonLogPathUtils.buildCommonPath(GovernanceCommonConf.RESULT_SET_STORE_PATH().getValue());
         Map<String, Object> jobMap = new HashMap<String, Object>();
         jobMap.put(RequestTask$.MODULE$.RESULT_SET_STORE_PATH(), resultSetPathRoot);
         runtimeMapOri.put(QueryParams$.MODULE$.JOB_KEY(), jobMap);


### PR DESCRIPTION
### What is the purpose of the change
fix the issue 1314, 
before this fixing , wds.linkis.resultSet.store.path is created by task launcher by default ,it would cause another task launcher failed to write on this path.


### Brief change log
(for example:)
1,only add one line in  linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob
2,when execute job, create wds.linkis.resultSet.store.path in hdfs by jvmuser if it not exists

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency):  no
- Anything that affects deployment:  no 
- The MGS(Microservice Governance Services),no 

### Documentation
- Does this pull request introduce a new feature? no 
