### PR TITLE
Add  Different Kinds Of Request Action For Linkis DataSource Client

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/CreateDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/CreateDataSourceAction.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.httpclient.dws.DWSHttpClient
+import org.apache.linkis.httpclient.request.POSTAction
+
+import java.util
+import scala.collection.JavaConverters._
+
+class CreateDataSourceAction extends POSTAction with DataSourceAction{
+  override def getRequestPayload: String = DWSHttpClient.jacksonJson.writeValueAsString(getRequestPayloads)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "info", "json")
+}
+object CreateDataSourceAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[CreateDataSourceAction]() {
+    private var user: String = _
+    private var payload: util.Map[String, Any] = new util.HashMap[String, Any]()
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def addRequestPayload(key: String, value: Any): Builder = {
+      if (value != null) this.payload.put(key, value)
+      this
+    }
+
+    def addRequestPayloads(map: util.Map[String, Any]): Builder = {
+      this.synchronized(this.payload = map)
+      this
+    }
+
+    def build(): CreateDataSourceAction = {
+      val action = new CreateDataSourceAction
+      action.setUser(user)
+      this.payload.asScala.foreach(k => {
+        action.addRequestPayload(k._1, k._2)
+      })
+      action
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DataSourceAction.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.httpclient.dws.request.DWSHttpAction
+
+trait DataSourceAction extends DWSHttpAction with org.apache.linkis.httpclient.request.UserAction

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DataSourceTestConnectAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DataSourceTestConnectAction.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.dws.DWSHttpClient
+import org.apache.linkis.httpclient.request.PutAction
+
+
+class DataSourceTestConnectAction private() extends PutAction with DataSourceAction {
+  private var user: String = _
+
+  private var dataSourceId: String = _
+
+  private var version: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, dataSourceId, version, "op", "connect")
+
+  override def getRequestPayload: String = DWSHttpClient.jacksonJson.writeValueAsString(getRequestPayloads)
+}
+object DataSourceTestConnectAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[DataSourceTestConnectAction]() {
+    private var user: String = _
+    private var dataSourceId: String = _
+    private var version: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: String): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setVersion(version: String): Builder = {
+      this.version = version
+      this
+    }
+
+    def build(): DataSourceTestConnectAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(version == null) throw new DataSourceClientBuilderException("version is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val action = new DataSourceTestConnectAction()
+      action.dataSourceId = dataSourceId
+      action.version = version
+      action.user = user
+
+      action
+    }
+  }
+}
+
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DeleteDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DeleteDataSourceAction.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.DeleteAction
+
+
+class DeleteDataSourceAction extends DeleteAction with DataSourceAction  {
+  private var user: String = _
+
+  private var resourceId: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "info", resourceId)
+}
+object DeleteDataSourceAction{
+  def builder(): Builder = new Builder
+  class Builder private[DeleteDataSourceAction]() {
+    private var user: String = _
+    private var resourceId: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setResourceId(resourceId: String): Builder = {
+      this.resourceId = resourceId
+      this
+    }
+
+    def builder(): DeleteDataSourceAction = {
+      if (user == null) throw new DataSourceClientBuilderException("user is needed!")
+      if(resourceId == null) throw new DataSourceClientBuilderException("resourceId is needed!")
+
+      val action = new DeleteDataSourceAction
+      action.user = user
+      action.resourceId = resourceId
+      action
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/ExpireDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/ExpireDataSourceAction.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.PutAction
+
+class ExpireDataSourceAction extends PutAction with DataSourceAction {
+  override def getRequestPayload: String = ""
+
+  private var user: String = _
+
+  private var dataSourceId: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "info", dataSourceId, "expire")
+}
+object ExpireDataSourceAction{
+  def builder(): Builder = new Builder
+  class Builder private[ExpireDataSourceAction]() {
+    private var user: String = _
+    private var dataSourceId: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: String): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+    def build(): ExpireDataSourceAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val action = new ExpireDataSourceAction()
+      action.dataSourceId = dataSourceId
+      action.user = user
+      action
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetAllDataSourceTypesAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetAllDataSourceTypesAction.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.httpclient.request.GetAction
+
+class GetAllDataSourceTypesAction extends GetAction with DataSourceAction {
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "type", "all")
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+object GetAllDataSourceTypesAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[GetAllDataSourceTypesAction]() {
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def build(): GetAllDataSourceTypesAction = {
+      val action = new GetAllDataSourceTypesAction
+      action.setUser(user)
+
+      action
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetConnectParamsByDataSourceIdAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetConnectParamsByDataSourceIdAction.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class GetConnectParamsByDataSourceIdAction extends GetAction with DataSourceAction {
+  private var dataSourceId: Long = _
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, dataSourceId.toString, "connect_params")
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+
+object GetConnectParamsByDataSourceIdAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[GetConnectParamsByDataSourceIdAction]() {
+    private var dataSourceId: Long = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): GetConnectParamsByDataSourceIdAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val getConnectParamsByDataSourceIdAction = new GetConnectParamsByDataSourceIdAction
+      getConnectParamsByDataSourceIdAction.dataSourceId = this.dataSourceId
+      getConnectParamsByDataSourceIdAction.setParameter("system", system)
+      getConnectParamsByDataSourceIdAction.setUser(user)
+      getConnectParamsByDataSourceIdAction
+    }
+  }
+
+}
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetConnectParamsByDataSourceNameAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetConnectParamsByDataSourceNameAction.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.httpclient.request.GetAction
+/**
+  * Get version parameters from data source
+ */
+class GetConnectParamsByDataSourceNameAction extends GetAction with DataSourceAction{
+  private var dataSourceName: String = _
+
+  private var user: String = _
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "name", dataSourceName, "connect_params")
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = user
+}
+
+object GetConnectParamsByDataSourceNameAction{
+  def builder(): Builder = new Builder
+
+  class Builder private[GetConnectParamsByDataSourceNameAction]() {
+    private var dataSourceName: String = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceName(dataSourceName: String): Builder = {
+      this.dataSourceName = dataSourceName
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): GetConnectParamsByDataSourceNameAction = {
+      if (dataSourceName == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+      // Use URIEncoder to encode the datSourceName
+      var requestDataSourceName = this.dataSourceName
+      try {
+        requestDataSourceName = URLEncoder.encode(dataSourceName, StandardCharsets.UTF_8.name())
+      } catch {
+        case e: Exception =>
+          throw new DataSourceClientBuilderException(s"Cannot encode the name of data source:[$dataSourceName] for request", e)
+      }
+      val getConnectParamsByDataSourceNameAction = new GetConnectParamsByDataSourceNameAction
+      getConnectParamsByDataSourceNameAction.dataSourceName = requestDataSourceName
+      getConnectParamsByDataSourceNameAction.setParameter("system", system)
+      getConnectParamsByDataSourceNameAction.setUser(user)
+      getConnectParamsByDataSourceNameAction
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetDataSourceVersionsAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetDataSourceVersionsAction.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+class GetDataSourceVersionsAction extends GetAction with DataSourceAction {
+  private var user: String = _
+  private var resourceId: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, resourceId, "versions")
+}
+object GetDataSourceVersionsAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[GetDataSourceVersionsAction]() {
+    private var user: String = _
+    private var resourceId: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setResourceId(resourceId: String): Builder = {
+      this.resourceId = resourceId
+      this
+    }
+
+    def build(): GetDataSourceVersionsAction = {
+      if (resourceId == null) throw new DataSourceClientBuilderException("resourceId is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val action = new GetDataSourceVersionsAction
+      action.user = user
+      action.resourceId = resourceId
+
+      action
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetInfoByDataSourceIdAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetInfoByDataSourceIdAction.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class GetInfoByDataSourceIdAction extends GetAction with DataSourceAction {
+  private var dataSourceId: Long = _
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "info", dataSourceId.toString)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+object GetInfoByDataSourceIdAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[GetInfoByDataSourceIdAction]() {
+    private var dataSourceId: Long = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): GetInfoByDataSourceIdAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val getInfoByDataSourceIdAction = new GetInfoByDataSourceIdAction
+      getInfoByDataSourceIdAction.dataSourceId = this.dataSourceId
+      getInfoByDataSourceIdAction.setParameter("system", system)
+      getInfoByDataSourceIdAction.setUser(user)
+      getInfoByDataSourceIdAction
+    }
+  }
+
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetKeyTypeDatasourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetKeyTypeDatasourceAction.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class GetKeyTypeDatasourceAction extends GetAction with DataSourceAction{
+  private var dataSourceTypeId: Long = _
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "key_define", "type", dataSourceTypeId.toString)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+object GetKeyTypeDatasourceAction{
+  def builder(): Builder = new Builder
+
+  class Builder private[GetKeyTypeDatasourceAction]() {
+    private var dataSourceTypeId: Long = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceTypeId(dataSourceTypeId: Long): Builder = {
+      this.dataSourceTypeId = dataSourceTypeId
+      this
+    }
+
+    def build(): GetKeyTypeDatasourceAction = {
+      if (user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val getKeyTypeDatasourceAction = new GetKeyTypeDatasourceAction
+      getKeyTypeDatasourceAction.dataSourceTypeId = this.dataSourceTypeId
+      getKeyTypeDatasourceAction.setUser(user)
+      getKeyTypeDatasourceAction
+    }
+  }
+}
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetColumnsAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetColumnsAction.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class MetadataGetColumnsAction extends GetAction with DataSourceAction {
+  private var dataSourceId: Long = _
+  private var database: String = _
+  private var table: String = _
+
+  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "columns", dataSourceId.toString, "db", database, "table", table)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+
+object MetadataGetColumnsAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[MetadataGetColumnsAction]() {
+    private var dataSourceId: Long = _
+    private var database: String = _
+    private var table: String = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setDatabase(database: String): Builder = {
+      this.database = database
+      this
+    }
+
+    def setTable(table: String): Builder = {
+      this.table = table
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): MetadataGetColumnsAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(database == null) throw new DataSourceClientBuilderException("database is needed!")
+      if(table == null) throw new DataSourceClientBuilderException("table is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+
+      val metadataGetColumnsAction = new MetadataGetColumnsAction
+      metadataGetColumnsAction.dataSourceId = this.dataSourceId
+      metadataGetColumnsAction.database = this.database
+      metadataGetColumnsAction.table = this.table
+      metadataGetColumnsAction.setParameter("system", system)
+      metadataGetColumnsAction.setUser(user)
+      metadataGetColumnsAction
+    }
+  }
+
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetDatabasesAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetDatabasesAction.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class MetadataGetDatabasesAction extends GetAction with DataSourceAction {
+  private var dataSourceId: Long = _
+
+  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "dbs", dataSourceId.toString)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+object MetadataGetDatabasesAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[MetadataGetDatabasesAction]() {
+    private var dataSourceId: Long = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): MetadataGetDatabasesAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val metadataGetDatabasesAction = new MetadataGetDatabasesAction
+      metadataGetDatabasesAction.dataSourceId = this.dataSourceId
+      metadataGetDatabasesAction.setParameter("system", system)
+      metadataGetDatabasesAction.setUser(user)
+      metadataGetDatabasesAction
+    }
+  }
+
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetPartitionsAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetPartitionsAction.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class MetadataGetPartitionsAction extends GetAction with DataSourceAction {
+  private var dataSourceId: String = _
+  private var database: String = _
+  private var table: String = _
+
+  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "partitions", dataSourceId, "db", database, "table", table)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+
+object MetadataGetPartitionsAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[MetadataGetPartitionsAction]() {
+    private var dataSourceId: String = _
+    private var database: String = _
+    private var table: String = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: String): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setDatabase(database: String): Builder = {
+      this.database = database
+      this
+    }
+
+    def setTable(table: String): Builder = {
+      this.table = table
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): MetadataGetPartitionsAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(database == null) throw new DataSourceClientBuilderException("database is needed!")
+      if(table == null) throw new DataSourceClientBuilderException("table is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+
+      val metadataGetPartitionsAction = new MetadataGetPartitionsAction
+      metadataGetPartitionsAction.dataSourceId = this.dataSourceId
+      metadataGetPartitionsAction.database = this.database
+      metadataGetPartitionsAction.table = this.table
+      metadataGetPartitionsAction.setParameter("system", system)
+      metadataGetPartitionsAction.setUser(user)
+      metadataGetPartitionsAction
+    }
+  }
+
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetTablePropsAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetTablePropsAction.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class MetadataGetTablePropsAction extends GetAction with DataSourceAction {
+  private var dataSourceId: Long = _
+  private var database: String = _
+  private var table: String = _
+
+  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "props", dataSourceId.toString, "db", database, "table", table)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+object MetadataGetTablePropsAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[MetadataGetTablePropsAction]() {
+    private var dataSourceId: Long = _
+    private var database: String = _
+    private var table: String = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setDatabase(database: String): Builder = {
+      this.database = database
+      this
+    }
+
+    def setTable(table: String): Builder = {
+      this.table = table
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): MetadataGetTablePropsAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(database == null) throw new DataSourceClientBuilderException("database is needed!")
+      if(table == null) throw new DataSourceClientBuilderException("table is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val metadataGetTablePropsAction = new MetadataGetTablePropsAction
+      metadataGetTablePropsAction.dataSourceId = this.dataSourceId
+      metadataGetTablePropsAction.database = this.database
+      metadataGetTablePropsAction.table = this.table
+      metadataGetTablePropsAction.setParameter("system", system)
+      metadataGetTablePropsAction.setUser(user)
+      metadataGetTablePropsAction
+    }
+  }
+
+}
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetTablesAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetTablesAction.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class MetadataGetTablesAction extends GetAction with DataSourceAction {
+  private var dataSourceId: Long = _
+  private var database: String = _
+
+  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "tables", dataSourceId.toString, "db", database)
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+object MetadataGetTablesAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[MetadataGetTablesAction]() {
+    private var dataSourceId: Long = _
+    private var database: String = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setDatabase(database: String): Builder = {
+      this.database = database
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): MetadataGetTablesAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(database == null) throw new DataSourceClientBuilderException("database is needed!")
+      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val metadataGetTablesAction = new MetadataGetTablesAction
+      metadataGetTablesAction.dataSourceId = this.dataSourceId
+      metadataGetTablesAction.database = this.database
+      metadataGetTablesAction.setParameter("system", system)
+      metadataGetTablesAction.setUser(user)
+      metadataGetTablesAction
+    }
+  }
+
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/PublishDataSourceVersionAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/PublishDataSourceVersionAction.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.dws.DWSHttpClient
+import org.apache.linkis.httpclient.request.POSTAction
+
+
+class PublishDataSourceVersionAction extends POSTAction with DataSourceAction{
+  override def getRequestPayload: String = DWSHttpClient.jacksonJson.writeValueAsString(getRequestPayloads)
+  private var user: String = _
+  private var dataSourceId: String = _
+  private var versionId: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "publish", dataSourceId, versionId)
+}
+object PublishDataSourceVersionAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[PublishDataSourceVersionAction]() {
+    private var user: String = _
+    private var dataSourceId: String = _
+    private var versionId: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: String): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def setVersion(versionId: String): Builder = {
+      this.versionId = versionId
+      this
+    }
+
+    def build(): PublishDataSourceVersionAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(versionId == null) throw new DataSourceClientBuilderException("versionId is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val action = new PublishDataSourceVersionAction()
+      action.dataSourceId = dataSourceId
+      action.versionId = versionId
+      action.user = user
+
+      action
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/QueryDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/QueryDataSourceAction.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class QueryDataSourceAction extends GetAction with DataSourceAction{
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "info")
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+object QueryDataSourceAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[QueryDataSourceAction]() {
+    private var system: String = _
+    private var name: String = _
+    private var typeId: Long = _
+    private var identifies: String = _
+    private var currentPage: Integer = _
+    private var pageSize: Integer = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def setName(name: String): Builder = {
+      this.name = name
+      this
+    }
+
+    def setTypeId(typeId: Long): Builder = {
+      this.typeId = typeId
+      this
+    }
+
+    def setIdentifies(identifies: String): Builder = {
+      this.identifies = identifies
+      this
+    }
+
+    def setCurrentPage(currentPage: Integer): Builder = {
+      this.currentPage = currentPage
+      this
+    }
+
+    def setPageSize(pageSize: Integer): Builder = {
+      this.pageSize = pageSize
+      this
+    }
+
+    def build(): QueryDataSourceAction = {
+      if (system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if(name == null) throw new DataSourceClientBuilderException("name is needed!")
+      if(typeId == null) throw new DataSourceClientBuilderException("typeId is needed!")
+      if(identifies == null) throw new DataSourceClientBuilderException("identifies is needed!")
+      if(currentPage == null) throw new DataSourceClientBuilderException("currentPage is needed!")
+      if(pageSize == null) throw new DataSourceClientBuilderException("pageSize is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val queryDataSourceAction = new QueryDataSourceAction
+      queryDataSourceAction.setParameter("system", system)
+      queryDataSourceAction.setParameter("name", name)
+      queryDataSourceAction.setParameter("typeId", typeId)
+      queryDataSourceAction.setParameter("identifies", identifies)
+      queryDataSourceAction.setParameter("currentPage", currentPage)
+      queryDataSourceAction.setParameter("pageSize", pageSize)
+      queryDataSourceAction.setUser(user)
+
+      queryDataSourceAction
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/QueryDataSourceEnvAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/QueryDataSourceEnvAction.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+
+class QueryDataSourceEnvAction extends GetAction with DataSourceAction{
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "env")
+
+  private var user: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+}
+
+
+object QueryDataSourceEnvAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[QueryDataSourceEnvAction]() {
+    private var name: String = _
+    private var typeId: Long = _
+    private var currentPage: Integer = _
+    private var pageSize: Integer = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setName(name: String): Builder = {
+      this.name = name
+      this
+    }
+
+    def setTypeId(typeId: Long): Builder = {
+      this.typeId = typeId
+      this
+    }
+
+    def setCurrentPage(currentPage: Integer): Builder = {
+      this.currentPage = currentPage
+      this
+    }
+
+    def setPageSize(pageSize: Integer): Builder = {
+      this.pageSize = pageSize
+      this
+    }
+
+    def build(): QueryDataSourceEnvAction = {
+      if (name == null) throw new DataSourceClientBuilderException("name is needed!")
+      if(typeId == null) throw new DataSourceClientBuilderException("typeId is needed!")
+      if(currentPage == null) throw new DataSourceClientBuilderException("currentPage is needed!")
+      if(pageSize == null) throw new DataSourceClientBuilderException("pageSize is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+
+      val queryDataSourceEnvAction = new QueryDataSourceEnvAction
+      queryDataSourceEnvAction.setParameter("name", name)
+      queryDataSourceEnvAction.setParameter("typeId", typeId)
+      queryDataSourceEnvAction.setParameter("currentPage", currentPage)
+      queryDataSourceEnvAction.setParameter("pageSize", pageSize)
+      queryDataSourceEnvAction.setUser(user)
+
+      queryDataSourceEnvAction
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceAction.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.dws.DWSHttpClient
+import org.apache.linkis.httpclient.request.PutAction
+
+import java.util
+import scala.collection.JavaConverters._
+
+class UpdateDataSourceAction extends PutAction with DataSourceAction{
+  override def getRequestPayload: String = DWSHttpClient.jacksonJson.writeValueAsString(getRequestPayloads)
+
+  private var user: String = _
+  private var dataSourceId: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "info", dataSourceId, "json")
+}
+object UpdateDataSourceAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[UpdateDataSourceAction]() {
+    private var user: String = _
+    private var dataSourceId: String = _
+    private var payload: util.Map[String, Any] = new util.HashMap[String, Any]
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: String): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def addRequestPayload(key: String, value: Any): Builder = {
+      if (value != null) this.payload.put(key, value)
+      this
+    }
+
+    def addRequestPayloads(map: util.Map[String, Any]): Builder = {
+      this.synchronized(this.payload = map)
+      this
+    }
+
+    def build(): UpdateDataSourceAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val action = new UpdateDataSourceAction()
+      action.dataSourceId = dataSourceId
+      action.user = user
+
+      this.payload.asScala.foreach(k => {
+        action.addRequestPayload(k._1, k._2)
+      })
+      action
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceParameterAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceParameterAction.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.dws.DWSHttpClient
+import org.apache.linkis.httpclient.request.POSTAction
+
+import scala.collection.JavaConverters._
+import java.util
+
+class UpdateDataSourceParameterAction extends POSTAction with DataSourceAction {
+  override def getRequestPayload: String = DWSHttpClient.jacksonJson.writeValueAsString(getRequestPayloads)
+
+  private var user: String = _
+  private var dataSourceId: String = _
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "parameter", dataSourceId, "json")
+}
+object UpdateDataSourceParameterAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[UpdateDataSourceParameterAction]() {
+    private var user: String = _
+    private var dataSourceId: String = _
+    private var payload: util.Map[String, Any] = new util.HashMap[String, Any]
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceId(dataSourceId: String): Builder = {
+      this.dataSourceId = dataSourceId
+      this
+    }
+
+    def addRequestPayload(key: String, value: Any): Builder = {
+      if (value != null) this.payload.put(key, value)
+      this
+    }
+
+    def addRequestPayloads(map: util.Map[String, Any]): Builder = {
+      this.synchronized(this.payload = map)
+      this
+    }
+
+    def build(): UpdateDataSourceParameterAction = {
+      if (dataSourceId == null) throw new DataSourceClientBuilderException("dataSourceId is needed!")
+      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val action = new UpdateDataSourceParameterAction()
+      action.dataSourceId = dataSourceId
+      action.user = user
+      this.payload.asScala.foreach(k => {
+        action.addRequestPayload(k._1, k._2)
+      })
+
+      action
+    }
+  }
+}


### PR DESCRIPTION
issue:https://github.com/apache/incubator-linkis/issues/1433
### What is the purpose of the change
Add  Different Kinds Of Request Action For Linkis DataSource Client

### Brief change log
(for example:)
- Define the request for create database action;
- Define the request for test datasource conection action;
- Define the request for delete datasource action;
- Define the request for expire datasource action;
- Define the request for get all datasource types action;
- Define the request for get connect params by datasource id action;
- Define the request for get connect params by datasource name action;
- Define the request for get datasource versions action;
- Define the request for get info by datasource id action;
- Define the request for key types action;
- Define the request for get columns of metadata action;
- Define the request for get databases of metadata action;
- Define the request for get partitions of metadata action;
- Define the request for get table props of metadata action;
- Define the request for get tables of metadata action;
- Define the request for publish datasource versions action;
- Define the request for query datasource action;
- Define the request for query datasource env action;
- Define the request for update datasource action;
- Define the request for update datasource params action;
### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)

### Documentation
- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)