### PR TITLE
Add MetaData Service Mysql For 1.1.0

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>org.apache.linkis</groupId>
+        <version>1.0.3</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-metadata-manager-service-mysql</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mysql.version>5.1.34</mysql.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-metadata-manager-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-module</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>asm</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+</project>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/assembly/distribution.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/assembly/distribution.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-metadata-manager-service-mysql</id>
+    <formats>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>linkis-metadata-manager-service-mysql</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>true</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+    </fileSets>
+
+</assembly>
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/java/org/apache/linkis/metadatamanager/service/MysqlMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/java/org/apache/linkis/metadatamanager/service/MysqlMetaService.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.service;
+
+import org.apache.linkis.datasourcemanager.common.util.json.Json;
+import org.apache.linkis.metadatamanager.common.domain.MetaColumnInfo;
+import org.apache.linkis.metadatamanager.common.service.AbstractMetaService;
+import org.apache.linkis.metadatamanager.common.service.MetadataConnection;
+import org.springframework.stereotype.Component;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class MysqlMetaService extends AbstractMetaService<SqlConnection> {
+    @Override
+    public MetadataConnection<SqlConnection> getConnection(String operator, Map<String, Object> params) throws Exception {
+        String host = String.valueOf(params.getOrDefault(SqlParamsMapper.PARAM_SQL_HOST.getValue(), ""));
+        //After deserialize, Integer will be Double, Why?
+        Integer port = (Double.valueOf(String.valueOf(params.getOrDefault(SqlParamsMapper.PARAM_SQL_PORT.getValue(), 0)))).intValue();
+        String username = String.valueOf(params.getOrDefault(SqlParamsMapper.PARAM_SQL_USERNAME.getValue(), ""));
+        String password = String.valueOf(params.getOrDefault(SqlParamsMapper.PARAM_SQL_PASSWORD.getValue(), ""));
+        Map<String, Object> extraParams = new HashMap<>();
+        Object sqlParamObj =  params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
+        if(null != sqlParamObj){
+            if(!(sqlParamObj instanceof Map)){
+                extraParams = Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+            }else{
+                extraParams = (Map<String, Object>)sqlParamObj;
+            }
+        }
+        assert extraParams != null;
+        return new MetadataConnection<>(new SqlConnection(host, port, username, password, extraParams));
+    }
+
+    @Override
+    public List<String> queryDatabases(SqlConnection connection) {
+        try {
+            return connection.getAllDatabases();
+        } catch (SQLException e) {
+            throw new RuntimeException("Fail to get Sql databases(获取数据库列表失败)", e);
+        }
+    }
+
+    @Override
+    public List<String> queryTables(SqlConnection connection, String database) {
+        try {
+            return connection.getAllTables(database);
+        } catch (SQLException e) {
+            throw new RuntimeException("Fail to get Sql tables(获取表列表失败)", e);
+        }
+    }
+
+    @Override
+    public List<MetaColumnInfo> queryColumns(SqlConnection connection, String database, String table) {
+        try {
+            return connection.getColumns(database, table);
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new RuntimeException("Fail to get Sql columns(获取字段列表失败)", e);
+        }
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/java/org/apache/linkis/metadatamanager/service/SqlConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/java/org/apache/linkis/metadatamanager/service/SqlConnection.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.service;
+
+import org.apache.linkis.common.conf.CommonVars;
+import org.apache.linkis.metadatamanager.common.domain.MetaColumnInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SqlConnection implements Closeable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SqlConnection.class);
+
+    private static final CommonVars<String> SQL_DRIVER_CLASS =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.driver", "com.mysql.jdbc.Driver");
+
+    private static final CommonVars<String> SQL_CONNECT_URL =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.url", "jdbc:mysql://%s:%s/%s");
+
+    private static final CommonVars<Integer> SQL_CONNECT_TIMEOUT =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.connect.timeout", 3000);
+
+    private static final CommonVars<Integer> SQL_SOCKET_TIMEOUT =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.socket.timeout", 6000);
+
+    private Connection conn;
+
+    private ConnectMessage connectMessage;
+
+    public SqlConnection(String host, Integer port,
+                         String username, String password,
+                         Map<String, Object> extraParams ) throws ClassNotFoundException, SQLException {
+        connectMessage = new ConnectMessage(host, port, username, password, extraParams);
+        conn = getDBConnection(connectMessage, "");
+        //Try to create statement
+        Statement statement = conn.createStatement();
+        statement.close();
+    }
+
+    public List<String> getAllDatabases() throws SQLException {
+        List<String> dataBaseName = new ArrayList<>();
+        Statement stmt = null;
+        ResultSet rs = null;
+        try{
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery("SHOW DATABASES");
+            while (rs.next()){
+                dataBaseName.add(rs.getString(1));
+            }
+        } finally {
+            closeResource(null, stmt, rs);
+        }
+        return dataBaseName;
+    }
+
+    public List<String> getAllTables(String database) throws SQLException {
+        List<String> tableNames = new ArrayList<>();
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery("SHOW TABLES FROM `" + database + "`");
+            while (rs.next()) {
+                tableNames.add(rs.getString(1));
+            }
+            return tableNames;
+        } finally{
+            closeResource(null, stmt, rs);
+        }
+    }
+
+    public List<MetaColumnInfo> getColumns(String database, String table) throws SQLException, ClassNotFoundException {
+        List<MetaColumnInfo> columns = new ArrayList<>();
+        String columnSql = "SELECT * FROM `" + database +"`.`" + table + "` WHERE 1 = 2";
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        ResultSetMetaData meta = null;
+        try {
+            List<String> primaryKeys = getPrimaryKeys(getDBConnection(connectMessage, database),  table);
+            ps = conn.prepareStatement(columnSql);
+            rs = ps.executeQuery();
+            meta = rs.getMetaData();
+            int columnCount = meta.getColumnCount();
+            for (int i = 1; i < columnCount + 1; i++) {
+                MetaColumnInfo info = new MetaColumnInfo();
+                info.setIndex(i);
+                info.setName(meta.getColumnName(i));
+                info.setType(meta.getColumnTypeName(i));
+                if(primaryKeys.contains(meta.getColumnName(i))){
+                    info.setPrimaryKey(true);
+                }
+                columns.add(info);
+            }
+        }finally {
+            closeResource(null, ps, rs);
+        }
+        return columns;
+    }
+
+    /**
+     * Get primary keys
+     * @param connection connection
+     * @param table table name
+     * @return
+     * @throws SQLException
+     */
+    private List<String> getPrimaryKeys(Connection connection, String table) throws SQLException {
+        ResultSet rs = null;
+        List<String> primaryKeys = new ArrayList<>();
+        try {
+            DatabaseMetaData dbMeta = connection.getMetaData();
+            rs = dbMeta.getPrimaryKeys(null, null, table);
+            while(rs.next()){
+                primaryKeys.add(rs.getString("column_name"));
+            }
+            return primaryKeys;
+        }finally{
+            if(null != rs){
+                closeResource(connection, null, rs);
+            }
+        }
+    }
+
+    /**
+     * close database resource
+     * @param connection connection
+     * @param statement statement
+     * @param resultSet result set
+     */
+    private void closeResource(Connection connection,  Statement statement, ResultSet resultSet){
+        try {
+            if(null != resultSet && !resultSet.isClosed()) {
+                resultSet.close();
+            }
+            if(null != statement && !statement.isClosed()){
+                statement.close();
+            }
+            if(null != connection && !connection.isClosed()){
+                connection.close();
+            }
+        }catch (SQLException e){
+            LOG.warn("Fail to release resource [" + e.getMessage() +"]", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        closeResource(conn, null, null);
+    }
+
+    /**
+     * @param connectMessage
+     * @param database
+     * @return
+     * @throws ClassNotFoundException
+     */
+    private Connection getDBConnection(ConnectMessage connectMessage, String database) throws ClassNotFoundException, SQLException {
+        String extraParamString = connectMessage.extraParams.entrySet()
+                .stream().map(e -> String.join("=", e.getKey(), String.valueOf(e.getValue())))
+                .collect(Collectors.joining("&"));
+        Class.forName(SQL_DRIVER_CLASS.getValue());
+        String url = String.format(SQL_CONNECT_URL.getValue(), connectMessage.host, connectMessage.port, database);
+        if(!connectMessage.extraParams.isEmpty()) {
+            url += "?" + extraParamString;
+        }
+        return DriverManager.getConnection(url, connectMessage.username, connectMessage.password);
+    }
+
+    /**
+     * Connect message
+     */
+    private static class ConnectMessage{
+        private String host;
+
+        private Integer port;
+
+        private String username;
+
+        private String password;
+
+        private Map<String, Object> extraParams;
+
+        public ConnectMessage(String host, Integer port,
+                              String username, String password,
+                              Map<String, Object> extraParams){
+            this.host = host;
+            this.port = port;
+            this.username = username;
+            this.password = password;
+            this.extraParams = extraParams;
+            this.extraParams.put("connectTimeout", SQL_CONNECT_TIMEOUT.getValue());
+            this.extraParams.put("socketTimeout", SQL_SOCKET_TIMEOUT.getValue());
+        }
+    }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/java/org/apache/linkis/metadatamanager/service/SqlParamsMapper.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/mysql/src/main/java/org/apache/linkis/metadatamanager/service/SqlParamsMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.linkis.metadatamanager.service;
+
+import org.apache.linkis.common.conf.CommonVars;
+
+public class SqlParamsMapper {
+
+    public static final CommonVars<String> PARAM_SQL_HOST =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.host", "host");
+
+    public static final CommonVars<String> PARAM_SQL_PORT =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.port", "port");
+
+    public static final CommonVars<String> PARAM_SQL_USERNAME =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.username", "username");
+
+    public static final CommonVars<String> PARAM_SQL_PASSWORD =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.password", "password");
+
+    public static final CommonVars<String> PARAM_SQL_EXTRA_PARAMS =
+            CommonVars.apply("wds.linkis.server.mdm.service.sql.params", "params");
+}

--- a/linkis-public-enhancements/linkis-datasource/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/pom.xml
@@ -37,5 +37,6 @@
         <module>linkis-metadata-manager/service/elasticsearch</module>
         <module>linkis-metadata-manager/service/hive</module>
         <module>linkis-metadata-manager/service/kafka</module>
+        <module>linkis-metadata-manager/service/mysql</module>
     </modules>
 </project>


### PR DESCRIPTION
module:linkis-metadata-manager-service-mysql
issue:https://github.com/apache/incubator-linkis/issues/1372
### What is the purpose of the change
Add Module linkis-metadata-manager-service-mysql

### Brief change log
(for example:)
- Define How To Connect Mysql to Get Meta Data;
- Define the Service Metadata For Mysql;

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)