### PR TITLE
Support users to deploy linkis without hdfs/hive/spark in localFs(without hdfs) mode

### DIFF
--- a/assembly-combined-package/bin/checkEnv.sh
+++ b/assembly-combined-package/bin/checkEnv.sh
@@ -34,10 +34,13 @@ function checkPythonAndJava(){
     isSuccess "execute cmd: java --version"
 }
 
-function checkHadoopAndHive(){
+function checkHdfs(){
     hadoopVersion="`hdfs version`"
     defaultHadoopVersion="2.7"
     checkversion "$hadoopVersion" $defaultHadoopVersion hadoop
+}
+
+function checkHive(){
     checkversion "$(whereis hive)" "2.3" hive
 }
 
@@ -96,7 +99,18 @@ echo "check sed"
 need_cmd sed
 echo "<-----end to check used cmd---->"
 
-checkSpark
 checkPythonAndJava
-checkHadoopAndHive
 
+if [ "$ENABLE_SPARK" == "true" ]; then
+  checkSpark
+fi
+
+
+if [ "$ENABLE_HDFS" == "true" ]; then
+  checkHdfs
+fi
+
+
+if [ "$ENABLE_HIVE" == "true" ]; then
+  checkHive
+fi

--- a/assembly-combined-package/deploy-config/linkis-env.sh
+++ b/assembly-combined-package/deploy-config/linkis-env.sh
@@ -148,3 +148,6 @@ LINKIS_PUBLIC_MODULE=lib/linkis-commons/public-module
 
 #If you want to start metadata related microservices, you can set this export ENABLE_METADATA_MANAGE=true
 export ENABLE_METADATA_MANAGER=false
+export ENABLE_HDFS=false
+export ENABLE_HIVE=false
+export ENABLE_SPARK=false


### PR DESCRIPTION
### What is the purpose of the change
Support users to deploy Apache Linkis in the environment without HDFS/Spark/Hive in localFs(without hdfs) mode.

The config is optional.

### Brief change log
- Modify the deploy shell scripts


### Verifying this change
This change added tests and can be verified as follows:  
- Copy Linkis tar files into a machine without Spark/Hive/HDFS
- Config and set `ENABLE_SPARK`, `ENABLE_HIVE`, `ENABLE_HDFS` to false in `linkis-env.sh` file
- execute 'bash install.sh'

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (yes )
- If yes, how is the feature documented? ( docs )
- The docs need to be pushed to linkis-website