### PR TITLE
Reduce the maximum idle time of engine resources

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/log4j2.xml
+++ b/assembly-combined-package/assembly-combined/conf/log4j2.xml
@@ -21,7 +21,10 @@
         <RollingFile name="RollingFile" append="false" fileName="${env:LINKIS_LOG_DIR}/${sys:serviceName}.log"
                      filePattern="${env:LINKIS_LOG_DIR}/$${date:yyyy-MM}/${sys:serviceName}/linkis-log-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-40t] %c{1.} (%L) [%M] - %msg%xEx%n"/>
-            <SizeBasedTriggeringPolicy size="100MB"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1 hour" />
+                <SizeBasedTriggeringPolicy size="100MB"/>
+            </Policies>
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
     </appenders>

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/conf/AccessibleExecutorConfiguration.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/conf/AccessibleExecutorConfiguration.scala
@@ -35,7 +35,7 @@ object AccessibleExecutorConfiguration {
   val ENGINECONN_LOG_SEND_SIZE = CommonVars[Int]("wds.linkis.engineconn.log.send.cache.size", 5)
 
 
-  val ENGINECONN_MAX_FREE_TIME = CommonVars("wds.linkis.engineconn.max.free.time", new TimeType("1h"))
+  val ENGINECONN_MAX_FREE_TIME = CommonVars("wds.linkis.engineconn.max.free.time", new TimeType("0.5h"))
 
   val ENGINECONN_LOCK_CHECK_INTERVAL = CommonVars("wds.linkis.engineconn.lock.free.interval", new TimeType("3m"))
 


### PR DESCRIPTION
### Problem Description

The maximum idle time of engine resources is relatively long. In the multi-user scenario, the competition pressure of engine resources is large and the waiting time is long.

### Description

Reduce the maximum idle time of engine resources

### Use case

_No response_

### solutions

Reduce the maximum idle time of engine resources from 1hour to 0.5hour.

### Anything else

_No response_