### PR TITLE
add the retry log of ec application

### DIFF
--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/engineConn/DefaultEngineConn.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/engineConn/DefaultEngineConn.scala
@@ -100,5 +100,5 @@ class DefaultEngineConn extends EngineConn {
 
   override def setEngineConnManagerEnv(env: EngineConnManagerEnv): Unit = this.ecmEnv = env
 
-  override def toString = s"DefaultEngineConn($status, $tickedId, $resource, $labels, $engineConnCreationDesc, $engineConnInfo, $ecmEnv, $engineConnLaunchRunner, $instance, $pid)"
+  override def toString = s"DefaultEngineConn($status, $tickedId, $instance, $pid)"
 }

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/service/impl/ProcessEngineConnLaunchService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/service/impl/ProcessEngineConnLaunchService.scala
@@ -109,7 +109,7 @@ abstract class ProcessEngineConnLaunchService extends AbstractEngineConnLaunchSe
         throw t
     }
     if (engineConn.getStatus == ShuttingDown) {
-      throw new ECMErrorException(ECMErrorConstants.ECM_ERROR, s"Failed to init $engineConn, status shutting down")
+      throw new ECMErrorException(ECMErrorCode.EC_START_FAILED, errorMsg.toString())
     }
   }
 

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
@@ -462,7 +462,7 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
     }
 
     @Override
-    @RequestMapping(path = "/killJobs", method = RequestMethod.POST)
+    @RequestMapping(path = "/{id}/killJobs", method = RequestMethod.POST)
     public Message killJobs(
             HttpServletRequest req,
             @RequestBody JsonNode jsonNode,

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/restful/EntranceRestfulRemote.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/restful/EntranceRestfulRemote.scala
@@ -45,7 +45,7 @@ trait EntranceRestfulRemote {
   @RequestMapping(value = Array("/entrance/{id}/log"), method = Array(RequestMethod.GET))
   def log(req: HttpServletRequest, @PathVariable("id") id: String): Message
 
-  @RequestMapping(value = Array("/entrance/killJobs"), method = Array(RequestMethod.POST))
+  @RequestMapping(value = Array("/entrance/{id}/killJobs"), method = Array(RequestMethod.POST))
   def killJobs(req: HttpServletRequest, @RequestBody jsonNode: JsonNode, @PathVariable("id") strongExecId: String): Message
 
   @RequestMapping(value = Array("/entrance/{id}/kill"), method = Array(RequestMethod.GET))

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/AMConfiguration.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/AMConfiguration.scala
@@ -61,7 +61,7 @@ object AMConfiguration {
 
 
 
-  val AM_CAN_RETRY_LOGS = CommonVars("wds.linkis.manager.am.can.retry.logs", "already in use")
+  val AM_CAN_RETRY_LOGS = CommonVars("wds.linkis.manager.am.can.retry.logs", "already in use,Cannot allocate memory")
 
   val ASK_ENGINE_ASYNC_MAX_THREAD_SIZE: Int = CommonVars("wds.linkis.ecm.launch.max.thread.size", 200).getValue
 

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/AMConfiguration.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/AMConfiguration.scala
@@ -61,7 +61,7 @@ object AMConfiguration {
 
 
 
-  val AM_CAN_RETRY_LOGS = CommonVars("wds.linkis.manager.am.can.retry.logs", "already in use,Cannot allocate memory")
+  val AM_CAN_RETRY_LOGS = CommonVars("wds.linkis.manager.am.can.retry.logs", "already in use;Cannot allocate memory")
 
   val ASK_ENGINE_ASYNC_MAX_THREAD_SIZE: Int = CommonVars("wds.linkis.ecm.launch.max.thread.size", 200).getValue
 

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/conf/EnvConfiguration.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/conf/EnvConfiguration.scala
@@ -36,7 +36,7 @@ object EnvConfiguration {
   val ENGINE_CONN_DEFAULT_JAVA_OPTS = CommonVars[String]("wds.linkis.engineConn.javaOpts.default", s"-XX:+UseG1GC -XX:MaxPermSize=250m -XX:PermSize=128m " +
     s"-Xloggc:%s -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Dwds.linkis.server.conf=linkis-engineconn.properties -Dwds.linkis.gateway.url=${Configuration.getGateWayURL()}")
 
-  val ENGINE_CONN_MEMORY = CommonVars("wds.linkis.engineConn.memory", new ByteType("2g"), "Specify the memory size of the java client(指定java进程的内存大小)")
+  val ENGINE_CONN_MEMORY = CommonVars("wds.linkis.engineConn.memory", new ByteType("1g"), "Specify the memory size of the java client(指定java进程的内存大小)")
 
   val ENGINE_CONN_JAVA_EXTRA_OPTS = CommonVars("wds.linkis.engineConn.java.extraOpts", "",
     "Specify the option parameter of the java process (please modify it carefully!!!)")

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
@@ -56,7 +56,7 @@ abstract class JavaProcessEngineConnLaunchBuilder extends ProcessEngineConnLaunc
     commandLine += "-server"
     val engineConnMemory = EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.getValue.toString
     commandLine += ("-Xmx" + engineConnMemory)
-    commandLine += ("-Xms" + engineConnMemory)
+    //commandLine += ("-Xms" + engineConnMemory)
     val javaOPTS = getExtractJavaOpts
     if (StringUtils.isNotEmpty(EnvConfiguration.ENGINE_CONN_DEFAULT_JAVA_OPTS.getValue))
       EnvConfiguration.ENGINE_CONN_DEFAULT_JAVA_OPTS.getValue.format(getGcLogDir(engineConnBuildRequest)).split("\\s+").foreach(commandLine += _)

--- a/linkis-public-enhancements/pom.xml
+++ b/linkis-public-enhancements/pom.xml
@@ -34,7 +34,7 @@
         <module>linkis-bml</module>
         <module>linkis-context-service</module>
         <module>linkis-datasource/linkis-metadata</module>
-        <module>linkis-datasource</module>
+        <!--<module>linkis-datasource</module>-->
         <module>linkis-publicservice</module>
     </modules>
 


### PR DESCRIPTION
### What is the purpose of the change
"Cannot allocate memory" added to retry log #1673 
reduce ec java default memory 

### Brief change log
(for example:)
- reduce ec java default memory ;
- add the retry log of ec application.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)