### PR TITLE
Init openLooKeng connection support

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~ 
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~ 
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+  
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>org.apache.linkis</groupId>
+        <version>1.1.0</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineplugin-openlookeng</artifactId>
+
+    <properties>
+        <openlookeng.version>1.5.0</openlookeng.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-computation-engineconn</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-storage</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- openLooKeng -->
+        <dependency>
+            <groupId>io.hetu.core</groupId>
+            <artifactId>presto-client</artifactId>
+            <version>${openlookeng.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.hetu.core</groupId>
+                    <artifactId>presto-spi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.hetu.core</groupId>
+                    <artifactId>hetu-transport</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.inject</groupId>
+                    <artifactId>guice</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.linkis</groupId>
+            <artifactId>linkis-rpc</artifactId>
+            <version>1.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+       <!-- <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-resource-group-managers</artifactId>
+            <version>${presto.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log-manager</artifactId>
+                    <groupId>com.facebook.airlift</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>-->
+
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.xml</include>
+                    <include>**/*.yml</include>
+                </includes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/assembly/distribution.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~ 
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~ 
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+  
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-engineplugin-openlookeng</id>
+    <formats>
+        <format>dir</format>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>openlookeng</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>/dist/v${openlookeng.version}/lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>false</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>linkis-engineconn.properties</include>
+                <include>log4j2-engineconn.xml</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>/dist/v${openlookeng.version}/conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}/target</directory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*doc.jar</exclude>
+            </excludes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>/plugin/${openlookeng.version}</outputDirectory>
+        </fileSet>
+
+    </fileSets>
+
+</assembly>
+

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/builder/OpenLooKengProcessECLaunchBuilder.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/builder/OpenLooKengProcessECLaunchBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.builder;
+
+import org.apache.linkis.manager.engineplugin.common.launch.process.JavaProcessEngineConnLaunchBuilder;
+import org.apache.linkis.manager.label.entity.engine.UserCreatorLabel;
+import org.apache.linkis.storage.utils.StorageConfiguration;
+
+public class OpenLooKengProcessECLaunchBuilder extends JavaProcessEngineConnLaunchBuilder {
+
+    @Override
+    public String getEngineStartUser(UserCreatorLabel label) {
+        return StorageConfiguration.HDFS_ROOT_USER().getValue();
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/conf/OpenLooKengConfiguration.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/conf/OpenLooKengConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.conf;
+
+import org.apache.linkis.common.conf.CommonVars;
+
+public class OpenLooKengConfiguration {
+
+    public static final CommonVars<Integer> OPENLOOKENG_CONCURRENT_LIMIT =
+            CommonVars.apply("linkis.openlookeng.engineconn.concurrent.limit", 100);
+    public static final CommonVars<Long> OPENLOOKENG_HTTP_CONNECT_TIME_OUT =
+            CommonVars.apply("linkis.openlookeng.http.connectTimeout", 60L);
+    public static final CommonVars<Long> OPENLOOKENG_HTTP_READ_TIME_OUT =
+            CommonVars.apply("linkis.openlookeng.http.readTimeout", 60L);
+    public static final CommonVars<Integer> ENGINE_DEFAULT_LIMIT =
+            CommonVars.apply("linkis.openlookeng.default.limit", 5000);
+    public static final CommonVars<String> OPENLOOKENG_URL =
+            CommonVars.apply("linkis.openlookeng.url", "http://127.0.0.1:8080");
+    public static final CommonVars<String> OPENLOOKENG_RESOURCE_CONFIG_PATH =
+            CommonVars.apply("linkis.openlookeng.resource.config", "");
+    public static final CommonVars<String> OPENLOOKENG_USER_NAME =
+            CommonVars.apply("linkis.openlookeng.username", "default");
+    public static final CommonVars<String> OPENLOOKENG_PASSWORD =
+            CommonVars.apply("linkis.openlookeng.password", "");
+    public static final CommonVars<String> OPENLOOKENG_CATALOG =
+            CommonVars.apply("linkis.openlookeng.catalog", "system");
+    public static final CommonVars<String> OPENLOOKENG_SCHEMA =
+            CommonVars.apply("linkis.openlookeng.schema", "");
+    public static final CommonVars<String> OPENLOOKENG_SOURCE =
+            CommonVars.apply("linkis.openlookeng.source", "global");
+    public static final CommonVars<String> OPENLOOKENG_REQUEST_MEMORY =
+            CommonVars.apply("openlookeng.session.query_max_total_memory", "8GB");
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/conf/OpenLooKengEngineConfCache.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/conf/OpenLooKengEngineConfCache.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.conf;
+
+import org.apache.linkis.common.conf.Configuration;
+import org.apache.linkis.governance.common.protocol.conf.RequestQueryEngineConfigWithGlobalConfig;
+import org.apache.linkis.governance.common.protocol.conf.ResponseQueryConfig;
+import org.apache.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.apache.linkis.manager.label.entity.engine.UserCreatorLabel;
+import org.apache.linkis.rpc.Sender;
+
+import java.util.Map;
+
+public class OpenLooKengEngineConfCache {
+
+    public static Map<String, String> getConfMap(
+            UserCreatorLabel userCreatorLabel, EngineTypeLabel engineTypeLabel) {
+        Sender sender =
+                Sender.getSender(
+                        Configuration.CLOUD_CONSOLE_CONFIGURATION_SPRING_APPLICATION_NAME()
+                                .getValue());
+        Object any =
+                sender.ask(
+                        new RequestQueryEngineConfigWithGlobalConfig(
+                                userCreatorLabel, engineTypeLabel, null));
+        if (any instanceof ResponseQueryConfig) {
+            return ((ResponseQueryConfig) any).getKeyAndValue();
+        }
+        return null;
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/exception/OpenLooKengClientException.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/exception/OpenLooKengClientException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.exception;
+
+import org.apache.linkis.common.exception.ErrorException;
+
+public class OpenLooKengClientException extends ErrorException {
+
+    public OpenLooKengClientException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/exception/OpenLooKengSourceGroupException.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/exception/OpenLooKengSourceGroupException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.exception;
+
+import org.apache.linkis.common.exception.ErrorException;
+
+public class OpenLooKengSourceGroupException extends ErrorException {
+
+    public OpenLooKengSourceGroupException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/exception/OpenLooKengStateInvalidException.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/exception/OpenLooKengStateInvalidException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.exception;
+
+import org.apache.linkis.common.exception.ErrorException;
+
+public class OpenLooKengStateInvalidException extends ErrorException {
+
+    public OpenLooKengStateInvalidException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/executor/OpenLooKengEngineConnExecutor.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/java/org/apache/linkis/engineplugin/openlookeng/executor/OpenLooKengEngineConnExecutor.java
@@ -1,0 +1,424 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.executor;
+
+import org.apache.linkis.common.io.MetaData;
+import org.apache.linkis.common.io.Record;
+import org.apache.linkis.common.io.resultset.ResultSetWriter;
+import org.apache.linkis.common.log.LogUtils;
+import org.apache.linkis.engineconn.common.conf.EngineConnConf;
+import org.apache.linkis.engineconn.common.conf.EngineConnConstant;
+import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask;
+import org.apache.linkis.engineconn.computation.executor.execute.ConcurrentComputationExecutor;
+import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext;
+import org.apache.linkis.engineconn.core.EngineConnObject;
+import org.apache.linkis.engineplugin.openlookeng.conf.OpenLooKengConfiguration;
+import org.apache.linkis.engineplugin.openlookeng.conf.OpenLooKengEngineConfCache;
+import org.apache.linkis.engineplugin.openlookeng.exception.OpenLooKengClientException;
+import org.apache.linkis.engineplugin.openlookeng.exception.OpenLooKengStateInvalidException;
+import org.apache.linkis.governance.common.paser.SQLCodeParser;
+import org.apache.linkis.manager.common.entity.resource.CommonNodeResource;
+import org.apache.linkis.manager.common.entity.resource.LoadResource;
+import org.apache.linkis.manager.common.entity.resource.NodeResource;
+import org.apache.linkis.manager.engineplugin.common.conf.EngineConnPluginConf;
+import org.apache.linkis.manager.label.entity.Label;
+import org.apache.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.apache.linkis.manager.label.entity.engine.UserCreatorLabel;
+import org.apache.linkis.manager.label.utils.LabelUtil;
+import org.apache.linkis.protocol.engine.JobProgressInfo;
+import org.apache.linkis.rpc.Sender;
+import org.apache.linkis.scheduler.executer.ErrorExecuteResponse;
+import org.apache.linkis.scheduler.executer.ExecuteResponse;
+import org.apache.linkis.scheduler.executer.SuccessExecuteResponse;
+import org.apache.linkis.storage.domain.DataType;
+import org.apache.linkis.storage.resultset.ResultSetFactory$;
+import org.apache.linkis.storage.resultset.table.TableMetaData;
+import org.apache.linkis.storage.resultset.table.TableRecord;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+
+import okhttp3.OkHttpClient;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.prestosql.client.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.linkis.engineplugin.openlookeng.conf.OpenLooKengConfiguration.OPENLOOKENG_HTTP_CONNECT_TIME_OUT;
+import static org.apache.linkis.engineplugin.openlookeng.conf.OpenLooKengConfiguration.OPENLOOKENG_HTTP_READ_TIME_OUT;
+
+public class OpenLooKengEngineConnExecutor extends ConcurrentComputationExecutor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenLooKengEngineConnExecutor.class);
+
+    private int id;
+
+    private OkHttpClient okHttpClient =
+            new OkHttpClient.Builder()
+                    .socketFactory(new SocketChannelSocketFactory())
+                    .connectTimeout(OPENLOOKENG_HTTP_CONNECT_TIME_OUT.getValue(), TimeUnit.SECONDS)
+                    .readTimeout(OPENLOOKENG_HTTP_READ_TIME_OUT.getValue(), TimeUnit.SECONDS)
+                    .build();
+
+    private List<Label<?>> executorLabels = new ArrayList<Label<?>>();
+
+    private Cache<String, ClientSession> clientSessionCache =
+            CacheBuilder.newBuilder()
+                    .expireAfterAccess(
+                            (Long) EngineConnConf.ENGINE_TASK_EXPIRE_TIME().getValue(),
+                            TimeUnit.MILLISECONDS)
+                    .maximumSize(EngineConnConstant.MAX_TASK_NUM())
+                    .build();
+
+    public OpenLooKengEngineConnExecutor(int outputPrintLimit, int id) {
+        super(outputPrintLimit);
+        this.id = id;
+    }
+
+    @Override
+    public void init() {
+        setCodeParser(new SQLCodeParser());
+        super.init();
+    }
+
+    @Override
+    public ExecuteResponse execute(EngineConnTask engineConnTask) {
+        List<Label<?>> labelList = Arrays.asList(engineConnTask.getLables());
+        UserCreatorLabel userCreatorLabel = LabelUtil.getUserCreatorLabel(labelList);
+        String user = userCreatorLabel.getUser();
+        EngineTypeLabel engineTypeLabel = LabelUtil.getEngineTypeLabel(labelList);
+        clientSessionCache.put(
+                engineConnTask.getTaskId(),
+                getClientSession(
+                        user,
+                        engineConnTask.getProperties(),
+                        OpenLooKengEngineConfCache.getConfMap(userCreatorLabel, engineTypeLabel)));
+        return super.execute(engineConnTask);
+    }
+
+    @Override
+    public ExecuteResponse executeLine(EngineExecutionContext engineExecutorContext, String code) {
+
+        String taskId = engineExecutorContext.getJobId().get();
+
+        ClientSession clientSession = clientSessionCache.getIfPresent(taskId);
+        StatementClient statement =
+                StatementClientFactory.newStatementClient(okHttpClient, clientSession, code);
+
+        initialStatusUpdates(taskId, engineExecutorContext, statement);
+
+        try {
+            if (statement.isRunning()
+                    || (statement.isFinished() && statement.finalStatusInfo().getError() == null)) {
+                queryOutput(taskId, engineExecutorContext, statement);
+            }
+
+            ErrorExecuteResponse errorResponse =
+                    verifyServerError(taskId, engineExecutorContext, statement);
+            if (errorResponse == null) {
+                // update session
+                clientSessionCache.put(taskId, updateSession(clientSession, statement));
+                return new SuccessExecuteResponse();
+            } else {
+                return errorResponse;
+            }
+        } catch (Exception e) {
+            return new ErrorExecuteResponse(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public ExecuteResponse executeCompletely(
+            EngineExecutionContext engineExecutorContext, String code, String completedLine) {
+        return null;
+    }
+
+    @Override
+    public float progress(String taskID) {
+        return 0;
+    }
+
+    @Override
+    public JobProgressInfo[] getProgressInfo(String taskID) {
+        return new JobProgressInfo[0];
+    }
+
+    @Override
+    public boolean supportCallBackLogs() {
+        return false;
+    }
+
+    @Override
+    public String getId() {
+        return Sender.getThisServiceInstance().getInstance() + this.id;
+    }
+
+    @Override
+    public int getConcurrentLimit() {
+        return OpenLooKengConfiguration.OPENLOOKENG_CONCURRENT_LIMIT.getValue();
+    }
+
+    @Override
+    public void killAll() {}
+
+    @Override
+    public List<Label<?>> getExecutorLabels() {
+        return executorLabels;
+    }
+
+    @Override
+    public void setExecutorLabels(List<Label<?>> labels) {
+        if (null != labels && !labels.isEmpty()) {
+            executorLabels.clear();
+            executorLabels.addAll(labels);
+        }
+    }
+
+    @Override
+    public NodeResource requestExpectedResource(NodeResource expectedResource) {
+        return null;
+    }
+
+    @Override
+    public NodeResource getCurrentNodeResource() {
+        Map<String, String> properties = EngineConnObject.getEngineCreationContext().getOptions();
+        if (properties.containsKey(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY().key())) {
+            String settingClientMemory =
+                    properties.get(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY().key());
+            if (!settingClientMemory.toLowerCase().endsWith("g")) {
+                properties.put(
+                        EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY().key(),
+                        settingClientMemory + "g");
+            }
+        }
+        CommonNodeResource resource = new CommonNodeResource();
+        LoadResource usedResource =
+                new LoadResource(
+                        EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY()
+                                .getValue(properties)
+                                .toLong(),
+                        (Integer)
+                                EngineConnPluginConf.JAVA_ENGINE_REQUEST_CORES()
+                                        .getValue(properties));
+        resource.setUsedResource(usedResource);
+        return resource;
+    }
+
+    private ClientSession getClientSession(
+            String user, Map<String, Object> taskParams, Map<String, String> cacheMap) {
+        Map<String, String> configMap = new HashMap<>();
+        if (null != cacheMap && !cacheMap.isEmpty()) {
+            configMap.putAll(cacheMap);
+        }
+
+        for (Map.Entry<String, Object> keyValue : taskParams.entrySet()) {
+            configMap.put(keyValue.getKey(), String.valueOf(keyValue.getValue()));
+        }
+
+        URI httpUri = URI.create(OpenLooKengConfiguration.OPENLOOKENG_URL.getValue(configMap));
+        String source = OpenLooKengConfiguration.OPENLOOKENG_SOURCE.getValue(configMap);
+        String catalog = OpenLooKengConfiguration.OPENLOOKENG_CATALOG.getValue(configMap);
+        String schema = OpenLooKengConfiguration.OPENLOOKENG_SCHEMA.getValue(configMap);
+
+        Map<String, String> properties = new HashMap<>();
+
+        for (Map.Entry<String, String> keyValue : configMap.entrySet()) {
+            if (keyValue.getKey().startsWith("presto.session.")) {
+                properties.put(
+                        keyValue.getKey().substring("presto.session.".length()),
+                        keyValue.getValue());
+            }
+        }
+
+        String clientInfo = "Linkis";
+        String transactionId = null;
+        Optional<String> traceToken = Optional.empty();
+        Set<String> clientTags = Collections.emptySet();
+        ZoneId timeZonId = TimeZone.getDefault().toZoneId();
+        Locale locale = Locale.getDefault();
+        Map<String, String> resourceEstimates = Collections.emptyMap();
+        Map<String, String> preparedStatements = Collections.emptyMap();
+        Map<String, ClientSelectedRole> roles = Collections.emptyMap();
+        Map<String, String> extraCredentials = Collections.emptyMap();
+
+        io.airlift.units.Duration clientRequestTimeout =
+                new io.airlift.units.Duration(0, TimeUnit.MILLISECONDS);
+
+        ClientSession session =
+                new ClientSession(
+                        httpUri,
+                        user,
+                        source,
+                        traceToken,
+                        clientTags,
+                        clientInfo,
+                        catalog,
+                        schema,
+                        "",
+                        timeZonId,
+                        locale,
+                        resourceEstimates,
+                        properties,
+                        preparedStatements,
+                        roles,
+                        extraCredentials,
+                        transactionId,
+                        clientRequestTimeout);
+        return session;
+    }
+
+    private void initialStatusUpdates(
+            String taskId,
+            EngineExecutionContext engineExecutorContext,
+            StatementClient statement) {
+        while (statement.isRunning()
+                && (statement.currentData().getData() == null
+                        || statement.currentStatusInfo().getUpdateType() != null)) {
+            engineExecutorContext.pushProgress(progress(taskId), getProgressInfo(taskId));
+            statement.advance();
+        }
+    }
+
+    private void queryOutput(
+            String taskId, EngineExecutionContext engineExecutorContext, StatementClient statement)
+            throws IOException {
+        int columnCount = 0;
+        int rows = 0;
+        ResultSetWriter<? extends MetaData, ? extends Record> resultSetWriter =
+                engineExecutorContext.createResultSetWriter(ResultSetFactory$.MODULE$.TABLE_TYPE());
+        try {
+            QueryStatusInfo results = null;
+            if (statement.isRunning()) {
+                results = statement.currentStatusInfo();
+            } else {
+                results = statement.finalStatusInfo();
+            }
+            if (results.getColumns() == null) {
+                throw new RuntimeException("openlookeng columns is null.");
+            }
+            org.apache.linkis.storage.domain.Column[] columns =
+                    results.getColumns().stream()
+                            .map(
+                                    column ->
+                                            new org.apache.linkis.storage.domain.Column(
+                                                    column.getName(),
+                                                    DataType.toDataType(column.getType()),
+                                                    ""))
+                            .toArray(org.apache.linkis.storage.domain.Column[]::new);
+            columnCount = columns.length;
+            resultSetWriter.addMetaData(new TableMetaData(columns));
+            while (statement.isRunning()) {
+                Iterable<List<Object>> data = statement.currentData().getData();
+                if (data != null) {
+                    for (List<Object> row : data) {
+                        Object[] rowArray = row.stream().map(String::valueOf).toArray();
+                        resultSetWriter.addRecord(new TableRecord(rowArray));
+                        rows += 1;
+                    }
+                }
+                engineExecutorContext.pushProgress(progress(taskId), getProgressInfo(taskId));
+                statement.advance();
+            }
+            LOG.warn("Fetched {} col(s) : {} row(s) in openlookeng", columnCount, rows);
+            engineExecutorContext.sendResultSet(resultSetWriter);
+        } finally {
+            IOUtils.closeQuietly(resultSetWriter);
+        }
+    }
+
+    // check error
+    private ErrorExecuteResponse verifyServerError(
+            String taskId, EngineExecutionContext engineExecutorContext, StatementClient statement)
+            throws OpenLooKengClientException, OpenLooKengStateInvalidException {
+        engineExecutorContext.pushProgress(progress(taskId), getProgressInfo(taskId));
+        if (statement.isFinished()) {
+            QueryStatusInfo info = statement.finalStatusInfo();
+            if (info.getError() != null) {
+                QueryError error = Objects.requireNonNull(info.getError());
+                String message =
+                        "openlookeng execute failed (#" + info.getId() + "):" + error.getMessage();
+                Throwable cause = null;
+                if (error.getFailureInfo() != null) {
+                    cause = error.getFailureInfo().toException();
+                }
+                engineExecutorContext.appendStdout(
+                        LogUtils.generateERROR(ExceptionUtils.getFullStackTrace(cause)));
+                return new ErrorExecuteResponse(ExceptionUtils.getMessage(cause), cause);
+            }
+        } else if (statement.isClientAborted()) {
+            LOG.warn("openlookeng statement is killed.");
+        } else if (statement.isClientError()) {
+            throw new OpenLooKengClientException(60001, "openlookeng client error.");
+        } else {
+            throw new OpenLooKengStateInvalidException(
+                    60002, "openlookeng status error. Statement is not finished.");
+        }
+        return null;
+    }
+
+    private ClientSession updateSession(ClientSession clientSession, StatementClient statement) {
+        ClientSession newSession = clientSession;
+        // update catalog and schema if present
+        if (statement.getSetCatalog().isPresent() || statement.getSetSchema().isPresent()) {
+            newSession =
+                    ClientSession.builder(newSession)
+                            .withCatalog(statement.getSetCatalog().orElse(newSession.getCatalog()))
+                            .withSchema(statement.getSetSchema().orElse(newSession.getSchema()))
+                            .build();
+        }
+
+        // update transaction ID if necessary
+        if (statement.isClearTransactionId())
+            newSession = ClientSession.stripTransactionId(newSession);
+
+        ClientSession.Builder builder = ClientSession.builder(newSession);
+
+        if (statement.getStartedTransactionId() != null)
+            builder = builder.withTransactionId(statement.getStartedTransactionId());
+
+        // update session properties if present
+        if (!statement.getSetSessionProperties().isEmpty()
+                || !statement.getResetSessionProperties().isEmpty()) {
+            Map<String, String> sessionProperties = new HashMap(newSession.getProperties());
+            sessionProperties.putAll(statement.getSetSessionProperties());
+            sessionProperties.keySet().removeAll(statement.getResetSessionProperties());
+            builder = builder.withProperties(sessionProperties);
+        }
+
+        // update session roles
+        if (!statement.getSetRoles().isEmpty()) {
+            Map<String, ClientSelectedRole> roles = new HashMap(newSession.getRoles());
+            roles.putAll(statement.getSetRoles());
+            builder = builder.withRoles(roles);
+        }
+
+        // update prepared statements if present
+        if (!statement.getAddedPreparedStatements().isEmpty()
+                || !statement.getDeallocatedPreparedStatements().isEmpty()) {
+            Map<String, String> preparedStatements =
+                    new HashMap(newSession.getPreparedStatements());
+            preparedStatements.putAll(statement.getAddedPreparedStatements());
+            preparedStatements.keySet().removeAll(statement.getDeallocatedPreparedStatements());
+            builder = builder.withPreparedStatements(preparedStatements);
+        }
+        return builder.build();
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/resources/linkis-engineconn.properties
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/resources/linkis-engineconn.properties
@@ -1,0 +1,27 @@
+# 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+wds.linkis.server.version=v1
+
+wds.linkis.engineconn.debug.enable=true
+
+#wds.linkis.keytab.enable=true
+
+wds.linkis.engineconn.plugin.default.class=org.apache.linkis.engineplugin.openlookeng.OpenLooKengECPlugin
+
+wds.linkis.engineconn.support.parallelism=true
+
+wds.linkis.engineconn.max.free.time=0

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/resources/log4j2-engineconn.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/resources/log4j2-engineconn.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~ 
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~ 
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+  
+<configuration status="error" monitorInterval="30">
+    <appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
+        </Console>
+        <Send name="Send" >
+            <Filters>
+                <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY" />
+            </Filters>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
+        </Send>
+
+        <File name="stderr" fileName="${env:PWD}/logs/stderr" append="true">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+        </File>
+    </appenders>
+    <loggers>
+        <root level="INFO">
+            <!--<appender-ref ref="RollingFile"/>-->
+            <appender-ref ref="Console"/>
+            <appender-ref ref="Send"/>
+        </root>
+        <logger name="org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter " level="error" additivity="true">
+            <appender-ref ref="stderr"/>
+        </logger>
+        <logger name="com.netflix.discovery" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.apache.hadoop.yarn" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.springframework" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.apache.linkis.server.security" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.apache.hadoop.hive.ql.exec.mr.ExecDriver" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.apache.hadoop.hdfs.KeyProviderCache" level="fatal" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.spark_project.jetty" level="ERROR" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.eclipse.jetty" level="ERROR" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.springframework" level="ERROR" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.reflections.Reflections" level="ERROR" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+
+        <logger name="org.apache.hadoop.ipc.Client" level="ERROR" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+    </loggers>
+</configuration>
+

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/scalar/org/apache/linkis/engineplugin/openlookeng/OpenLooKengECPlugin.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/scalar/org/apache/linkis/engineplugin/openlookeng/OpenLooKengECPlugin.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng
+
+import java.util
+import java.util.List
+
+import org.apache.linkis.engineplugin.openlookeng.builder.OpenLooKengProcessECLaunchBuilder
+import org.apache.linkis.engineplugin.openlookeng.factory.OpenLooKengEngineConnFactory
+import org.apache.linkis.manager.engineplugin.common.EngineConnPlugin
+import org.apache.linkis.manager.engineplugin.common.creation.EngineConnFactory
+import org.apache.linkis.manager.engineplugin.common.launch.EngineConnLaunchBuilder
+import org.apache.linkis.manager.engineplugin.common.resource.{EngineResourceFactory, GenericEngineResourceFactory}
+import org.apache.linkis.manager.label.entity.Label
+import org.apache.linkis.manager.label.entity.engine.EngineType
+import org.apache.linkis.manager.label.utils.EngineTypeLabelCreator
+
+class OpenLooKengECPlugin extends EngineConnPlugin {
+
+  private val resourceLocker = new Object()
+
+  private val engineLaunchBuilderLocker = new Object()
+
+  private val engineFactoryLocker = new Object()
+
+  private var engineResourceFactory: EngineResourceFactory = _
+
+  private var engineLaunchBuilder: EngineConnLaunchBuilder = _
+
+  private var engineFactory: EngineConnFactory = _
+
+  private val defaultLabels: List[Label[_]] = new util.ArrayList[Label[_]]()
+
+  override def init(params: util.Map[String, Any]): Unit = {
+    val engineTypeLabel = EngineTypeLabelCreator.createEngineTypeLabel(EngineType.OPENLOOKENG.toString)
+    this.defaultLabels.add(engineTypeLabel)
+  }
+
+  override def getEngineResourceFactory(): EngineResourceFactory = {
+    if (null == engineResourceFactory) resourceLocker synchronized {
+      engineResourceFactory = new GenericEngineResourceFactory
+    }
+    engineResourceFactory
+  }
+
+  override def getEngineConnLaunchBuilder(): EngineConnLaunchBuilder = {
+    new OpenLooKengProcessECLaunchBuilder;
+  }
+
+  override def getEngineConnFactory(): EngineConnFactory = {
+    if (null == engineFactory) engineFactoryLocker synchronized {
+      engineFactory = new OpenLooKengEngineConnFactory
+    }
+    engineFactory
+  }
+
+  override def getDefaultLabels(): util.List[Label[_]] = {
+    this.defaultLabels
+  }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/scalar/org/apache/linkis/engineplugin/openlookeng/factory/OpenLooKengEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/scalar/org/apache/linkis/engineplugin/openlookeng/factory/OpenLooKengEngineConnFactory.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.openlookeng.factory
+
+import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.engineconn.common.creation.EngineCreationContext
+import org.apache.linkis.engineconn.common.engineconn.EngineConn
+import org.apache.linkis.engineconn.computation.executor.creation.ComputationSingleExecutorEngineConnFactory
+import org.apache.linkis.engineconn.executor.entity.LabelExecutor
+import org.apache.linkis.engineplugin.openlookeng.executor.OpenLooKengEngineConnExecutor
+import org.apache.linkis.manager.label.entity.engine.EngineType.EngineType
+import org.apache.linkis.manager.label.entity.engine.RunType.RunType
+import org.apache.linkis.manager.label.entity.engine.{EngineType, RunType}
+
+class OpenLooKengEngineConnFactory extends ComputationSingleExecutorEngineConnFactory with Logging {
+
+  override protected def getEngineConnType: EngineType = EngineType.OPENLOOKENG
+
+  override protected def getRunType: RunType = RunType.SQL
+
+  override def newExecutor(id: Int, engineCreationContext: EngineCreationContext, engineConn: EngineConn): LabelExecutor = {
+    new OpenLooKengEngineConnExecutor(100, id)
+  }
+}

--- a/linkis-engineconn-plugins/pom.xml
+++ b/linkis-engineconn-plugins/pom.xml
@@ -38,7 +38,7 @@
         <module>engineconn-plugins/hive</module>
         <module>engineconn-plugins/spark</module>
         <module>engineconn-plugins/python</module>
-
+        <module>engineconn-plugins/openlookeng</module>
         <module>engineconn-plugins/io_file</module>
         <module>engineconn-plugins/shell</module>
         <module>engineconn-plugins/pipeline</module>

--- a/tool/dependencies/known-dependencies.txt
+++ b/tool/dependencies/known-dependencies.txt
@@ -207,6 +207,8 @@ jackson-databind-2.11.4.jar
 jackson-dataformat-xml-2.11.4.jar
 jackson-datatype-jdk8-2.11.4.jar
 jackson-datatype-jsr310-2.11.4.jar
+jackson-datatype-guava-2.11.4.jar
+jackson-datatype-joda-2.11.4.jar
 jackson-jaxrs-1.9.13.jar
 jackson-jaxrs-1.9.2.jar
 jackson-mapper-asl-1.9.13.jar
@@ -290,7 +292,9 @@ joda-time-2.3.jar
 joda-time-2.5.jar
 joda-time-2.8.1.jar
 joda-time-2.9.3.jar
+jol-core-0.2.jar
 jpam-1.1.jar
+json-0.193.jar
 json-1.8.jar
 json-20090211.jar
 json4s-ast_2.11-3.5.3.jar
@@ -317,6 +321,7 @@ libthrift-0.15.0.pom
 libthrift-0.9.2.jar
 libthrift-0.9.3.jar
 listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
+log-0.193.jar
 log4j-1.2-api-2.13.3.jar
 log4j-1.2.16.jar
 log4j-1.2.17.jar
@@ -371,6 +376,9 @@ netty-transport-native-unix-common-4.1.65.Final.jar
 nio-multipart-parser-1.1.0.jar
 nio-stream-storage-1.1.3.jar
 objenesis-3.2.jar
+okhttp-3.14.9.jar
+okhttp-urlconnection-3.14.9.jar
+okio-1.17.2.jar
 opencsv-2.3.jar
 orc-core-1.3.3.jar
 oro-2.0.8.jar
@@ -384,6 +392,7 @@ poi-5.2.1.jar
 poi-ooxml-5.2.1.jar
 poi-ooxml-lite-5.2.1.jar
 poi-shared-strings-2.5.1.jar
+presto-client-1.5.0.jar
 protobuf-java-3.14.0.jar
 protobuf-java-3.15.8.jar
 protostuff-api-1.6.2.jar
@@ -416,9 +425,11 @@ scala-reflect-2.11.12.jar
 scala-xml_2.11-1.0.5.jar
 scalap-2.11.12.jar
 scopt_2.11-3.5.0.jar
+security-0.193.jar
 servo-core-0.12.21.jar
 slf4j-api-1.7.30.jar
 slf4j-log4j12-1.7.30.jar
+slice-0.38.jar
 snakeyaml-1.26.jar
 snappy-java-1.0.4.1.jar
 snappy-java-1.0.5.jar
@@ -485,6 +496,7 @@ stringtemplate-3.2.1.jar
 tomcat-embed-core-9.0.46.jar
 tomcat-embed-websocket-9.0.46.jar
 txw2-2.3.4.jar
+units-1.3.jar
 validation-api-2.0.1.Final.jar
 velocity-1.5.jar
 websocket-api-9.4.42.v20210604.jar


### PR DESCRIPTION
### What is the purpose of the change
Add openLooKeng support in linkis

### Brief change log
- Define the core abstraction and interfaces of the openLooKeng EngineConn Factory;
- Change the parent pom file and add openLooKeng module in engine
- fix #1639

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes / no) yes
- Anything that affects deployment: (yes / no / don't know) no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes / no) no

### Documentation
- Does this pull request introduce a new feature? (yes / no)  no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) JavaDocs