### PR TITLE
Fix replace-package-header error in linkis-cs-persistence and linkis-engineplugin-spark

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis-ps-cs.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis-ps-cs.properties
@@ -24,3 +24,5 @@ wds.linkis.server.mybatis.BasePackage=org.apache.linkis.cs.persistence.dao
 spring.server.port=9108
 # ps-cs prefix must be started with 'cs_'
 spring.eureka.instance.metadata-map.route=cs_1_dev
+wds.linkis.cs.deserialize.replace_package_header.enable=false
+

--- a/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/args/SparkScalaPreExecutionHook.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/args/SparkScalaPreExecutionHook.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.args
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
+import org.apache.linkis.engineplugin.spark.common.SparkKind
+import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
+import org.apache.linkis.engineplugin.spark.extension.SparkPreExecutionHook
+import org.apache.linkis.governance.common.paser.CodeType
+import org.apache.linkis.manager.label.entity.engine.RunType
+import org.apache.linkis.manager.label.utils.LabelUtil
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+import scala.collection.JavaConverters.seqAsJavaListConverter
+
+@Component
+class SparkScalaPreExecutionHook extends SparkPreExecutionHook with Logging {
+
+  @PostConstruct
+  private def init(): Unit = {
+    SparkPreExecutionHook.register(this)
+  }
+
+  override def hookName: String = getClass.getSimpleName
+
+  override def callPreExecutionHook(engineExecutionContext: EngineExecutionContext, code: String): String = {
+    if (!SparkConfiguration.ENABLE_REPLACE_PACKAGE_NAME.getValue || StringUtils.isBlank(code)) {
+      return code
+    }
+    val codeTypeLabel = LabelUtil.getCodeTypeLabel(engineExecutionContext.getLabels.toList.asJava)
+    if (null != codeTypeLabel) {
+      codeTypeLabel.getCodeType.toLowerCase() match {
+        case SparkKind.SCALA_LAN | SparkKind.FUNCTION_MDQ_TYPE =>
+          if (!code.contains(SparkConfiguration.REPLACE_PACKAGE_HEADER.getValue)) {
+            return code
+          } else {
+            logger.info(s"Replaced ${SparkConfiguration.REPLACE_PACKAGE_HEADER.getValue} to ${SparkConfiguration.REPLACE_PACKAGE_TO_HEADER}")
+            return code.replaceAll(SparkConfiguration.REPLACE_PACKAGE_HEADER.getValue, SparkConfiguration.REPLACE_PACKAGE_TO_HEADER)
+          }
+        case _ =>
+      }
+    }
+    code
+  }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
@@ -84,6 +84,12 @@ object SparkConfiguration extends Logging {
 
   val PYSPARK_PYTHON3_PATH = CommonVars[String]("pyspark.python3.path", "/appcom/Install/anaconda3/bin/python")
 
+  val ENABLE_REPLACE_PACKAGE_NAME = CommonVars("wds.linkis.spark.engine.scala.replace_package_header.enable", true)
+
+  val REPLACE_PACKAGE_HEADER = CommonVars("wds.linkis.spark.engine.scala.replace_package.header", "com.webank.wedatasphere.linkis")
+
+  val REPLACE_PACKAGE_TO_HEADER = "org.apache.linkis"
+
   private def getMainJarName(): String = {
     val somePath = ClassUtils.jarOfClass(classOf[SparkEngineConnFactory])
     if (somePath.isDefined) {

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/conf/PersistenceConf.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/conf/PersistenceConf.java
@@ -17,7 +17,6 @@
 
 package org.apache.linkis.cs.persistence.conf;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.linkis.common.conf.CommonVars;
 
 public class PersistenceConf {
@@ -32,10 +31,13 @@ public class PersistenceConf {
     public static final CommonVars<String> TUNING_METHOD =
             CommonVars.apply("wds.linkis.cs.ha.proxymethod", "getContextHAProxy");
 
-    public static final CommonVars<Boolean> ENABLE_CS_DESERIALIZE_REPLACE_PACKAGE_HEADER = CommonVars.apply("wds.linkis.cs.deserialize.replace_package_header.enable", false);
+    public static final CommonVars<Boolean> ENABLE_CS_DESERIALIZE_REPLACE_PACKAGE_HEADER =
+            CommonVars.apply("wds.linkis.cs.deserialize.replace_package_header.enable", false);
 
-    public static final CommonVars<String> CS_DESERIALIZE_REPLACE_PACKAGE_HEADER = CommonVars.apply("wds.linkis.cs.deserialize.replace_package.header", "com.webank.wedatasphere.linkis");
+    public static final CommonVars<String> CS_DESERIALIZE_REPLACE_PACKAGE_HEADER =
+            CommonVars.apply(
+                    "wds.linkis.cs.deserialize.replace_package.header",
+                    "com.webank.wedatasphere.linkis");
 
     public static final String CSID_PACKAGE_HEADER = "org.apache.linkis";
-
 }

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/conf/PersistenceConf.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/conf/PersistenceConf.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.cs.persistence.conf;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.linkis.common.conf.CommonVars;
 
 public class PersistenceConf {
@@ -30,4 +31,11 @@ public class PersistenceConf {
 
     public static final CommonVars<String> TUNING_METHOD =
             CommonVars.apply("wds.linkis.cs.ha.proxymethod", "getContextHAProxy");
+
+    public static final CommonVars<Boolean> ENABLE_CS_DESERIALIZE_REPLACE_PACKAGE_HEADER = CommonVars.apply("wds.linkis.cs.deserialize.replace_package_header.enable", false);
+
+    public static final CommonVars<String> CS_DESERIALIZE_REPLACE_PACKAGE_HEADER = CommonVars.apply("wds.linkis.cs.deserialize.replace_package.header", "com.webank.wedatasphere.linkis");
+
+    public static final String CSID_PACKAGE_HEADER = "org.apache.linkis";
+
 }

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextIDPersistenceImpl.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextIDPersistenceImpl.java
@@ -17,8 +17,10 @@
 
 package org.apache.linkis.cs.persistence.persistence.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.linkis.cs.common.entity.source.ContextID;
 import org.apache.linkis.cs.common.exception.CSErrorException;
+import org.apache.linkis.cs.persistence.conf.PersistenceConf;
 import org.apache.linkis.cs.persistence.dao.ContextIDMapper;
 import org.apache.linkis.cs.persistence.entity.ExtraFieldClass;
 import org.apache.linkis.cs.persistence.entity.PersistenceContextID;
@@ -82,6 +84,18 @@ public class ContextIDPersistenceImpl implements ContextIDPersistence {
         try {
             PersistenceContextID pContextID = contextIDMapper.getContextID(contextId);
             if (pContextID == null) return null;
+            if (PersistenceConf.ENABLE_CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue()) {
+                if (StringUtils.isBlank(pContextID.getSource()) || StringUtils.isBlank(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                    logger.error("Source : {} of ContextID or CSID_REPLACE_PACKAGE_HEADER : {} cannot be empty.", pContextID.getSource(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue());
+                } else {
+                    if (pContextID.getSource().contains(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Will replace package header of source : {} from : {} to : {}", pContextID.getSource(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER);
+                        }
+                        pContextID.setSource(pContextID.getSource().replaceAll(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER));
+                    }
+                }
+            }
             ExtraFieldClass extraFieldClass =
                     json.readValue(pContextID.getSource(), ExtraFieldClass.class);
             ContextID contextID = PersistenceUtils.transfer(extraFieldClass, pContextID);

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextIDPersistenceImpl.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextIDPersistenceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.linkis.cs.persistence.persistence.impl;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.linkis.cs.common.entity.source.ContextID;
 import org.apache.linkis.cs.common.exception.CSErrorException;
 import org.apache.linkis.cs.persistence.conf.PersistenceConf;
@@ -28,6 +27,7 @@ import org.apache.linkis.cs.persistence.persistence.ContextIDPersistence;
 import org.apache.linkis.cs.persistence.util.PersistenceUtils;
 import org.apache.linkis.server.BDPJettyServerHelper;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Pair;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,14 +85,35 @@ public class ContextIDPersistenceImpl implements ContextIDPersistence {
             PersistenceContextID pContextID = contextIDMapper.getContextID(contextId);
             if (pContextID == null) return null;
             if (PersistenceConf.ENABLE_CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue()) {
-                if (StringUtils.isBlank(pContextID.getSource()) || StringUtils.isBlank(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
-                    logger.error("Source : {} of ContextID or CSID_REPLACE_PACKAGE_HEADER : {} cannot be empty.", pContextID.getSource(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue());
+                if (StringUtils.isBlank(pContextID.getSource())
+                        || StringUtils.isBlank(
+                                PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                    logger.error(
+                            "Source : {} of ContextID or CSID_REPLACE_PACKAGE_HEADER : {} cannot be empty.",
+                            pContextID.getSource(),
+                            PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue());
                 } else {
-                    if (pContextID.getSource().contains(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                    if (pContextID
+                            .getSource()
+                            .contains(
+                                    PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER
+                                            .getValue())) {
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Will replace package header of source : {} from : {} to : {}", pContextID.getSource(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER);
+                            logger.debug(
+                                    "Will replace package header of source : {} from : {} to : {}",
+                                    pContextID.getSource(),
+                                    PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER
+                                            .getValue(),
+                                    PersistenceConf.CSID_PACKAGE_HEADER);
                         }
-                        pContextID.setSource(pContextID.getSource().replaceAll(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER));
+                        pContextID.setSource(
+                                pContextID
+                                        .getSource()
+                                        .replaceAll(
+                                                PersistenceConf
+                                                        .CS_DESERIALIZE_REPLACE_PACKAGE_HEADER
+                                                        .getValue(),
+                                                PersistenceConf.CSID_PACKAGE_HEADER));
                     }
                 }
             }

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextMapPersistenceImpl.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextMapPersistenceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.linkis.cs.persistence.persistence.impl;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.linkis.cs.common.entity.enumeration.ContextScope;
 import org.apache.linkis.cs.common.entity.enumeration.ContextType;
 import org.apache.linkis.cs.common.entity.source.ContextID;
@@ -37,6 +36,7 @@ import org.apache.linkis.cs.persistence.persistence.ContextMapPersistence;
 import org.apache.linkis.cs.persistence.util.PersistenceUtils;
 import org.apache.linkis.server.BDPJettyServerHelper;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Pair;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,14 +125,33 @@ public class ContextMapPersistenceImpl implements ContextMapPersistence {
             PersistenceContextKey pK = (PersistenceContextKey) pKV.getContextKey();
             PersistenceContextValue pV = (PersistenceContextValue) pKV.getContextValue();
             if (PersistenceConf.ENABLE_CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue()) {
-                if (StringUtils.isBlank(pKV.getProps()) || StringUtils.isBlank(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
-                    logger.error("Props : {} of ContextMap or CSID_REPLACE_PACKAGE_HEADER : {} cannot be empty.", pKV.getProps(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue());
+                if (StringUtils.isBlank(pKV.getProps())
+                        || StringUtils.isBlank(
+                                PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                    logger.error(
+                            "Props : {} of ContextMap or CSID_REPLACE_PACKAGE_HEADER : {} cannot be empty.",
+                            pKV.getProps(),
+                            PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue());
                 } else {
-                    if (pKV.getProps().contains(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                    if (pKV.getProps()
+                            .contains(
+                                    PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER
+                                            .getValue())) {
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Will replace package header of source : {} from : {} to : {}", pKV.getProps(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER);
+                            logger.debug(
+                                    "Will replace package header of source : {} from : {} to : {}",
+                                    pKV.getProps(),
+                                    PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER
+                                            .getValue(),
+                                    PersistenceConf.CSID_PACKAGE_HEADER);
                         }
-                        pKV.setProps(pKV.getProps().replaceAll(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER));
+                        pKV.setProps(
+                                pKV.getProps()
+                                        .replaceAll(
+                                                PersistenceConf
+                                                        .CS_DESERIALIZE_REPLACE_PACKAGE_HEADER
+                                                        .getValue(),
+                                                PersistenceConf.CSID_PACKAGE_HEADER));
                     }
                 }
             }

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextMapPersistenceImpl.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-persistence/src/main/java/org/apache/linkis/cs/persistence/persistence/impl/ContextMapPersistenceImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.cs.persistence.persistence.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.linkis.cs.common.entity.enumeration.ContextScope;
 import org.apache.linkis.cs.common.entity.enumeration.ContextType;
 import org.apache.linkis.cs.common.entity.source.ContextID;
@@ -26,6 +27,7 @@ import org.apache.linkis.cs.common.entity.source.ContextValue;
 import org.apache.linkis.cs.common.exception.CSErrorException;
 import org.apache.linkis.cs.common.serialize.helper.ContextSerializationHelper;
 import org.apache.linkis.cs.common.serialize.helper.SerializationHelper;
+import org.apache.linkis.cs.persistence.conf.PersistenceConf;
 import org.apache.linkis.cs.persistence.dao.ContextMapMapper;
 import org.apache.linkis.cs.persistence.entity.ExtraFieldClass;
 import org.apache.linkis.cs.persistence.entity.PersistenceContextKey;
@@ -122,6 +124,18 @@ public class ContextMapPersistenceImpl implements ContextMapPersistence {
             // TODO: 2020/2/14 null return
             PersistenceContextKey pK = (PersistenceContextKey) pKV.getContextKey();
             PersistenceContextValue pV = (PersistenceContextValue) pKV.getContextValue();
+            if (PersistenceConf.ENABLE_CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue()) {
+                if (StringUtils.isBlank(pKV.getProps()) || StringUtils.isBlank(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                    logger.error("Props : {} of ContextMap or CSID_REPLACE_PACKAGE_HEADER : {} cannot be empty.", pKV.getProps(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue());
+                } else {
+                    if (pKV.getProps().contains(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue())) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Will replace package header of source : {} from : {} to : {}", pKV.getProps(), PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER);
+                        }
+                        pKV.setProps(pKV.getProps().replaceAll(PersistenceConf.CS_DESERIALIZE_REPLACE_PACKAGE_HEADER.getValue(), PersistenceConf.CSID_PACKAGE_HEADER));
+                    }
+                }
+            }
             ExtraFieldClass extraFieldClass = json.readValue(pKV.getProps(), ExtraFieldClass.class);
             ContextKey key = PersistenceUtils.transfer(extraFieldClass.getOneSub(0), pK);
             ContextValue value = PersistenceUtils.transfer(extraFieldClass.getOneSub(1), pV);


### PR DESCRIPTION
### What is the purpose of the change
#1725  #1727 
Fix replace-package-header problems in linkis-cs-persistence and linkis-engineplugin-spark

### Brief change log
- Define a switch in linkis-cs-persistence module.
- Define a SparkPreExecutionHook in linkis-engineplugin-spark.

### Verifying this change
(Please pick either of the following options)  
This change added tests and can be verified as follows:  
(example:)  
- Added scala scripts to save dataframe as excel with old package header, which contains "com.webank.wedatasphere.linkis" 

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)