### PR TITLE
[fix #1538] Fix bug of "kill" method in linkis-entrance to support null param "taskID"

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
@@ -451,7 +451,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
     @RequestMapping(path = "/{id}/kill", method = RequestMethod.GET)
     public Message kill(
             @PathVariable("id") String id,
-            @RequestParam(value = "taskID", required = false) long taskID) {
+            @RequestParam(value = "taskID", required = false) Long taskID) {
         String realId = ZuulEntranceUtils.parseExecID(id)[3];
         // 通过jobid获取job,可能会由于job找不到而导致有looparray的报错,一旦报错的话，就可以将该任务直接置为Cancenlled
         Option<Job> job = Option.apply(null);

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/restful/EntranceRestfulRemote.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/restful/EntranceRestfulRemote.scala
@@ -53,7 +53,7 @@ trait EntranceRestfulRemote {
   def killJobs(req: HttpServletRequest, @RequestBody jsonNode: JsonNode): Message
 
   @RequestMapping(value = Array("/entrance/{id}/kill"), method = Array(RequestMethod.POST))
-  def kill(@PathVariable("id") id: String, @RequestParam("taskID") taskID:scala.Long): Message
+  def kill(@PathVariable("id") id: String, @RequestParam("taskID") taskID: java.lang.Long): Message
 
   @RequestMapping(value = Array("/entrance/{id}/pause"), method = Array(RequestMethod.POST))
   def pause(@PathVariable("id") id: String): Message


### PR DESCRIPTION

### What is the purpose of the change
close #1538

### Brief change log
- Change type of param "taskID" from scala.Lang to java.lang.Lang

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: ( no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)

### Documentation
- Does this pull request introduce a new feature? (no)