### PR TITLE
fix [Bug] The xml annotation of the Message object should be removed #1607

### DIFF
--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/Message.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/Message.scala
@@ -20,14 +20,12 @@ package org.apache.linkis.server
 import java.util
 
 import javax.servlet.http.HttpServletRequest
-import javax.xml.bind.annotation.XmlRootElement
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.slf4j.LoggerFactory
 import org.springframework.web.context.request.{RequestContextHolder, ServletRequestAttributes}
 
 
-@XmlRootElement(name = "message")
 class Message(private var method: String,
               private var status: Int = 0,          //-1 no login, 0 success, 1 error, 2 validate failed, 3 auth failed, 4 warning
               private var message: String,


### PR DESCRIPTION
What is the purpose of the change
fix [Bug] The xml annotation of the Message object should be removed #1607

Brief change log
change return type from xml to json

Verifying this change
(Please pick either of the following options)
This change is a trivial rework / code cleanup without any test coverage.

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
Anything that affects deployment: no
The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: no

Documentation
Does this pull request introduce a new feature? no