### PR TITLE
Add Linkis MetaData Manager Server For 1.1.0

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>org.apache.linkis</groupId>
+        <version>1.0.3</version>
+        <relativePath>../../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-metadata-manager-server</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/pom.xml
@@ -1,20 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>linkis</artifactId>
         <groupId>org.apache.linkis</groupId>
         <version>1.0.3</version>
-        <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>linkis-metadata-manager-server</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <!--Metadata common-->
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-metadata-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+        <!-- data source manager common dependency-->
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-datasource-manager-common</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>asm</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!--rpc-->
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-rpc</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
 </project>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/assembly/distribution.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/assembly/distribution.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-metadata-manager-server</id>
+    <formats>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>linkis-mdm-server</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>true</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/../service/elasticsearch/target/out/lib</directory>
+            <fileMode>0755</fileMode>
+            <outputDirectory>lib/service/elasticsearch</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*-javadoc.jar</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../service/hive/target/out/lib</directory>
+            <fileMode>0755</fileMode>
+            <outputDirectory>lib/service/hive</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*-javadoc.jar</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../service/kafka/target/out/lib</directory>
+            <fileMode>0755</fileMode>
+            <outputDirectory>lib/service/kafka</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*-javadoc.jar</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../service/mysql/target/out/lib</directory>
+            <fileMode>0755</fileMode>
+            <outputDirectory>lib/service/mysql</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*-javadoc.jar</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../service/tdsql/target/out/lib</directory>
+            <fileMode>0755</fileMode>
+            <outputDirectory>lib/service/tdsql</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*-javadoc.jar</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+
+</assembly>
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/LinkisMetadataManagerApplication.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/LinkisMetadataManagerApplication.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.server;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.linkis.LinkisBaseServerApp;
+
+
+public class LinkisMetadataManagerApplication {
+
+    private static final Log logger = LogFactory.getLog(LinkisMetadataManagerApplication.class);
+
+    public static void main(String[] args) throws ReflectiveOperationException {
+        logger.info("Start to running LinkisMetadataManagerApplication");
+        LinkisBaseServerApp.main(args);
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/loader/MetaClassLoaderManager.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/loader/MetaClassLoaderManager.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.server.loader;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.linkis.common.conf.CommonVars;
+import org.apache.linkis.common.exception.ErrorException;
+import org.apache.linkis.metadatamanager.common.exception.MetaRuntimeException;
+import org.apache.linkis.metadatamanager.common.service.AbstractMetaService;
+import org.apache.linkis.metadatamanager.common.service.MetadataService;
+import org.apache.linkis.metadatamanager.server.utils.MetadataUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+/**
+ * Class Loader for metaClass
+ * // TODO used interface class
+ */
+public class MetaClassLoaderManager {
+
+    private final Map<String, ClassLoader> classLoaders = new ConcurrentHashMap<>();
+
+    private final Map<String, MetaServiceInstance> metaServiceInstances = new ConcurrentHashMap<>();
+
+    public static CommonVars<String> LIB_DIR = CommonVars.apply("wds.linkis.server.mdm.service.lib.dir", "/lib/linkis-pulicxxxx-/linkis-metdata-manager/service");
+
+    public static CommonVars<Integer> INSTANCE_EXPIRE_TIME = CommonVars.apply("wds.linkis.server.mdm.service.instance.expire-in-seconds", 60);
+
+    private static final String META_CLASS_NAME = "com.webank.wedatasphere.linkis.metadatamanager.service.%sMetaService";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetaClassLoaderManager.class);
+
+    public BiFunction<String, Object[], Object> getInvoker(String dsType) throws ErrorException {
+        boolean needToLoad = true;
+        MetaServiceInstance serviceInstance = metaServiceInstances.get(dsType);
+        if (Objects.nonNull(serviceInstance)){
+            Integer expireTimeInSec = INSTANCE_EXPIRE_TIME.getValue();
+            //Lazy load
+            needToLoad = Objects.nonNull(expireTimeInSec) && expireTimeInSec > 0 &&
+                    (serviceInstance.initTimeStamp +
+                            TimeUnit.MILLISECONDS.convert(expireTimeInSec,  TimeUnit.SECONDS)) < System.currentTimeMillis();
+        }
+        if(needToLoad) {
+            MetaServiceInstance finalServiceInstance1 = serviceInstance;
+            serviceInstance = metaServiceInstances.compute(dsType, (key, instance) -> {
+                if(null != instance && !Objects.equals(finalServiceInstance1, instance)){
+                    return instance;
+                }
+                LOG.info("Start to load/reload meta instance of data source type: [" + dsType + "]");
+                ClassLoader parentClassLoader = MetaClassLoaderManager.class.getClassLoader();
+                ClassLoader metaClassLoader = classLoaders.compute(dsType, (type, classLoader) -> {
+                    String lib = LIB_DIR.getValue();
+                    String stdLib = lib.endsWith("/") ? lib.replaceAll(".$", "") : lib;
+                    String componentLib = stdLib + "/" + dsType;
+                    try {
+                        return new URLClassLoader(getJarsUrlsOfPath(componentLib).toArray(new URL[0]), parentClassLoader);
+                    } catch (Exception e) {
+                        LOG.error("Cannot init the classloader of type: [" + dsType + "] in library path: [" + componentLib + "]", e);
+                        return null;
+                    }
+                });
+                if (Objects.isNull(metaClassLoader)) {
+                    throw new MetaRuntimeException("Error in creating classloader of type: [" + dsType + "]", null);
+                }
+                String expectClassName = null;
+                if (dsType.length() > 0) {
+                    String prefix = dsType.substring(0, 1).toUpperCase() + dsType.substring(1);
+                    expectClassName = String.format(META_CLASS_NAME, prefix);
+                }
+                Class<? extends MetadataService> metaServiceClass = searchForLoadMetaServiceClass(metaClassLoader, expectClassName, true);
+                if (Objects.isNull(metaServiceClass)) {
+                    throw new MetaRuntimeException("Fail to init and load meta service class for type: [" + dsType + "]", null);
+                }
+                MetadataService metadataService = MetadataUtils.loadMetaService(metaServiceClass, metaClassLoader);
+                if (metadataService instanceof AbstractMetaService){
+                    LOG.info("Invoke the init() method in meta service for type: [" + dsType +"]");
+                    ((AbstractMetaService<?>)metadataService).init();
+                }
+                return new MetaServiceInstance(metadataService, metaClassLoader);
+            });
+        }
+        Method[] childMethods = serviceInstance.methods;
+        MetaServiceInstance finalServiceInstance = serviceInstance;
+        return (String m, Object...args)-> {
+            ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(finalServiceInstance.metaClassLoader);
+                Method method = Arrays.stream(childMethods)
+                        .filter(eachMethod -> eachMethod.getName().equals(m)).collect(Collectors.toList()).get(0);
+                return method.invoke(finalServiceInstance.serviceInstance, args);
+            } catch (Exception e) {
+                Throwable t = e;
+                // UnWrap the Invocation target exception
+                while (t instanceof InvocationTargetException){
+                    t = t.getCause();
+                }
+                String message = "Fail to invoke method: [" + m + "] in meta service instance: [" + finalServiceInstance.serviceInstance.toString() + "]";
+                LOG.warn(message, t);
+                throw new MetaRuntimeException(message, t);
+            }finally {
+                Thread.currentThread().setContextClassLoader(currentClassLoader);
+            }
+        };
+    }
+
+
+
+
+    private Class<? extends MetadataService> searchForLoadMetaServiceClass(ClassLoader classLoader,
+                                                                           String expectClassName, boolean initialize){
+        ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try{
+            Class<? extends MetadataService> metaClass = null;
+            if(StringUtils.isNotBlank(expectClassName)){
+                metaClass = MetadataUtils.loadMetaServiceClass(classLoader, expectClassName,
+                        initialize, "Cannot find class in using expect class name: [" + expectClassName + "]");
+            }
+            if (Objects.isNull(metaClass)){
+                if (classLoader instanceof URLClassLoader){
+                    String[] metaServiceClassNames = MetadataUtils.searchMetaServiceClassInLoader((URLClassLoader)classLoader);
+                    if (metaServiceClassNames.length > 0){
+                        String metaServiceClassName = metaServiceClassNames[0];
+                        metaClass = MetadataUtils.loadMetaServiceClass(classLoader, metaServiceClassName,
+                                initialize, "Cannot load class in canonical name: [" + metaServiceClassName + "], please check the compiled jar/file");
+                    }
+                }
+            }
+            return metaClass;
+        } finally{
+            Thread.currentThread().setContextClassLoader(currentClassLoader);
+        }
+    }
+
+
+    private List<URL> getJarsUrlsOfPath(String path) throws MalformedURLException {
+        File file = new File(path);
+        List<URL> jars = new ArrayList<>();
+        if (file.listFiles() != null){
+            for(File f : Objects.requireNonNull(file.listFiles())){
+                if (!f.isDirectory() && f.getName().endsWith(".jar")){
+                    jars.add(f.toURI().toURL());
+                }else if(f.isDirectory()){
+                    jars.addAll(getJarsUrlsOfPath(f.getPath()));
+                }
+            }
+        }
+        return jars;
+    }
+
+    /**
+     * ServiceInstance Holder
+     */
+    public static class MetaServiceInstance{
+        private MetadataService serviceInstance;
+
+        private Method[] methods;
+
+        private ClassLoader metaClassLoader;
+
+        private long initTimeStamp = 0L;
+
+        public MetaServiceInstance(MetadataService serviceInstance, ClassLoader metaClassLoader){
+            this.serviceInstance = serviceInstance;
+            this.metaClassLoader = metaClassLoader;
+            this.methods = serviceInstance.getClass().getMethods();
+            this.initTimeStamp = System.currentTimeMillis();
+        }
+
+        public MetadataService getServiceInstance() {
+            return serviceInstance;
+        }
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/restful/MetadataCoreRestful.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/restful/MetadataCoreRestful.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.server.restful;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.linkis.common.exception.ErrorException;
+import org.apache.linkis.datasourcemanager.common.util.json.Json;
+import org.apache.linkis.metadatamanager.common.domain.MetaColumnInfo;
+import org.apache.linkis.metadatamanager.common.domain.MetaPartitionInfo;
+import org.apache.linkis.metadatamanager.common.exception.MetaMethodInvokeException;
+import org.apache.linkis.metadatamanager.server.service.MetadataAppService;
+import org.apache.linkis.server.Message;
+import org.apache.linkis.server.security.SecurityFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping(value = "/metadatamanager", produces = {"application/json"})
+public class MetadataCoreRestful {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetadataCoreRestful.class);
+
+    @Autowired
+    private MetadataAppService metadataAppService;
+
+    @RequestMapping(value = "/dbs/{data_source_id}", method = RequestMethod.GET)
+    public Message getDatabases(@PathVariable("data_source_id")String dataSourceId,
+                                 @RequestParam("system")String system,
+                                 HttpServletRequest request){
+        try{
+            if(StringUtils.isBlank(system)){
+                return Message.error("'system' is missing[缺少系统名]");
+            }
+            List<String> databases = metadataAppService.getDatabasesByDsId(dataSourceId, system,
+                    SecurityFilter.getLoginUsername(request));
+            return Message.ok().data("dbs", databases);
+        }catch(Exception e){
+            return errorToResponseMessage("Fail to get database list[获取库信息失败], id:[" + dataSourceId +"], system:[" + system + "]", e);
+        }
+    }
+
+    @RequestMapping( value = "/tables/{data_source_id}/db/{database}", method = RequestMethod.GET)
+    public Message getTables(@PathVariable("data_source_id")String dataSourceId,
+                              @PathVariable("database")String database,
+                              @RequestParam("system")String system,
+                              HttpServletRequest request){
+        try{
+            if(StringUtils.isBlank(system)){
+                return Message.error("'system' is missing[缺少系统名]");
+            }
+            List<String> tables = metadataAppService.getTablesByDsId(dataSourceId, database, system,
+                    SecurityFilter.getLoginUsername(request));
+            return Message.ok().data("tables", tables);
+        }catch(Exception e){
+            return errorToResponseMessage("Fail to get table list[获取表信息失败], id:[" + dataSourceId +"]" +
+                            ", system:[" + system + "], database:[" +database +"]", e);
+        }
+    }
+
+    @RequestMapping( value = "/props/{data_source_id}/db/{database}/table/{table}", method = RequestMethod.GET)
+    public Message getTableProps(@PathVariable("data_source_id")String dataSourceId,
+                                  @PathVariable("database")String database,
+                                  @PathVariable("table") String table,
+                                  @RequestParam("system")String system,
+                                   HttpServletRequest request){
+        try{
+            if(StringUtils.isBlank(system)){
+                return Message.error("'system' is missing[缺少系统名]");
+            }
+            Map<String, String> tableProps = metadataAppService.getTablePropsByDsId(dataSourceId, database, table, system,
+                    SecurityFilter.getLoginUsername(request));
+            return Message.ok().data("props", tableProps);
+        }catch(Exception e){
+            return errorToResponseMessage("Fail to get table properties[获取表参数信息失败], id:[" + dataSourceId +"]" +
+                            ", system:[" + system + "], database:[" +database +"], table:[" + table +"]", e);
+        }
+    }
+
+    @RequestMapping( value = "/partitions/{data_source_id}/db/{database}/table/{table}", method = RequestMethod.GET)
+    public Message getPartitions(@PathVariable("data_source_id")String dataSourceId,
+                                  @PathVariable("database")String database,
+                                  @PathVariable("table") String table,
+                                  @RequestParam("system")String system,
+                                   HttpServletRequest request){
+        try{
+            if(StringUtils.isBlank(system)){
+                return Message.error("'system' is missing[缺少系统名]");
+            }
+            MetaPartitionInfo partitionInfo = metadataAppService.getPartitionsByDsId(dataSourceId, database, table, system,
+                    SecurityFilter.getLoginUsername(request));
+            return Message.ok().data("props", partitionInfo);
+        }catch(Exception e){
+            return errorToResponseMessage("Fail to get partitions[获取表分区信息失败], id:[" + dataSourceId +"]" +
+                            ", system:[" + system + "], database:[" +database +"], table:[" + table +"]", e);
+        }
+    }
+
+    @RequestMapping( value = "/columns/{data_source_id}/db/{database}/table/{table}", method = RequestMethod.GET)
+    public Message getColumns(@PathVariable("data_source_id")String dataSourceId,
+                               @PathVariable("database")String database,
+                               @PathVariable("table") String table,
+                               @RequestParam("system")String system,
+                                HttpServletRequest request){
+        try{
+            if(StringUtils.isBlank(system)){
+                return Message.error("'system' is missing[缺少系统名]");
+            }
+            List<MetaColumnInfo> columns = metadataAppService.getColumns(dataSourceId, database, table, system,
+                    SecurityFilter.getLoginUsername(request));
+            return Message.ok().data("columns", columns);
+        }catch(Exception e){
+            return errorToResponseMessage("Fail to get column list[获取表字段信息失败], id:[" + dataSourceId +"]" +
+                            ", system:[" + system + "], database:[" +database +"], table:[" + table +"]", e);
+        }
+    }
+
+    private Message errorToResponseMessage(String uiMessage, Exception e){
+        if (e instanceof MetaMethodInvokeException){
+            MetaMethodInvokeException invokeException = (MetaMethodInvokeException)e;
+            if (LOG.isDebugEnabled()) {
+                String argumentJson = null;
+                try {
+                    argumentJson = Json.toJson(invokeException.getArgs(), null);
+                } catch (Exception je) {
+                    // Ignore
+                }
+                LOG.trace(uiMessage + " => Method: " + invokeException.getMethod() + ", Arguments:" + argumentJson, e);
+            }
+            uiMessage += " possible reason[可能原因]: (" + invokeException.getCause().getMessage() + ")";
+        }else {
+            if (e instanceof ErrorException){
+                uiMessage += " possible reason[可能原因]: (" + e.getMessage() + ")";
+            }
+           LOG.error(uiMessage, e);
+        }
+        return Message.error(uiMessage);
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/MetadataAppService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/MetadataAppService.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.server.service;
+
+import org.apache.linkis.common.exception.ErrorException;
+import org.apache.linkis.metadatamanager.common.domain.MetaColumnInfo;
+import org.apache.linkis.metadatamanager.common.domain.MetaPartitionInfo;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MetadataAppService {
+
+    /**
+     * Get connection
+     * @param params connect params
+     * @return
+     */
+    void getConnection(String dataSourceType, String operator, Map<String, Object> params) throws Exception;
+
+    /**
+     * @param dataSourceId data source id
+     * @param system system
+     * @return
+     */
+    List<String> getDatabasesByDsId(String dataSourceId, String system, String userName) throws ErrorException;
+
+    /**
+     * @param dataSourceId data source id
+     * @param system system
+     * @param database database
+     * @return
+     */
+    List<String> getTablesByDsId(String dataSourceId, String database, String system, String userName) throws ErrorException;
+
+    /**
+     * @param dataSourceId data source id
+     * @param database database
+     * @param table table
+     * @param system system
+     * @return
+     */
+    Map<String, String> getTablePropsByDsId(String dataSourceId, String database, String table,
+                                            String system, String userName) throws ErrorException;
+    /**
+     * @param dataSourceId data source i
+     * @param database database
+     * @param table table
+     * @param system system
+     * @return
+     */
+    MetaPartitionInfo getPartitionsByDsId(String dataSourceId, String database, String table,
+                                          String system, String userName) throws ErrorException;
+
+    /**
+     * @param dataSourceId data source id
+     * @param database database
+     * @param table table
+     * @param system system
+     * @return
+     */
+    List<MetaColumnInfo> getColumns(String dataSourceId, String database, String table,
+                                    String system, String userName) throws ErrorException;
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/impl/MetadataAppServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/impl/MetadataAppServiceImpl.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.server.service.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.linkis.common.exception.ErrorException;
+import org.apache.linkis.datasourcemanager.common.auth.AuthContext;
+import org.apache.linkis.datasourcemanager.common.protocol.DsInfoQueryRequest;
+import org.apache.linkis.datasourcemanager.common.protocol.DsInfoResponse;
+import org.apache.linkis.metadatamanager.common.MdmConfiguration;
+import org.apache.linkis.metadatamanager.common.domain.MetaColumnInfo;
+import org.apache.linkis.metadatamanager.common.domain.MetaPartitionInfo;
+import org.apache.linkis.metadatamanager.common.exception.MetaMethodInvokeException;
+import org.apache.linkis.metadatamanager.common.exception.MetaRuntimeException;
+import org.apache.linkis.metadatamanager.common.service.MetadataConnection;
+import org.apache.linkis.metadatamanager.server.loader.MetaClassLoaderManager;
+import org.apache.linkis.metadatamanager.server.service.MetadataAppService;
+import org.apache.linkis.rpc.Sender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.*;
+import java.util.function.BiFunction;
+
+@Service
+public class MetadataAppServiceImpl implements MetadataAppService {
+    private Sender dataSourceRpcSender;
+    private MetaClassLoaderManager metaClassLoaderManager;
+    private static final Logger LOG = LoggerFactory.getLogger(MetadataAppServiceImpl.class);
+    @PostConstruct
+    public void init(){
+        dataSourceRpcSender = Sender.getSender(MdmConfiguration.DATA_SOURCE_SERVICE_APPLICATION.getValue());
+        metaClassLoaderManager = new MetaClassLoaderManager();
+    }
+
+
+    @Override
+    public void getConnection(String dataSourceType, String operator, Map<String, Object> params) throws Exception {
+        MetadataConnection<Closeable> metadataConnection = invokeMetaMethod(dataSourceType, "getConnection", new Object[]{operator, params}, Map.class);
+        if (Objects.nonNull(metadataConnection)){
+            Closeable connection = metadataConnection.getConnection();
+            try {
+                connection.close();
+            }catch(IOException e){
+                LOG.warn("Fail to close connection[关闭连接失败], [" + e.getMessage() + "]", e);
+            }
+        }
+    }
+
+    @Override
+    public List<String> getDatabasesByDsId(String dataSourceId, String system, String userName) throws ErrorException {
+        DsInfoResponse dsInfoResponse = reqToGetDataSourceInfo(dataSourceId, system, userName);
+        if(StringUtils.isNotBlank(dsInfoResponse.dsType())){
+            return invokeMetaMethod(dsInfoResponse.dsType(), "getDatabases",   new Object[]{dsInfoResponse.creator(), dsInfoResponse.params()}, List.class);
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<String> getTablesByDsId(String dataSourceId, String database, String system,
+                                        String userName) throws ErrorException {
+        DsInfoResponse dsInfoResponse = reqToGetDataSourceInfo(dataSourceId, system, userName);
+        if(StringUtils.isNotBlank(dsInfoResponse.dsType())){
+            return invokeMetaMethod(dsInfoResponse.dsType(), "getTables", new Object[]{dsInfoResponse.creator(), dsInfoResponse.params(), database}, List.class);
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Map<String, String> getTablePropsByDsId(String dataSourceId, String database, String table,
+                                                   String system, String userName) throws ErrorException {
+        DsInfoResponse dsInfoResponse = reqToGetDataSourceInfo(dataSourceId, system, userName);
+        if(StringUtils.isNotBlank(dsInfoResponse.dsType())){
+            return invokeMetaMethod(dsInfoResponse.dsType(), "getTableProps",  new Object[]{dsInfoResponse.creator(), dsInfoResponse.params(), database, table},
+                    Map.class);
+        }
+        return new HashMap<>();
+    }
+
+    @Override
+    public MetaPartitionInfo getPartitionsByDsId(String dataSourceId, String database, String table,
+                                                 String system, String userName) throws ErrorException {
+        DsInfoResponse dsInfoResponse = reqToGetDataSourceInfo(dataSourceId, system, userName);
+        if(StringUtils.isNotBlank(dsInfoResponse.dsType())){
+            return invokeMetaMethod(dsInfoResponse.dsType(), "getPartitions", new Object[]{dsInfoResponse.creator(), dsInfoResponse.params(), database, table},
+                    MetaPartitionInfo.class);
+        }
+        return new MetaPartitionInfo();
+    }
+
+    @Override
+    public List<MetaColumnInfo> getColumns(String dataSourceId, String database, String table,
+                                           String system, String userName) throws ErrorException {
+        DsInfoResponse dsInfoResponse = reqToGetDataSourceInfo(dataSourceId, system, userName);
+        if(StringUtils.isNotBlank(dsInfoResponse.dsType())){
+            return invokeMetaMethod(dsInfoResponse.dsType(), "getColumns", new Object[]{dsInfoResponse.creator(), dsInfoResponse.params(), database, table},
+                    List.class);
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * Request to get data source information
+     * (type and connection parameters)
+     * @param dataSourceId data source id
+     * @param system system
+     * @return
+     * @throws ErrorException
+     */
+    public DsInfoResponse reqToGetDataSourceInfo(String dataSourceId, String system,
+                                                 String userName) throws ErrorException{
+        Object rpcResult = null;
+        try {
+            rpcResult = dataSourceRpcSender.ask(new DsInfoQueryRequest(dataSourceId, null, system));
+        }catch(Exception e){
+            throw new ErrorException(-1, "Remote Service Error[远端服务出错, 联系运维处理]");
+        }
+        if(rpcResult instanceof DsInfoResponse){
+            DsInfoResponse response = (DsInfoResponse)rpcResult;
+            if(!response.status()){
+                throw new ErrorException(-1, "Error in Data Source Manager Server[数据源服务出错]");
+            }
+            boolean hasPermission = (AuthContext.isAdministrator(userName) ||
+                    (StringUtils.isNotBlank(response.creator()) && userName.equals(response.creator())));
+            if(!hasPermission){
+                throw new ErrorException(-1, "Don't have query permission for data source [没有数据源的查询权限]");
+            } else if (response.params().isEmpty()){
+                throw new ErrorException(-1, "Have you published the data source? [数据源未发布或者参数为空]");
+            }
+            return response;
+        }else{
+            throw new ErrorException(-1, "Remote Service Error[远端服务出错, 联系运维处理]");
+        }
+    }
+
+    /**
+     * Invoke method in meta service
+     * @param method method name
+     * @param methodArgs arguments
+     */
+    @SuppressWarnings("unchecked")
+    private <T>T invokeMetaMethod(String dsType,
+                                  String method, Object[] methodArgs,
+                                  Class<?> returnType) throws MetaMethodInvokeException {
+        BiFunction<String, Object[], Object> invoker;
+        try {
+            invoker = metaClassLoaderManager.getInvoker(dsType);
+        }catch (Exception e){
+            // TODO ERROR CODE
+            throw new MetaMethodInvokeException(-1, "Load meta service for " + dsType +
+                    " fail 加载 [" + dsType + "] 元数据服务失败", e);
+        }
+        if (Objects.nonNull(invoker)){
+            try {
+                Object returnObj = invoker.apply(method, methodArgs);
+                if (Objects.nonNull(returnType)) {
+                    return (T) returnObj;
+                }
+            }catch (Exception e){
+                if (e instanceof MetaRuntimeException){
+                    throw new MetaMethodInvokeException(method, methodArgs, -1, e.getMessage(), e.getCause());
+                }
+                // TODO ERROR CODE
+                throw new MetaMethodInvokeException(method, methodArgs, -1,
+                        "Invoke method [" + method +"] fail, message:[" + e.getMessage() + "]", e);
+            }
+        }
+        return null;
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/utils/MetadataUtils.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/utils/MetadataUtils.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.server.utils;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.linkis.metadatamanager.common.exception.MetaRuntimeException;
+import org.apache.linkis.metadatamanager.common.service.MetadataService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.function.Function;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+/**
+ * Metadata Utils
+ */
+public class MetadataUtils {
+
+    private static final String JAR_SUF_NAME = ".jar";
+
+    private static final String CLASS_SUF_NAME = ".class";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetadataUtils.class);
+
+    public static MetadataService loadMetaService(Class<? extends MetadataService> metaServiceClass,
+                                                  ClassLoader metaServiceClassLoader){
+        ClassLoader storeClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(metaServiceClassLoader);
+        try{
+            final Constructor<?>[] constructors = metaServiceClass.getConstructors();
+            if (constructors.length <= 0){
+                throw new MetaRuntimeException("No public constructor in meta service class: [" + metaServiceClass.getName() + "]", null);
+            }
+            List<Constructor<?>> acceptConstructor = Arrays.stream(constructors)
+                    .filter( constructor -> constructor.getParameterCount() == 0).collect(Collectors.toList());
+            if (acceptConstructor.size() > 0){
+                //Choose the first one
+                Constructor<?> constructor = acceptConstructor.get(0);
+                try {
+                    return (MetadataService)constructor.newInstance();
+                } catch (Exception e) {
+                    throw new MetaRuntimeException("Unable to construct meta service class: [" + metaServiceClass.getName() + "]", e);
+                }
+            }else{
+                throw new MetaRuntimeException("Illegal arguments in constructor of meta service class: [" + metaServiceClass.getName() + "]", null);
+            }
+        }finally{
+            Thread.currentThread().setContextClassLoader(storeClassLoader);
+        }
+    }
+    /**
+     * Search meta service class from classloader
+     * @param serviceClassLoader service class loader
+     * @return collect
+     */
+    public static String[] searchMetaServiceClassInLoader(URLClassLoader serviceClassLoader){
+        URL[] urlsOfClassLoader = serviceClassLoader.getURLs();
+        List<String> classNameList = new ArrayList<>();
+        for( URL url : urlsOfClassLoader ){
+            String pathForUrl = url.getPath();
+             List<String> searchResult = searchMetaServiceClassFormURI(pathForUrl, className -> isSubMetaServiceClass(className, serviceClassLoader));
+             if (Objects.nonNull(searchResult)){
+                 classNameList.addAll(searchResult);
+             }
+        }
+        return classNameList.toArray(new String[]{});
+    }
+
+    public static Class<? extends MetadataService> loadMetaServiceClass(ClassLoader classLoader, String className,
+                                                                        boolean initialize, String notFoundMessage){
+        //Try to load use expectClassName
+        try {
+           return Class.forName(className, initialize, classLoader).asSubclass(MetadataService.class);
+        }catch(ClassNotFoundException ne){
+            LOG.warn(notFoundMessage, ne);
+        }
+        return null;
+    }
+
+    private static List<String> searchMetaServiceClassFormURI(String url, Function<String, Boolean> acceptedFunction){
+        List<String> classNameList = new ArrayList<>();
+        if(url.endsWith(CLASS_SUF_NAME)){
+            String className = url.substring(0, url.lastIndexOf(CLASS_SUF_NAME));
+            int splitIndex = className.lastIndexOf(IOUtils.DIR_SEPARATOR);
+            if(splitIndex >= 0){
+                className = className.substring(splitIndex);
+            }
+            if (acceptedFunction.apply(className)){
+                classNameList.add(className);
+            }
+        }else if(url.endsWith(JAR_SUF_NAME)){
+            try {
+                JarFile jarFile = new JarFile(new File(url));
+                Enumeration<JarEntry> en = jarFile.entries();
+                while(en.hasMoreElements()){
+                    String name = en.nextElement().getName();
+                    if(name.endsWith(CLASS_SUF_NAME)){
+                        String className = name.substring(0, name.lastIndexOf(CLASS_SUF_NAME));
+                        //If the splicer is different in WINDOWS system?
+                        className = className.replaceAll(String.valueOf(IOUtils.DIR_SEPARATOR_UNIX), ".");
+                        if(acceptedFunction.apply(className)){
+                           classNameList.add(className);
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                //Trace
+                LOG.trace("Fail to parse jar file:[" + url + "] in service classpath", e);
+                return classNameList;
+            }
+        }
+        return classNameList;
+    }
+
+    private static boolean isSubMetaServiceClass(String className, ClassLoader serviceClassLoader){
+        if(StringUtils.isEmpty(className)){
+            return false;
+        }
+        Class<?> clazz;
+        try{
+            clazz = Class.forName(className, false, serviceClassLoader);
+            //Skip interface and abstract class
+            if (Modifier.isAbstract(clazz.getModifiers()) || Modifier.isInterface(clazz.getModifiers())) {
+                return false;
+            }
+        } catch (Throwable t){
+            LOG.trace("Class: {} can not be found", className, t);
+            return false;
+        }
+        return MetadataService.class.isAssignableFrom(clazz);
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/pom.xml
@@ -33,5 +33,6 @@
         <module>linkis-datasource-manager/common</module>
         <module>linkis-datasource-manager/server</module>
         <module>linkis-metadata-manager/common</module>
+        <module>linkis-metadata-manager/server</module>
     </modules>
 </project>


### PR DESCRIPTION
module:linkis-metadata-manager-server
issue:https://github.com/apache/incubator-linkis/issues/1355
### What is the purpose of the change
To Supply Service For Linkis DataSource MetaData Manage

### Brief change log
(for example:)
- Define module linkis-metadata-manager-server;
- Define entry main class LinkisMetadataManagerApplication;
- Define metadata utils class;
- Define meta class loader manager class;
- Define service interface and implement class;
- Add restful api

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)