### PR TITLE
Unify RequestMethod and fix Entrance read log loss bug

### DIFF
--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/ProxyUserSSOUtils.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/ProxyUserSSOUtils.scala
@@ -77,6 +77,13 @@ object ProxyUserSSOUtils extends Logging {
     }
   }
 
+  def removeLoginUserByAddCookie(addEmptyCookie: Cookie => Unit): Unit = {
+    val cookie = new Cookie(PROXY_USER_TICKET_ID_STRING, null)
+    cookie.setMaxAge(0)
+    cookie.setPath("/")
+    addEmptyCookie(cookie)
+  }
+
   def getProxyUserUsername(req: HttpServletRequest): Option[String] = {
     val ticketOption = Option(req.getCookies).flatMap(_.find(_.getName == PROXY_USER_TICKET_ID_STRING).map(_.getValue))
     if (ticketOption.isDefined) {

--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/ProxyUserSSOUtils.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/ProxyUserSSOUtils.scala
@@ -87,6 +87,7 @@ object ProxyUserSSOUtils extends Logging {
   def getProxyUserUsername(req: HttpServletRequest): Option[String] = {
     val ticketOption = Option(req.getCookies).flatMap(_.find(_.getName == PROXY_USER_TICKET_ID_STRING).map(_.getValue))
     if (ticketOption.isDefined) {
+      logger.info(s"PROXY_USER_TICKET_ID_STRING: ${ticketOption.get}")
       getProxyUsernameByTicket(ticketOption.get)
     } else {
       None

--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/SSOUtils.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/security/SSOUtils.scala
@@ -112,6 +112,7 @@ object SSOUtils extends Logging {
     cookie.setPath("/")
     if(sslEnable) cookie.setSecure(true)
     addEmptyCookie(cookie)
+    removeLoginUserByAddCookie(addEmptyCookie)
   }
 
   def removeLoginUser(removeKeyReturnValue: String => Option[String]): Unit = removeKeyReturnValue(USER_TICKET_ID_STRING).foreach{ t =>

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
@@ -54,6 +54,7 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
 
     private LogReader logReader;
     private LogWriter logWriter;
+    private Object logWriterLocker = new Object();
     private WebSocketCacheLogReader webSocketCacheLogReader;
     private WebSocketLogWriter webSocketLogWriter;
     private static final Logger logger = LoggerFactory.getLogger(EntranceExecutionJob.class);
@@ -62,6 +63,10 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
 
     public EntranceExecutionJob(PersistenceManager persistenceManager) {
         this.persistenceManager = persistenceManager;
+    }
+
+    public Object getLogWriterLocker() {
+        return logWriterLocker;
     }
 
     @Override

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/parser/ParserUtils.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/parser/ParserUtils.java
@@ -48,16 +48,10 @@ public final class ParserUtils {
         types.put("sparksql", "sql");
     }
 
-    public static void generateLogPath(
-            JobRequest jobRequest, Map<String, String> responseQueryConfig) {
+    public static void generateLogPath(JobRequest jobRequest, Map<String, String> params) {
         String logPath = null;
         String logPathPrefix = null;
         String logMid = "log";
-        if (responseQueryConfig != null) {
-            logPathPrefix =
-                    responseQueryConfig.get(
-                            EntranceConfiguration$.MODULE$.CLOUD_CONSOLE_LOGPATH_KEY().getValue());
-        }
         if (StringUtils.isEmpty(logPathPrefix)) {
             logPathPrefix = EntranceConfiguration$.MODULE$.DEFAULT_LOGPATH_PREFIX().getValue();
         }
@@ -70,7 +64,7 @@ public final class ParserUtils {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String dateString = dateFormat.format(date);
         String creator = LabelUtil.getUserCreator(jobRequest.getLabels())._2;
-        String umUser = jobRequest.getSubmitUser();
+        String umUser = jobRequest.getExecuteUser();
         FsPath lopPrefixPath = new FsPath(logPathPrefix);
         if (StorageUtils.HDFS().equals(lopPrefixPath.getFsType())) {
             String commonLogPath = logPathPrefix + "/" + "log" + "/" + dateString + "/" + creator;

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/persistence/QueryPersistenceManager.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/persistence/QueryPersistenceManager.java
@@ -173,7 +173,6 @@ public class QueryPersistenceManager extends PersistenceManager {
 
     @Override
     public void onJobInited(Job job) {
-        updateJobStatus(job);
         cliHeartbeatMonitor.registerIfCliJob(job);
     }
 

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
@@ -73,6 +73,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
      * execution ID is returned to the user. execute函数处理的是用户提交执行任务的请求，返回给用户的是执行ID json Incoming
      * key-value pair(传入的键值对) Repsonse
      */
+    @Override
     @RequestMapping(path = "/execute", method = RequestMethod.POST)
     public Message execute(HttpServletRequest req, @RequestBody Map<String, Object> json) {
         Message message = null;
@@ -125,6 +126,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         return message;
     }
 
+    @Override
     @RequestMapping(path = "/submit", method = RequestMethod.POST)
     public Message submit(HttpServletRequest req, @RequestBody Map<String, Object> json) {
         Message message = null;
@@ -180,6 +182,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         entranceServer.getEntranceContext().getOrCreateLogManager().onLogUpdate(job, log);
     }
 
+    @Override
     @RequestMapping(path = "/{id}/status", method = RequestMethod.GET)
     public Message status(
             @PathVariable("id") String id,
@@ -213,6 +216,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         return message;
     }
 
+    @Override
     @RequestMapping(path = "/{id}/progress", method = RequestMethod.GET)
     public Message progress(@PathVariable("id") String id) {
         Message message = null;
@@ -253,6 +257,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         return message;
     }
 
+    @Override
     @RequestMapping(path = "/{id}/progressWithResource", method = RequestMethod.GET)
     public Message progressWithResource(@PathVariable("id") String id) {
         Message message = null;
@@ -353,6 +358,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         list.add(map);
     }
 
+    @Override
     @RequestMapping(path = "/{id}/log", method = RequestMethod.GET)
     public Message log(HttpServletRequest req, @PathVariable("id") String id) {
         String realId = ZuulEntranceUtils.parseExecID(id)[3];
@@ -455,8 +461,9 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         return message;
     }
 
+    @Override
     @RequestMapping(path = "/killJobs", method = RequestMethod.POST)
-    public Message killJobs(HttpServletRequest req, @RequestBody JsonNode jsonNode) {
+    public Message killJobs(HttpServletRequest req, @RequestBody JsonNode jsonNode, @PathVariable("id") String strongExecId) {
         JsonNode idNode = jsonNode.get("idList");
         JsonNode taskIDNode = jsonNode.get("taskIDList");
         ArrayList<Long> waitToForceKill = new ArrayList<>();
@@ -544,7 +551,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         return Message.ok("success").data("messages", messages);
     }
 
-    // todo confirm long or Long
+    @Override
     @RequestMapping(path = "/{id}/kill", method = RequestMethod.GET)
     public Message kill(
             @PathVariable("id") String id,
@@ -603,6 +610,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
         return message;
     }
 
+    @Override
     @RequestMapping(path = "/{id}/pause", method = RequestMethod.GET)
     public Message pause(@PathVariable("id") String id) {
         String realId = ZuulEntranceUtils.parseExecID(id)[3];

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
@@ -463,7 +463,10 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
 
     @Override
     @RequestMapping(path = "/killJobs", method = RequestMethod.POST)
-    public Message killJobs(HttpServletRequest req, @RequestBody JsonNode jsonNode, @PathVariable("id") String strongExecId) {
+    public Message killJobs(
+            HttpServletRequest req,
+            @RequestBody JsonNode jsonNode,
+            @PathVariable("id") String strongExecId) {
         JsonNode idNode = jsonNode.get("idList");
         JsonNode taskIDNode = jsonNode.get("taskIDList");
         ArrayList<Long> waitToForceKill = new ArrayList<>();

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
@@ -102,14 +102,14 @@ abstract class EntranceServer extends Logging {
         t => logger.error("Failed to write init log, reason: ", t)
       }
 
+      /**
+       * job.afterStateChanged() method is only called in job.run(), and job.run() is called only after job is scheduled
+       * so it suggest that we lack a hook for job init, currently we call this to trigger JobListener.onJobinit()
+       * */
+      Utils.tryAndWarn(job.getJobListener.foreach(_.onJobInited(job)))
       getEntranceContext.getOrCreateScheduler().submit(job)
       val msg = s"Job with jobId : ${job.getId} and execID : ${job.getId()} submitted "
       logger.info(msg)
-      /**
-        * job.afterStateChanged() method is only called in job.run(), and job.run() is called only after job is scheduled
-        * so it suggest that we lack a hook for job init, currently we call this to trigger JobListener.onJobinit()
-        * */
-      job.getJobListener.foreach(_.onJobInited(job))
 
       job match {
         case entranceJob: EntranceJob =>

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/cache/GlobalConfigurationKeyValueCache.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/cache/GlobalConfigurationKeyValueCache.scala
@@ -31,7 +31,7 @@ object GlobalConfigurationKeyValueCache extends
   RPCMapCache[JobRequest, String, String](Configuration.CLOUD_CONSOLE_CONFIGURATION_SPRING_APPLICATION_NAME.getValue) {
 
   override protected def createRequest(jobReq: JobRequest): CacheableProtocol =
-    RequestQueryGlobalConfig(jobReq.getSubmitUser)
+    RequestQueryGlobalConfig(jobReq.getExecuteUser)
 
   override protected def createMap(any: Any): util.Map[String, String] = any match {
     case response: ResponseQueryConfig => response.getKeyAndValue

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceExecutorManager.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceExecutorManager.scala
@@ -53,7 +53,7 @@ abstract class EntranceExecutorManager(groupFactory: GroupFactory) extends Execu
     markReq.setCreateService(EntranceConfiguration.DEFAULT_CREATE_SERVICE.getValue)
     // todo get default config from db
     markReq.setProperties(jobReq.getParams)
-    markReq.setUser(jobReq.getSubmitUser)
+    markReq.setUser(jobReq.getExecuteUser)
     markReq.setLabels(LabelUtils.labelsToMap(jobReq.getLabels))
     markReq
   }

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/CustomVariableUtils.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/CustomVariableUtils.scala
@@ -207,7 +207,7 @@ object CustomVariableUtils extends Logging {
     //    nameAndType("run_year_now_end") = YearType(new CustomYearType(new CustomYearType(run_today.toString, false) - 1, false, true))
     //    nameAndType("run_year_now_end_std") = YearType(new CustomYearType(new CustomYearType(run_today.toString, false) - 1, true, true))
     if (nameAndType.get("user").isEmpty) {
-      nameAndType("user") = StringType(jobRequest.getSubmitUser)
+      nameAndType("user") = StringType(jobRequest.getExecuteUser)
     }
     (true, parserVar(code, nameAndType))
   }

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/LogPathCreateInterceptor.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/LogPathCreateInterceptor.scala
@@ -19,13 +19,10 @@ package org.apache.linkis.entrance.interceptor.impl
 
 import org.apache.linkis.common.exception.ErrorException
 import org.apache.linkis.common.utils.{Logging, Utils}
-import org.apache.linkis.entrance.cache.GlobalConfigurationKeyValueCache
 import org.apache.linkis.entrance.interceptor.EntranceInterceptor
 import org.apache.linkis.entrance.interceptor.exception.LogPathCreateException
 import org.apache.linkis.entrance.parser.ParserUtils
 import org.apache.linkis.governance.common.entity.job.JobRequest
-import org.apache.linkis.governance.common.entity.task.RequestPersistTask
-import org.apache.linkis.protocol.task.Task
 
 /**
   * Description:Log path generation interceptor, used to set the path log of the task(日志路径生成拦截器, 用于设置task的路径日志)
@@ -36,7 +33,7 @@ class LogPathCreateInterceptor extends EntranceInterceptor with Logging {
   override def apply(jobRequest: JobRequest, logAppender: java.lang.StringBuilder): JobRequest = {
     jobRequest match {
       case jobReq: JobRequest => Utils.tryThrow {
-        ParserUtils.generateLogPath(jobReq, Utils.tryAndWarn(GlobalConfigurationKeyValueCache.getCacheMap(jobReq)))
+        ParserUtils.generateLogPath(jobReq, null)
         jobReq
       } {
         case e: ErrorException =>

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/StorePathEntranceInterceptor.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/StorePathEntranceInterceptor.scala
@@ -17,8 +17,8 @@
 
 package org.apache.linkis.entrance.interceptor.impl
 
-import org.apache.linkis.common.utils.{Logging, Utils}
-import org.apache.linkis.entrance.cache.GlobalConfigurationKeyValueCache
+import org.apache.commons.lang.time.DateFormatUtils
+import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.entrance.exception.{EntranceErrorCode, EntranceErrorException}
 import org.apache.linkis.entrance.interceptor.EntranceInterceptor
 import org.apache.linkis.governance.common.conf.GovernanceCommonConf
@@ -26,7 +26,6 @@ import org.apache.linkis.governance.common.entity.job.JobRequest
 import org.apache.linkis.manager.label.utils.LabelUtil
 import org.apache.linkis.protocol.utils.TaskUtils
 import org.apache.linkis.server.BDPJettyServerHelper
-import org.apache.commons.lang.time.DateFormatUtils
 
 import java.util
 import scala.collection.JavaConverters.{asScalaBufferConverter, mapAsScalaMapConverter}
@@ -43,15 +42,9 @@ class StorePathEntranceInterceptor extends EntranceInterceptor with Logging {
    * @return
    */
   override def apply(jobReq: JobRequest, logAppender: java.lang.StringBuilder): JobRequest = {
-    val globalConfig = Utils.tryAndWarn(GlobalConfigurationKeyValueCache.getCacheMap(jobReq))
-    var parentPath: String = null
-    if (null != globalConfig && globalConfig.containsKey(GovernanceCommonConf.RESULT_SET_STORE_PATH.key))
-      parentPath = GovernanceCommonConf.RESULT_SET_STORE_PATH.getValue(globalConfig)
-    else {
-      parentPath = GovernanceCommonConf.RESULT_SET_STORE_PATH.getValue
-      if (!parentPath.endsWith("/")) parentPath += "/"
-      parentPath += jobReq.getSubmitUser
-    }
+    var parentPath: String = GovernanceCommonConf.RESULT_SET_STORE_PATH.getValue
+    if (!parentPath.endsWith("/")) parentPath += "/"
+    parentPath += jobReq.getExecuteUser
     if (!parentPath.endsWith("/")) parentPath += "/linkis/"
     else parentPath += "linkis/"
     val userCreator = LabelUtil.getUserCreator(jobReq.getLabels)

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/log/LogManager.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/log/LogManager.scala
@@ -45,7 +45,7 @@ abstract class LogManager extends LogListener with Logging {
       //     warn(s"jobid :${job.getId()}\nlog : ${log}")
       job match {
         case entranceExecutionJob: EntranceExecutionJob =>
-          if (entranceExecutionJob.getLogWriter.isEmpty) entranceExecutionJob synchronized {
+          if (entranceExecutionJob.getLogWriter.isEmpty) entranceExecutionJob.getLogWriterLocker synchronized {
             if (entranceExecutionJob.getLogWriter.isEmpty) {
               val logWriter = createLogWriter(entranceExecutionJob)
               if (null == logWriter) {

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/restful/EntranceRestfulRemote.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/restful/EntranceRestfulRemote.scala
@@ -36,22 +36,22 @@ trait EntranceRestfulRemote {
   @RequestMapping(value = Array("/entrance/{id}/status"), method = Array(RequestMethod.GET))
   def status(@PathVariable("id") id : String, @RequestParam(value = "taskID", required = false) taskID: String): Message
 
-  @RequestMapping(value = Array("/entrance/{id}/progress"), method = Array(RequestMethod.POST))
+  @RequestMapping(value = Array("/entrance/{id}/progress"), method = Array(RequestMethod.GET))
   def progress(@PathVariable("id") id: String): Message
 
-  @RequestMapping(value = Array("/entrance/{id}/progressWithResource"), method = Array(RequestMethod.POST))
+  @RequestMapping(value = Array("/entrance/{id}/progressWithResource"), method = Array(RequestMethod.GET))
   def progressWithResource(@PathVariable("id") id: String): Message
 
-  @RequestMapping(value = Array("/entrance/{id}/log"), method = Array(RequestMethod.POST))
+  @RequestMapping(value = Array("/entrance/{id}/log"), method = Array(RequestMethod.GET))
   def log(req: HttpServletRequest, @PathVariable("id") id: String): Message
 
   @RequestMapping(value = Array("/entrance/killJobs"), method = Array(RequestMethod.POST))
-  def killJobs(req: HttpServletRequest, @RequestBody jsonNode: JsonNode): Message
+  def killJobs(req: HttpServletRequest, @RequestBody jsonNode: JsonNode, @PathVariable("id") strongExecId: String): Message
 
-  @RequestMapping(value = Array("/entrance/{id}/kill"), method = Array(RequestMethod.POST))
+  @RequestMapping(value = Array("/entrance/{id}/kill"), method = Array(RequestMethod.GET))
   def kill(@PathVariable("id") id: String, @RequestParam("taskID") taskID: java.lang.Long): Message
 
-  @RequestMapping(value = Array("/entrance/{id}/pause"), method = Array(RequestMethod.POST))
+  @RequestMapping(value = Array("/entrance/{id}/pause"), method = Array(RequestMethod.GET))
   def pause(@PathVariable("id") id: String): Message
 
 

--- a/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/restful/RMMonitorRest.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/scala/org/apache/linkis/resourcemanager/restful/RMMonitorRest.scala
@@ -183,8 +183,8 @@ class RMMonitorRest extends Logging {
   }
 
   @RequestMapping(path = Array("allUserResource"), method = Array(RequestMethod.GET))
-  def getAllUserResource(request: HttpServletRequest, @RequestParam(value = "username") username: String,
-                         @RequestParam(value = "creator") creator: String, @RequestParam(value = "engineType") engineType: String,
+  def getAllUserResource(request: HttpServletRequest, @RequestParam(value = "username", required = false) username: String,
+                         @RequestParam(value = "creator", required = false) creator: String, @RequestParam(value = "engineType", required = false) engineType: String,
                          @RequestParam(value = "page", required = false) page: Int, @RequestParam(value = "size", required = false) size: Int): Message = {
     val queryUser = SecurityFilter.getLoginUser(request)
     val admins = RMUtils.GOVERNANCE_STATION_ADMIN.getValue.split(",")

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.sql.Date;
 import java.util.*;
 
 @RestController

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
@@ -113,7 +113,7 @@ public class QueryRestfulApi {
             @RequestParam(value = "proxyUser", required = false) String proxyUser,
             @RequestParam(value = "isAdminView", required = false) Boolean isAdminView)
             throws IOException, QueryException {
-        String username = ModuleUserUtils.getOperationUser(req, "list task ");
+        String username = SecurityFilter.getLoginUsername(req);
         if (StringUtils.isEmpty(status)) {
             status = null;
         }

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
@@ -27,6 +27,7 @@ import org.apache.linkis.jobhistory.service.JobHistoryQueryService;
 import org.apache.linkis.jobhistory.util.QueryUtils;
 import org.apache.linkis.protocol.constants.TaskConstant;
 import org.apache.linkis.server.Message;
+import org.apache.linkis.server.security.SecurityFilter;
 import org.apache.linkis.server.utils.ModuleUserUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +64,7 @@ public class QueryRestfulApi {
 
     @RequestMapping(path = "/{id}/get", method = RequestMethod.GET)
     public Message getTaskByID(HttpServletRequest req, @PathVariable("id") Long jobId) {
-        String username = ModuleUserUtils.getOperationUser(req, "get task " + jobId);
+        String username = SecurityFilter.getLoginUsername(req);
         if (QueryUtils.isJobHistoryAdmin(username)
                 || !JobhistoryConfiguration.JOB_HISTORY_SAFE_TRIGGER()) {
             username = null;

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/JobHistoryDetailQueryService.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/JobHistoryDetailQueryService.java
@@ -18,12 +18,8 @@
 package org.apache.linkis.jobhistory.service;
 
 import org.apache.linkis.governance.common.protocol.job.*;
-import org.apache.linkis.jobhistory.entity.QueryJobHistory;
-import org.apache.linkis.rpc.Sender;
 
-import java.sql.Date;
 import java.util.ArrayList;
-import java.util.List;
 
 public interface JobHistoryDetailQueryService {
 

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
@@ -213,7 +213,7 @@ class JobHistoryQueryServiceImpl extends JobHistoryQueryService with Logging {
   }
 
    override def search(jobId: java.lang.Long, username: String, status: String, sDate: Date, eDate: Date, engineType: String): util.List[JobHistory] = {
-    import scala.collection.JavaConversions._
+
     val split: util.List[String] = if (status != null) status.split(",").toList else null
     jobHistoryMapper.search(jobId, username, split, sDate, eDate, engineType)
   }

--- a/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -528,7 +528,8 @@ public class FsRestfulApi {
             @RequestParam(value = "outputFileName", defaultValue = "downloadResultset")
                     String outputFileName,
             @RequestParam(value = "sheetName", defaultValue = "result") String sheetName,
-            @RequestParam(value = "nullValue", defaultValue = "NULL") String nullValue)
+            @RequestParam(value = "nullValue", defaultValue = "NULL") String nullValue,
+            @RequestParam(value = "limit", defaultValue = "0") Integer limit)
             throws WorkSpaceException, IOException {
         ServletOutputStream outputStream = null;
         FsWriter fsWriter = null;
@@ -541,6 +542,11 @@ public class FsRestfulApi {
             boolean isLimitDownloadSize = RESULT_SET_DOWNLOAD_IS_LIMIT.getValue();
             Integer csvDownloadSize = RESULT_SET_DOWNLOAD_MAX_SIZE_CSV.getValue();
             Integer excelDownloadSize = RESULT_SET_DOWNLOAD_MAX_SIZE_EXCEL.getValue();
+            if (limit > 0) {
+                csvDownloadSize = limit;
+                excelDownloadSize = limit;
+            }
+
             if (StringUtils.isEmpty(path)) {
                 throw WorkspaceExceptionManager.createException(80004, path);
             }
@@ -617,7 +623,8 @@ public class FsRestfulApi {
             @RequestParam(value = "path", required = false) String path,
             @RequestParam(value = "outputFileName", defaultValue = "downloadResultset")
                     String outputFileName,
-            @RequestParam(value = "nullValue", defaultValue = "NULL") String nullValue)
+            @RequestParam(value = "nullValue", defaultValue = "NULL") String nullValue,
+            @RequestParam(value = "limit", defaultValue = "0") Integer limit)
             throws WorkSpaceException, IOException {
         ServletOutputStream outputStream = null;
         FsWriter fsWriter = null;
@@ -641,6 +648,9 @@ public class FsRestfulApi {
             FsPath[] fsPaths = fsPathListWithError.getFsPaths().toArray(new FsPath[] {});
             boolean isLimitDownloadSize = RESULT_SET_DOWNLOAD_IS_LIMIT.getValue();
             Integer excelDownloadSize = RESULT_SET_DOWNLOAD_MAX_SIZE_EXCEL.getValue();
+            if (limit > 0) {
+                excelDownloadSize = limit;
+            }
             response.addHeader(
                     "Content-Disposition",
                     "attachment;filename="


### PR DESCRIPTION
### What is the purpose of the change
Unified RequestMethod #1641 
Modify to create inputStream every time #1640 
Adjust the resultsetToExcel interface to support passing the number of rows downloaded #1624
Fix issue that Entrance is using the submit user in the log path and result set path error #1623

### Brief change log
- fix Entracen log bug
- Adjust the resultsetToExcel interface to support passing the number of rows downloaded

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)
