### PR TITLE
standardize the output message for better understanding

### DIFF
--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -415,4 +415,4 @@ fi
 
 
 echo "Congratulations! You have installed Linkis $LINKIS_VERSION successfully, please use sh $LINKIS_HOME/sbin/linkis-start-all.sh to start it!"
-echo "Your default account password is$deployUser/$defaultPwd"
+echo "Your default account/password is $deployUser/$defaultPwd"


### PR DESCRIPTION
### What is the purpose of the change
The raw output message
> Your default account password is$deployUser/$defaultPwd

will output the following message when install successfully.
> Your default account password isHadoop/sdf123dsf

This will mislead users to think `isHadoop` as account.

To resolve this, we can improve the message as
> Your default account/password is $deployUser/$defaultPwd

### Brief change log
import output message for better understanding

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: ( no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? ( not documented)