### PR TITLE
Add Metadata Service For Kafka

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>org.apache.linkis</groupId>
+        <version>1.0.3</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>linkis-metadata-manager-service-kafka</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-metadata-manager-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-module</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!--bml client-->
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-bml-client</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>**/*.properties</exclude>
+                    <exclude>**/application.yml</exclude>
+                    <exclude>**/bootstrap.yml</exclude>
+                    <exclude>**/log4j2.xml</exclude>
+                </excludes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+</project>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 ~ Licensed to the Apache Software Foundation (ASF) under one or more
 ~ contributor license agreements.  See the NOTICE file distributed with

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/assembly/distribution.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/assembly/distribution.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-metadata-manager-service-kafka</id>
+    <formats>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>linkis-metadata-manager-service-kafka</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>true</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+    </fileSets>
+
+</assembly>
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/java/org/apache/linkis/metadatamanager/service/KafkaConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/java/org/apache/linkis/metadatamanager/service/KafkaConnection.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.service;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.producer.ProducerConfig;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Properties;
+
+public class KafkaConnection implements Closeable {
+    private AdminClient adminClient;
+
+    public KafkaConnection(String uris) throws Exception{
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, uris);
+        adminClient = KafkaAdminClient.create(props);
+    }
+
+    public KafkaConnection(String uris, String principle, String keytabFilePath) throws Exception {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, uris);
+        adminClient = KafkaAdminClient.create(props);
+    }
+
+    public AdminClient getClient(){
+        return adminClient;
+    }
+
+    @Override
+    public void close() throws IOException {
+        adminClient.close();
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/java/org/apache/linkis/metadatamanager/service/KafkaMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/java/org/apache/linkis/metadatamanager/service/KafkaMetaService.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.service;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.linkis.bml.client.BmlClient;
+import org.apache.linkis.bml.client.BmlClientFactory;
+import org.apache.linkis.bml.protocol.BmlDownloadResponse;
+import org.apache.linkis.common.conf.CommonVars;
+import org.apache.linkis.metadatamanager.common.exception.MetaRuntimeException;
+import org.apache.linkis.metadatamanager.common.service.AbstractMetaService;
+import org.apache.linkis.metadatamanager.common.service.MetadataConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+public class KafkaMetaService extends AbstractMetaService<KafkaConnection> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaMetaService.class);
+    private static final CommonVars<String> TMP_FILE_STORE_LOCATION =
+            CommonVars.apply("wds.linkis.server.mdm.service.temp.location", "classpath:/tmp");
+    private BmlClient client;
+
+    @PostConstruct
+    public void buildClient(){
+        client = BmlClientFactory.createBmlClient();
+    }
+
+    @Override
+    public MetadataConnection<KafkaConnection> getConnection(String operator, Map<String, Object> params) throws Exception {
+        Resource resource = new PathMatchingResourcePatternResolver().getResource(TMP_FILE_STORE_LOCATION.getValue());
+        String brokers = String.valueOf(params.getOrDefault(KafkaParamsMapper.PARAM_KAFKA_BROKERS.getValue(), ""));
+        String principle = String.valueOf(params.getOrDefault(KafkaParamsMapper.PARAM_KAFKA_PRINCIPLE.getValue(), ""));
+        KafkaConnection conn;
+
+        if(StringUtils.isNotBlank(principle)){
+            LOG.info("Try to connect Kafka MetaStore in kerberos with principle:[" + principle +"]");
+            String keytabResourceId = String.valueOf(params.getOrDefault(KafkaParamsMapper.PARAM_KAFKA_KEYTAB.getValue(), ""));
+            if(StringUtils.isNotBlank(keytabResourceId)){
+                LOG.info("Start to download resource id:[" + keytabResourceId +"]");
+                String keytabFilePath = resource.getFile().getAbsolutePath() + "/" + UUID.randomUUID().toString().replace("-", "");
+                if(!downloadResource(keytabResourceId, operator, keytabFilePath)){
+                    throw new MetaRuntimeException("Fail to download resource i:[" + keytabResourceId +"]", null);
+                }
+                conn = new KafkaConnection(brokers, principle, keytabFilePath);
+            }else{
+                throw new MetaRuntimeException("Cannot find the keytab file in connect parameters", null);
+            }
+        }else{
+            conn = new KafkaConnection(brokers);
+        }
+
+        // because KafkaAdminClient.create does not do a real connection, we use listTopics here for testing connection
+        conn.getClient().listTopics().names().get();
+
+        return new MetadataConnection<>(conn, true);
+    }
+
+
+    @Override
+    public List<String> queryDatabases(KafkaConnection connection){
+        return Arrays.asList("default");
+    }
+
+    @Override
+    public List<String> queryTables(KafkaConnection connection, String database){
+        try {
+            return connection.getClient().listTopics().names().get().stream().collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Fail to get Kafka topics(获取topic列表失败)", e);
+        }
+    }
+
+
+    private boolean downloadResource(String resourceId, String user, String absolutePath) throws IOException {
+        BmlDownloadResponse downloadResponse = client.downloadResource(user, resourceId, absolutePath);
+        if(downloadResponse.isSuccess()){
+            IOUtils.copy(downloadResponse.inputStream(), new FileOutputStream(absolutePath));
+            return true;
+        }
+        return false;
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/java/org/apache/linkis/metadatamanager/service/KafkaParamsMapper.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/kafka/src/main/java/org/apache/linkis/metadatamanager/service/KafkaParamsMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadatamanager.service;
+
+import org.apache.linkis.common.conf.CommonVars;
+
+public class KafkaParamsMapper {
+    public static final CommonVars<String> PARAM_KAFKA_PRINCIPLE =
+            CommonVars.apply("wds.linkis.server.mdm.service.kafka.principle", "principle");
+
+    public static final CommonVars<String> PARAM_KAFKA_KEYTAB =
+            CommonVars.apply("wds.linkis.server.mdm.service.kafka.keytab", "keytab");
+
+    public static final CommonVars<String> PARAM_KAFKA_BROKERS =
+            CommonVars.apply("wds.linkis.server.mdm.service.kafka.brokers", "brokers");
+}

--- a/linkis-public-enhancements/linkis-datasource/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/pom.xml
@@ -36,5 +36,6 @@
         <module>linkis-metadata-manager/server</module>
         <module>linkis-metadata-manager/service/elasticsearch</module>
         <module>linkis-metadata-manager/service/hive</module>
+        <module>linkis-metadata-manager/service/kafka</module>
     </modules>
 </project>


### PR DESCRIPTION
module:linkis-metadata-manager-service-kafka
issue:https://github.com/apache/incubator-linkis/issues/1370

### What is the purpose of the change
add module linkis-metadata-manager-service-hive

### Brief change log
(for example:)
- Define How to Connect Kafka Meta Service;
- Define Service For Kafka Meta Data;

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)