### PR TITLE
Limit the size of data written to a single row of the result set 

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/conf/LinkisStorageConf.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/conf/LinkisStorageConf.scala
@@ -17,7 +17,8 @@
 
 package org.apache.linkis.storage.conf
 
-import org.apache.linkis.common.conf.CommonVars
+import org.apache.linkis.common.conf.{ByteType, CommonVars}
+import org.apache.linkis.common.utils.ByteTimeUtils
 
 object LinkisStorageConf {
   val HDFS_FILE_SYSTEM_REST_ERRS: String =
@@ -25,4 +26,9 @@ object LinkisStorageConf {
       "wds.linkis.hdfs.rest.errs",
       ".*Filesystem closed.*|.*Failed to find any Kerberos tgt.*")
       .getValue
+
+  val ROW_BYTE_MAX_LEN_STR = CommonVars("wds.linkis.resultset.row.max.str", "10m").getValue
+
+  val ROW_BYTE_MAX_LEN = ByteTimeUtils.byteStringAsBytes(ROW_BYTE_MAX_LEN_STR)
+
 }


### PR DESCRIPTION
### What is the purpose of the change
#1793

### Brief change log
- Limit the size of data written to a single row of the result set 

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)