### PR TITLE
Add feature to fetch properties of partition in Hive datasource and fix connection problem

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetPartitionsResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetPartitionsResult.scala
@@ -17,13 +17,21 @@
 
 package org.apache.linkis.datasource.client.response
 
+import org.apache.linkis.httpclient.dws.DWSHttpClient
 import org.apache.linkis.httpclient.dws.annotation.DWSHttpMessageResult
 import org.apache.linkis.httpclient.dws.response.DWSResult
 import org.apache.linkis.metadatamanager.common.domain.MetaPartitionInfo
-
+import java.util
 import scala.beans.BeanProperty
 
 @DWSHttpMessageResult("/api/rest_j/v\\d+/metadatamanager/partitions/(\\S+)/db/(\\S+)/table/(\\S+)")
 class MetadataGetPartitionsResult extends DWSResult{
-  @BeanProperty var props: MetaPartitionInfo = _
+  @BeanProperty var props: util.Map[String, Any] = _
+  def getPartitionInfo: MetaPartitionInfo = {
+    this.props match {
+      case map : util.Map[String, Any] =>
+        DWSHttpClient.jacksonJson.convertValue(map, classOf[MetaPartitionInfo])
+      case _ => null
+    }
+  }
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/service/impl/DataSourceInfoServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/service/impl/DataSourceInfoServiceImpl.java
@@ -234,9 +234,12 @@ public class DataSourceInfoServiceImpl implements DataSourceInfoService {
     @Override
     public PageInfo<DataSource> queryDataSourceInfoPage(DataSourceVo dataSourceVo) {
         PageHelper.startPage(dataSourceVo.getCurrentPage(), dataSourceVo.getPageSize());
-        List<DataSource> queryList = dataSourceDao.selectByPageVo(dataSourceVo);
-        PageInfo<DataSource> pageInfo = new PageInfo<>(queryList);
-        return pageInfo;
+        try {
+            List<DataSource> queryList = dataSourceDao.selectByPageVo(dataSourceVo);
+            return new PageInfo<>(queryList);
+        } finally {
+            PageHelper.clearPage();
+        }
     }
 
     @Override

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
@@ -73,6 +73,8 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
                             assert notification.getValue() != null;
                             close(notification.getValue().getConnection());
                         });
+        // Clean up the req cache
+        reqCache.cleanUp();
     }
 
     @Override
@@ -98,9 +100,9 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
 
     @Override
     public MetaPartitionInfo getPartitions(
-            String operator, Map<String, Object> params, String database, String table) {
+            String operator, Map<String, Object> params, String database, String table, boolean traverse) {
         return this.getConnAndRun(
-                operator, params, conn -> this.queryPartitions(conn, database, table));
+                operator, params, conn -> this.queryPartitions(conn, database, table, traverse));
     }
 
     @Override
@@ -139,7 +141,7 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
      * @param table table
      * @return
      */
-    public MetaPartitionInfo queryPartitions(C connection, String database, String table) {
+    public MetaPartitionInfo queryPartitions(C connection, String database, String table, boolean traverse) {
         throw new WarnException(-1, "This method is no supported");
     }
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
@@ -112,6 +112,14 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
                 operator, params, conn -> this.queryColumns(conn, database, table));
     }
 
+    @Override
+    public  Map<String, String> getPartitionProps(
+            String operator, Map<String, Object> params, String database, String table,
+                                                  String partition) {
+        return this.getConnAndRun(
+                operator, params, conn -> this.queryPartitionProps(conn, database, table, partition));
+    }
+
     /**
      * Get database list by connection
      *
@@ -154,6 +162,18 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
      * @return
      */
     public List<MetaColumnInfo> queryColumns(C connection, String database, String table) {
+        throw new WarnException(-1, "This method is no supported");
+    }
+
+    /**
+     * Get the properties of partition
+     * @param connection
+     * @param database
+     * @param table
+     * @param partition
+     * @return
+     */
+    public Map<String, String> queryPartitionProps(C connection, String database, String table, String partition){
         throw new WarnException(-1, "This method is no supported");
     }
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/AbstractMetaService.java
@@ -100,7 +100,11 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
 
     @Override
     public MetaPartitionInfo getPartitions(
-            String operator, Map<String, Object> params, String database, String table, boolean traverse) {
+            String operator,
+            Map<String, Object> params,
+            String database,
+            String table,
+            boolean traverse) {
         return this.getConnAndRun(
                 operator, params, conn -> this.queryPartitions(conn, database, table, traverse));
     }
@@ -113,11 +117,16 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
     }
 
     @Override
-    public  Map<String, String> getPartitionProps(
-            String operator, Map<String, Object> params, String database, String table,
-                                                  String partition) {
+    public Map<String, String> getPartitionProps(
+            String operator,
+            Map<String, Object> params,
+            String database,
+            String table,
+            String partition) {
         return this.getConnAndRun(
-                operator, params, conn -> this.queryPartitionProps(conn, database, table, partition));
+                operator,
+                params,
+                conn -> this.queryPartitionProps(conn, database, table, partition));
     }
 
     /**
@@ -149,7 +158,8 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
      * @param table table
      * @return
      */
-    public MetaPartitionInfo queryPartitions(C connection, String database, String table, boolean traverse) {
+    public MetaPartitionInfo queryPartitions(
+            C connection, String database, String table, boolean traverse) {
         throw new WarnException(-1, "This method is no supported");
     }
 
@@ -167,13 +177,15 @@ public abstract class AbstractMetaService<C extends Closeable> implements Metada
 
     /**
      * Get the properties of partition
+     *
      * @param connection
      * @param database
      * @param table
      * @param partition
      * @return
      */
-    public Map<String, String> queryPartitionProps(C connection, String database, String table, String partition){
+    public Map<String, String> queryPartitionProps(
+            C connection, String database, String table, String partition) {
         throw new WarnException(-1, "This method is no supported");
     }
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
@@ -61,10 +61,15 @@ public interface MetadataDbService extends BaseMetadataService {
      * @return
      */
     MetaPartitionInfo getPartitions(
-            String operator, Map<String, Object> params, String database, String table, boolean traverse);
+            String operator,
+            Map<String, Object> params,
+            String database,
+            String table,
+            boolean traverse);
 
     /**
      * Get partition properties
+     *
      * @param operator operator
      * @param params params
      * @param database database
@@ -72,7 +77,11 @@ public interface MetadataDbService extends BaseMetadataService {
      * @return
      */
     Map<String, String> getPartitionProps(
-            String operator, Map<String, Object> params, String database, String table, String partition);
+            String operator,
+            Map<String, Object> params,
+            String database,
+            String table,
+            String partition);
     /**
      * Get all field information from table specified
      *

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
@@ -64,6 +64,16 @@ public interface MetadataDbService extends BaseMetadataService {
             String operator, Map<String, Object> params, String database, String table, boolean traverse);
 
     /**
+     * Get partition properties
+     * @param operator operator
+     * @param params params
+     * @param database database
+     * @param partition partition
+     * @return
+     */
+    Map<String, String> getPartitionProps(
+            String operator, Map<String, Object> params, String database, String table, String partition);
+    /**
      * Get all field information from table specified
      *
      * @param params

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/common/src/main/java/org/apache/linkis/metadatamanager/common/service/MetadataDbService.java
@@ -57,10 +57,11 @@ public interface MetadataDbService extends BaseMetadataService {
      * @param params params
      * @param database
      * @param table
+     * @param traverse if traverse to get all values, default: false
      * @return
      */
     MetaPartitionInfo getPartitions(
-            String operator, Map<String, Object> params, String database, String table);
+            String operator, Map<String, Object> params, String database, String table, boolean traverse);
 
     /**
      * Get all field information from table specified

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/restful/MetadataCoreRestful.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/restful/MetadataCoreRestful.java
@@ -142,6 +142,44 @@ public class MetadataCoreRestful {
     }
 
     @RequestMapping(
+            value = "/props/{data_source_id}/db/{database}/table/{table}/partition/{partition}",
+            method = RequestMethod.GET)
+    public Message getPartitionProps(
+            @PathVariable("data_source_id")String dataSourceId,
+            @PathVariable("database")String database,
+            @PathVariable("table") String table,
+            @PathVariable("partition") String partition,
+            @RequestParam("system")String system,
+            HttpServletRequest request) {
+        try{
+            if(StringUtils.isBlank(system)){
+                return Message.error("'system' is missing[缺少系统名]");
+            }
+            Map<String, String> partitionProps = metadataAppService.getPartitionPropsByDsId(
+                    dataSourceId,
+                    database,
+                    table,
+                    partition,
+                    system,
+                    SecurityFilter.getLoginUsername(request));
+            return Message.ok().data("props", partitionProps);
+        }catch(Exception e){
+            return errorToResponseMessage(
+                    "Fail to get partition properties[获取分区参数信息失败], id:["
+                            + dataSourceId +"]"
+                            + ", system:["
+                            + system
+                            + "], database:["
+                            + database
+                            + "], table:["
+                            + table
+                            + "], partition:["
+                            + partition + "]",
+                    e);
+        }
+    }
+
+    @RequestMapping(
             value = "/partitions/{data_source_id}/db/{database}/table/{table}",
             method = RequestMethod.GET)
     public Message getPartitions(

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/restful/MetadataCoreRestful.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/restful/MetadataCoreRestful.java
@@ -145,28 +145,30 @@ public class MetadataCoreRestful {
             value = "/props/{data_source_id}/db/{database}/table/{table}/partition/{partition}",
             method = RequestMethod.GET)
     public Message getPartitionProps(
-            @PathVariable("data_source_id")String dataSourceId,
-            @PathVariable("database")String database,
+            @PathVariable("data_source_id") String dataSourceId,
+            @PathVariable("database") String database,
             @PathVariable("table") String table,
             @PathVariable("partition") String partition,
-            @RequestParam("system")String system,
+            @RequestParam("system") String system,
             HttpServletRequest request) {
-        try{
-            if(StringUtils.isBlank(system)){
+        try {
+            if (StringUtils.isBlank(system)) {
                 return Message.error("'system' is missing[缺少系统名]");
             }
-            Map<String, String> partitionProps = metadataAppService.getPartitionPropsByDsId(
-                    dataSourceId,
-                    database,
-                    table,
-                    partition,
-                    system,
-                    SecurityFilter.getLoginUsername(request));
+            Map<String, String> partitionProps =
+                    metadataAppService.getPartitionPropsByDsId(
+                            dataSourceId,
+                            database,
+                            table,
+                            partition,
+                            system,
+                            SecurityFilter.getLoginUsername(request));
             return Message.ok().data("props", partitionProps);
-        }catch(Exception e){
+        } catch (Exception e) {
             return errorToResponseMessage(
                     "Fail to get partition properties[获取分区参数信息失败], id:["
-                            + dataSourceId +"]"
+                            + dataSourceId
+                            + "]"
                             + ", system:["
                             + system
                             + "], database:["
@@ -174,7 +176,8 @@ public class MetadataCoreRestful {
                             + "], table:["
                             + table
                             + "], partition:["
-                            + partition + "]",
+                            + partition
+                            + "]",
                     e);
         }
     }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/MetadataAppService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/MetadataAppService.java
@@ -54,6 +54,21 @@ public interface MetadataAppService {
             throws ErrorException;
 
     /**
+     *
+     * @param dataSourceId data source id
+     * @param database database
+     * @param table table
+     * @param partition partition
+     * @param system system
+     * @param userName userName
+     * @return
+     * @throws ErrorException
+     */
+    Map<String, String> getPartitionPropsByDsId(
+            String dataSourceId, String database, String table, String partition, String system, String userName)
+            throws ErrorException;
+
+    /**
      * @param dataSourceId data source id
      * @param database database
      * @param table table

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/MetadataAppService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/MetadataAppService.java
@@ -54,7 +54,6 @@ public interface MetadataAppService {
             throws ErrorException;
 
     /**
-     *
      * @param dataSourceId data source id
      * @param database database
      * @param table table
@@ -65,7 +64,12 @@ public interface MetadataAppService {
      * @throws ErrorException
      */
     Map<String, String> getPartitionPropsByDsId(
-            String dataSourceId, String database, String table, String partition, String system, String userName)
+            String dataSourceId,
+            String database,
+            String table,
+            String partition,
+            String system,
+            String userName)
             throws ErrorException;
 
     /**

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/impl/MetadataAppServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/impl/MetadataAppServiceImpl.java
@@ -108,14 +108,25 @@ public class MetadataAppServiceImpl implements MetadataAppService {
 
     @Override
     public Map<String, String> getPartitionPropsByDsId(
-            String dataSourceId, String database, String table, String partition, String system, String userName)
+            String dataSourceId,
+            String database,
+            String table,
+            String partition,
+            String system,
+            String userName)
             throws ErrorException {
         DsInfoResponse dsInfoResponse = reqToGetDataSourceInfo(dataSourceId, system, userName);
-        if (StringUtils.isNotBlank(dsInfoResponse.dsType())){
+        if (StringUtils.isNotBlank(dsInfoResponse.dsType())) {
             return invokeMetaMethod(
                     dsInfoResponse.dsType(),
                     "getPartitionProps",
-                    new Object[]{dsInfoResponse.creator(), dsInfoResponse.params(), database, table, partition},
+                    new Object[] {
+                        dsInfoResponse.creator(),
+                        dsInfoResponse.params(),
+                        database,
+                        table,
+                        partition
+                    },
                     Map.class);
         }
         return new HashMap<>();

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/impl/MetadataAppServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/src/main/java/org/apache/linkis/metadatamanager/server/service/impl/MetadataAppServiceImpl.java
@@ -107,6 +107,21 @@ public class MetadataAppServiceImpl implements MetadataAppService {
     }
 
     @Override
+    public Map<String, String> getPartitionPropsByDsId(
+            String dataSourceId, String database, String table, String partition, String system, String userName)
+            throws ErrorException {
+        DsInfoResponse dsInfoResponse = reqToGetDataSourceInfo(dataSourceId, system, userName);
+        if (StringUtils.isNotBlank(dsInfoResponse.dsType())){
+            return invokeMetaMethod(
+                    dsInfoResponse.dsType(),
+                    "getPartitionProps",
+                    new Object[]{dsInfoResponse.creator(), dsInfoResponse.params(), database, table, partition},
+                    Map.class);
+        }
+        return new HashMap<>();
+    }
+
+    @Override
     public Map<String, String> getTablePropsByDsId(
             String dataSourceId, String database, String table, String system, String userName)
             throws ErrorException {


### PR DESCRIPTION
### What is the purpose of the change
Supple the interface method of the MetadataDbService and fix related problems #1506

### Brief change log
-  Fix the deserialization problem in MetadataGetPartitionsResult.
-  Enable to fetch properties of partition in Hive datasource.
-  Clear connection cache in metadata service.
- 
### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment:  (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)