### PR TITLE
Dev 1.2.0 Add junit5 test code for [linkis-common] 

### DIFF
--- a/linkis-commons/linkis-common/pom.xml
+++ b/linkis-commons/linkis-common/pom.xml
@@ -75,6 +75,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${fasterxml.jackson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-annotations</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -98,6 +104,14 @@
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-reflect</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-annotations</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -116,17 +130,39 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j2.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-api</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
             <version>${log4j2.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-api</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--用于与sfl4j保持桥接-->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j2.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-core</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>log4j-api</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/ErrorCodeUtilsTest.java
+++ b/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/ErrorCodeUtilsTest.java
@@ -81,7 +81,6 @@ public class ErrorCodeUtilsTest {
             System.setSecurityManager(null);
         }
         Assertions.assertThat(isExited).isEqualTo(false);
-
     }
 
 } 

--- a/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/ErrorCodeUtilsTest.java
+++ b/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/ErrorCodeUtilsTest.java
@@ -1,0 +1,87 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.errorcode;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.security.AccessControlException;
+import java.security.Permission;
+
+/**
+ * ErrorCodeUtils Tester
+ */
+public class ErrorCodeUtilsTest {
+
+    @Autowired
+    private ErrorCodeUtils errorCodeUtils;
+
+    @BeforeEach
+    @DisplayName("Each unit test method is executed once before execution")
+    public void before() throws Exception {
+        final SecurityManager securityManager = new SecurityManager() {
+            public void checkPermission(Permission permission) {
+                if (permission.getName().startsWith("exitVM")) {
+                    throw new AccessControlException("");
+                }
+            }
+        };
+        System.setSecurityManager(securityManager);
+
+    }
+
+    @AfterEach
+    @DisplayName("Each unit test method is executed once before execution")
+    public void after() throws Exception {
+    }
+
+
+    @Test
+    @DisplayName("Method description: ...")
+    public void testValidateErrorCode() throws Exception {
+        boolean isExited = false;
+        try {
+            ErrorCodeUtils.validateErrorCode(0,1,2);
+        } catch (RuntimeException e) {
+            isExited = true;
+        }
+        Assertions.assertThat(isExited).isEqualTo(true);
+        isExited = false;
+        try {
+            ErrorCodeUtils.validateErrorCode(10000,1,2);
+        } catch (RuntimeException e) {
+            isExited = true;
+        }
+        Assertions.assertThat(isExited).isEqualTo(true);
+        isExited = false;
+        try {
+            ErrorCodeUtils.validateErrorCode(20000,20000,24999);
+        } catch (RuntimeException e) {
+            isExited = true;
+        } finally {
+            System.setSecurityManager(null);
+        }
+        Assertions.assertThat(isExited).isEqualTo(false);
+
+    }
+
+} 

--- a/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/LinkisCommonsErrorCodeSummaryTest.java
+++ b/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/LinkisCommonsErrorCodeSummaryTest.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * LinkisCommonsErrorCodeSummary Tester
+ */
 class LinkisCommonsErrorCodeSummaryTest {
 
     @ParameterizedTest

--- a/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/LinkisCommonsErrorCodeSummaryTest.java
+++ b/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/errorcode/LinkisCommonsErrorCodeSummaryTest.java
@@ -1,0 +1,100 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.errorcode;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LinkisCommonsErrorCodeSummaryTest {
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testGetErrorCode(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals(11000, linkisCommonsErrorCodeSummary.getErrorCode());
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testSetErrorCode(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals(11000, linkisCommonsErrorCodeSummary.getErrorCode());
+        linkisCommonsErrorCodeSummary.setErrorCode(1);
+        assertEquals(1, linkisCommonsErrorCodeSummary.getErrorCode());
+        linkisCommonsErrorCodeSummary.setErrorCode(2147483647);
+        assertEquals(2147483647, linkisCommonsErrorCodeSummary.getErrorCode());
+        linkisCommonsErrorCodeSummary.setErrorCode(11000);
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testGetErrorDesc(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals("引擎启动失败", linkisCommonsErrorCodeSummary.getErrorDesc());
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testSetErrorDesc(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals("引擎启动失败", linkisCommonsErrorCodeSummary.getErrorDesc());
+        linkisCommonsErrorCodeSummary.setErrorDesc("testSetErrorDesc");
+        assertEquals("testSetErrorDesc", linkisCommonsErrorCodeSummary.getErrorDesc());
+        linkisCommonsErrorCodeSummary.setErrorDesc("引擎启动失败");
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testGetComment(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals("引擎启动失败", linkisCommonsErrorCodeSummary.getComment());
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testSetComment(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals("引擎启动失败", linkisCommonsErrorCodeSummary.getComment());
+        linkisCommonsErrorCodeSummary.setComment("testSetComment");
+        assertEquals("testSetComment", linkisCommonsErrorCodeSummary.getComment());
+        linkisCommonsErrorCodeSummary.setComment("引擎启动失败");
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testGetModule(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals("hiveEngineConn", linkisCommonsErrorCodeSummary.getModule());
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testSetModule(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        assertEquals("hiveEngineConn", linkisCommonsErrorCodeSummary.getModule());
+        linkisCommonsErrorCodeSummary.setModule("testSetModule");
+        assertEquals("testSetModule", linkisCommonsErrorCodeSummary.getModule());
+        linkisCommonsErrorCodeSummary.setModule("hiveEngineConn");
+    }
+
+    @ParameterizedTest
+    @EnumSource(LinkisCommonsErrorCodeSummary.class)
+    void testToString(LinkisCommonsErrorCodeSummary linkisCommonsErrorCodeSummary) {
+        linkisCommonsErrorCodeSummary.setErrorCode(0);
+        linkisCommonsErrorCodeSummary.setErrorDesc("testSetErrorDesc");
+        assertEquals("errorCode: 0, errorDesc:testSetErrorDesc", linkisCommonsErrorCodeSummary.toString());
+        linkisCommonsErrorCodeSummary.setErrorCode(11000);
+        linkisCommonsErrorCodeSummary.setErrorDesc("引擎启动失败");
+        assertEquals("errorCode: 11000, errorDesc:引擎启动失败", linkisCommonsErrorCodeSummary.toString());
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change
Add JUNIT test for ErrorCodeUtils & LinkisCommonsErrorCodeSummary
Related issues: #1634 . 

### Brief change log
- Add test code for 	org.apache.linkis.common.errorcode.ErrorCodeUtils;
- Add test code for org.apache.linkis.common.errorcode.LinkisCommonsErrorCodeSummary.

### Verifying this change
- Added some tests under the [linkis-common] module, which pass after excluding conflicting dependencies locally.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (don't know)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)