### PR TITLE
create resultset path in install to fix bug 1314

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis-cg-entrance.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis-cg-entrance.properties
@@ -18,6 +18,6 @@
 wds.linkis.server.restful.scan.packages=org.apache.linkis.entrance.restful
 wds.linkis.server.socket.mode=false
 #wds.linkis.entrance.config.log.path=hdfs:///tmp/linkis/
-#wds.linkis.resultSet.store.path=hdfs:///tmp/linkis
+wds.linkis.resultSet.store.path=hdfs:///tmp/linkis
 ##Spring
 spring.server.port=9104

--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -189,8 +189,8 @@ isSuccess "create  $WORKSPACE_USER_ROOT_PATH directory"
          sudo chmod -R 775 $localRootDir/$deployUser
    elif [[ $RESULT_SET_ROOT_PATH == hdfs://* ]];then
      localRootDir=${RESULT_SET_ROOT_PATH#hdfs://}
-         hdfs dfs -mkdir -p $localRootDir/$deployUser
-
+         hdfs dfs -mkdir -p $localRootDir
+         hdfs dfs -chmod 775 $localRootDir
    else
      echo "does not support $RESULT_SET_ROOT_PATH filesystem types"
    fi
@@ -373,6 +373,10 @@ entrance_conf=$LINKIS_HOME/conf/linkis-cg-entrance.properties
 if [ "$ENTRANCE_PORT" != "" ]
 then
   sed -i ${txt}  "s#spring.server.port.*#spring.server.port=$ENTRANCE_PORT#g" $entrance_conf
+fi
+if [ "$RESULT_SET_ROOT_PATH" != "" ]
+then
+  sed -i ${txt}  "s#wds.linkis.resultSet.store.path.*wds.linkis.resultSet.store.path=$RESULT_SET_ROOT_PATH#g" $entrance_conf
 fi
 
 publicservice_conf=$LINKIS_HOME/conf/linkis-ps-publicservice.properties

--- a/assembly-combined-package/deploy-config/linkis-env.sh
+++ b/assembly-combined-package/deploy-config/linkis-env.sh
@@ -43,7 +43,7 @@ ENGINECONN_ROOT_PATH=/appcom/tmp
 #ENTRANCE_CONFIG_LOG_PATH=hdfs:///tmp/linkis/
 
 ### Path to store job ResultSet:file or hdfs path
-#RESULT_SET_ROOT_PATH=hdfs:///tmp/linkis ##hdfs:// required
+RESULT_SET_ROOT_PATH=hdfs:///tmp/linkis ##hdfs:// required
 
 ### Provide the DB information of Hive metadata database.
 ### Attention! If there are special characters like "&", they need to be enclosed in quotation marks.


### PR DESCRIPTION
### What is the purpose of the change
fix the issue 1314 which is a bug, create the resultset path in install script to make sure all dss users can access this path. 

### Brief change log
(for example:)
- adjust the logic of creating resultset path in install script
- make the resultset path in linkis-cg-entrance.properties to be required 

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes / no) no
- Anything that affects deployment: (yes / no / don't know) no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes / no) no

### Documentation
- Does this pull request introduce a new feature? (yes / no)  no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)