### PR TITLE
Fix bug that default configuration for creator won't take effect.

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/ConfigurationMapCache.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/ConfigurationMapCache.scala
@@ -20,8 +20,9 @@ package org.apache.linkis.manager.am.conf
 import java.util
 
 import org.apache.linkis.common.conf.Configuration
-import org.apache.linkis.governance.common.protocol.conf.{RequestQueryEngineConfig, RequestQueryGlobalConfig, ResponseQueryConfig}
+import org.apache.linkis.governance.common.protocol.conf.{RequestQueryEngineConfig, RequestQueryGlobalConfig, RequestQueryEngineConfigWithGlobalConfig, ResponseQueryConfig}
 import org.apache.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import org.apache.linkis.manager.label.utils.EngineTypeLabelCreator
 import org.apache.linkis.protocol.CacheableProtocol
 import org.apache.linkis.rpc.RPCMapCache
 
@@ -38,10 +39,11 @@ object ConfigurationMapCache {
     }
   }
 
+
   val engineMapCache = new RPCMapCache[(UserCreatorLabel, EngineTypeLabel), String, String](
     Configuration.CLOUD_CONSOLE_CONFIGURATION_SPRING_APPLICATION_NAME.getValue) {
     override protected def createRequest(labelTuple: (UserCreatorLabel, EngineTypeLabel)): CacheableProtocol =
-      RequestQueryEngineConfig(labelTuple._1, labelTuple._2)
+    RequestQueryEngineConfigWithGlobalConfig(labelTuple._1, labelTuple._2)
 
     override protected def createMap(any: Any): util.Map[String, String] = any match {
       case response: ResponseQueryConfig => response.getKeyAndValue

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/EngineConnConfigurationService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/conf/EngineConnConfigurationService.scala
@@ -43,10 +43,6 @@ class DefaultEngineConnConfigurationService extends EngineConnConfigurationServi
     val engineTypeLabelOption = label.find(_.isInstanceOf[EngineTypeLabel])
     if (userCreatorLabelOption.isDefined) {
       val userCreatorLabel = userCreatorLabelOption.get.asInstanceOf[UserCreatorLabel]
-      val globalConfig = Utils.tryAndWarn(ConfigurationMapCache.globalMapCache.getCacheMap(userCreatorLabel))
-      if (null != globalConfig) {
-        properties.putAll(globalConfig)
-      }
       if (engineTypeLabelOption.isDefined) {
         val engineTypeLabel = engineTypeLabelOption.get.asInstanceOf[EngineTypeLabel]
         val engineConfig = Utils.tryAndWarn(ConfigurationMapCache.engineMapCache.getCacheMap((userCreatorLabel, engineTypeLabel)))

--- a/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/main/scala/org/apache/linkis/configuration/conf/Configuration.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/main/scala/org/apache/linkis/configuration/conf/Configuration.scala
@@ -35,7 +35,7 @@ object Configuration {
 
   val GLOBAL_CONF_LABEL = "*-*,*-*"
 
-  val USE_CREATOR_DEFAULE_VALUE = CommonVars.apply("wds.linkis.configuration.use.creator.default.value", false).getValue
+  val USE_CREATOR_DEFAULE_VALUE = CommonVars.apply("wds.linkis.configuration.use.creator.default.value", true).getValue
 
 
 

--- a/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
@@ -228,7 +228,7 @@ class ConfigurationService extends Logging {
         defaultConfig.setIsUserDefined(false)
         configs.asScala.foreach(config => {
           if(config.getKey != null && config.getKey.equals(defaultConfig.getKey)){
-            if(config.getConfigValue != null){
+            if(StringUtils.isNotBlank(config.getConfigValue)) {
               defaultConfig.setConfigValue(config.getConfigValue)
               defaultConfig.setConfigLabelId(config.getConfigLabelId)
               defaultConfig.setValueId(config.getValueId)
@@ -412,12 +412,24 @@ class ConfigurationService extends Logging {
     val map = new util.HashMap[String, String]()
     val allConfig = all.asScala.map(configTree => configTree.getSettings)
     val userConfig = user.asScala.map(configTree => configTree.getSettings)
-    if(filter != null){
-      allConfig.foreach(f => f.asScala.foreach(configKeyValue => if(configKeyValue.getKey.contains(filter)) map.put(configKeyValue.getKey,configKeyValue.getDefaultValue)))
-      userConfig.foreach(f => f.asScala.foreach(configKeyValue => if(configKeyValue.getKey.contains(filter) && StringUtils.isNotEmpty(configKeyValue.getConfigValue)) map.put(configKeyValue.getKey,configKeyValue.getConfigValue)))
-    }else{
-      allConfig.foreach(f => f.asScala.foreach(configKeyValue => map.put(configKeyValue.getKey,configKeyValue.getDefaultValue)))
-      userConfig.foreach(f => f.asScala.foreach(configKeyValue => if(StringUtils.isNotEmpty(configKeyValue.getConfigValue))map.put(configKeyValue.getKey,configKeyValue.getConfigValue)))
+    if (filter != null) {
+      allConfig.foreach(f => f.asScala.foreach(configKeyValue => if (configKeyValue.getKey.contains(filter)) map.put(configKeyValue.getKey, configKeyValue.getDefaultValue)))
+      userConfig.foreach(f => f.asScala.foreach(configKeyValue => if (configKeyValue.getKey.contains(filter)) {
+        if (StringUtils.isNotEmpty(configKeyValue.getConfigValue)) {
+          map.put(configKeyValue.getKey, configKeyValue.getConfigValue)
+        } else {
+          map.put(configKeyValue.getKey, configKeyValue.getDefaultValue)
+        }
+      }))
+    } else {
+      allConfig.foreach(f => f.asScala.foreach(configKeyValue => map.put(configKeyValue.getKey, configKeyValue.getDefaultValue)))
+      userConfig.foreach(f => f.asScala.foreach(configKeyValue => {
+        if (StringUtils.isNotEmpty(configKeyValue.getConfigValue)) {
+          map.put(configKeyValue.getKey, configKeyValue.getConfigValue)
+        } else {
+          map.put(configKeyValue.getKey, configKeyValue.getDefaultValue)
+        }
+      }))
     }
     /*此处的用户配置会覆盖默认的配置*/
     map


### PR DESCRIPTION
### What is the purpose of the change
close #1764

### Brief change log
- Change request in linkis-application-manager to get all engine's global configurations and user-defined configurations in   one request.
- Fix bug in linkis-configuration to get correct default creator params.

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  (yes)  
This change is already covered by existing tests, such as (please describe tests).  (no)  
This change added tests and can be verified as follows:  
(example:)  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)