### PR TITLE
[Feature] Use regex to match against gateway URLs, if matched, let them pass

### DIFF
--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/config/GatewayConfiguration.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/config/GatewayConfiguration.scala
@@ -63,4 +63,7 @@ object GatewayConfiguration {
 
   val DSS_QUERY_WORKSPACE_SERVICE_NAME = CommonVars("wds.dss.query.workspace.service", "dss-framework-project-server")
   val USER_WORKSPACE_REFLESH_TIME  = CommonVars("wds.linkis.user.workspace.reflesh.time", 10)
+
+  // Use regex to match against URLs, if matched, let them pass anyway(even if not currently logged in)
+  val GATEWAY_NO_AUTH_URL_REGEX = CommonVars("wds.linkis.gateway.no.auth.url.regex", ".*visualis.*share.*")
 }

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/SecurityFilter.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/SecurityFilter.scala
@@ -36,6 +36,7 @@ import org.apache.linkis.server.exception.{LoginExpireException, NonLoginExcepti
 import org.apache.linkis.server.{Message, validateFailed}
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang.exception.ExceptionUtils
+import java.util.regex.Pattern
 
 object SecurityFilter extends Logging {
 
@@ -132,6 +133,9 @@ object SecurityFilter extends Logging {
             .data("enableSSO", true).data("SSOURL", SSOInterceptor.getSSOInterceptor.redirectTo(gatewayContext.getRequest.getURI)) << gatewayContext.getRequest.getRequestURI)
           false
         }
+      } else if (gatewayContext.getRequest.getRequestURI.matches(GatewayConfiguration.GATEWAY_NO_AUTH_URL_REGEX.getValue)){
+        GatewaySSOUtils.info("Not logged in, still let it pass (GATEWAY_NO_AUTH_URL): " + gatewayContext.getRequest.getRequestURI)
+        true
       } else {
         filterResponse(gatewayContext, Message.noLogin("You are not logged in, please login first(您尚未登录，请先登录)!") << gatewayContext.getRequest.getRequestURI)
         false


### PR DESCRIPTION
This PR is based on https://github.com/apache/incubator-linkis/pull/556

If we share a dashboard of Visualis in the normal way(no login required, as defined by Visualis), anonymous users would not be able to visit this shared URL because Linkis gateway would filter this URL out, don't let it pass, and this dashboard can never be really shared this way.

That's not what was intended to be.
This BUG is fixed in this PR. With REGEX Support.