### PR TITLE
Support BML Service deploy in localFs mode

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis.properties
@@ -38,7 +38,7 @@ wds.linkis.filesystem.root.path=file:///tmp/linkis/
 wds.linkis.filesystem.hdfs.root.path=hdfs:///tmp/linkis/
 ##bml path:default use hdfs
 wds.linkis.bml.is.hdfs=true
-wds.linkis.bml.hdfs.prefix=/apps-data
+#wds.linkis.bml.hdfs.prefix=/apps-data
 #wds.linkis.bml.local.prefix=/data/dss/bml
 
 ##engine Version

--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -18,6 +18,7 @@
 source ~/.bash_profile
 shellDir=`dirname $0`
 workDir=`cd ${shellDir}/..;pwd`
+common_conf=$LINKIS_HOME/conf/linkis.properties
 
 #To be compatible with MacOS and Linux
 txt=""
@@ -67,77 +68,8 @@ until mysql -h$MYSQL_HOST -P$MYSQL_PORT -u$MYSQL_USER -p$MYSQL_PASSWORD  -e ";" 
      exit 1
 done
 
-echo "======= Step 3: Create necessary directory =========="
 
-echo "[WORKSPACE_USER_ROOT_PATH] try to create directory"
-if [ "$WORKSPACE_USER_ROOT_PATH" != "" ]
-then
-  localRootDir=$WORKSPACE_USER_ROOT_PATH
-  if [[ $WORKSPACE_USER_ROOT_PATH == file://* ]];then
-    localRootDir=${WORKSPACE_USER_ROOT_PATH#file://}
-    echo "[WORKSPACE_USER_ROOT_PATH] try to create local dir,cmd is: mkdir -p $localRootDir/$deployUser"
-    mkdir -p $localRootDir/$deployUser
-    sudo chmod -R 775 $localRootDir/$deployUser
-  elif [[ $WORKSPACE_USER_ROOT_PATH == hdfs://* ]];then
-    localRootDir=${WORKSPACE_USER_ROOT_PATH#hdfs://}
-    echo "[WORKSPACE_USER_ROOT_PATH] try to create hdfs dir,cmd is: hdfs dfs -mkdir -p $localRootDir/$deployUser"
-    hdfs dfs -mkdir -p $localRootDir/$deployUser
-    hdfs dfs -chmod -R 775 $localRootDir/$deployUser
-  else
-    echo "[WORKSPACE_USER_ROOT_PATH] does not support $WORKSPACE_USER_ROOT_PATH filesystem types"
-  fi
-  isSuccess "create WORKSPACE_USER_ROOT_PATH: $WORKSPACE_USER_ROOT_PATH directory"
-fi
-
-
-
-########################  init hdfs and db  ################################
-echo "[HDFS_USER_ROOT_PATH] try to create directory"
- if [ "$HDFS_USER_ROOT_PATH" != "" ]
- then
-     localRootDir=$HDFS_USER_ROOT_PATH
-   if [[ $HDFS_USER_ROOT_PATH == file://* ]];then
-     localRootDir=${HDFS_USER_ROOT_PATH#file://}
-     echo "[HDFS_USER_ROOT_PATH] try to create local dir,cmd is: mkdir -p $localRootDir/$deployUser"
-     mkdir -p $localRootDir/$deployUser
-     sudo chmod -R 775 $localRootDir/$deployUser
-   elif [[ $HDFS_USER_ROOT_PATH == hdfs://* ]];then
-     localRootDir=${HDFS_USER_ROOT_PATH#hdfs://}
-     echo "[HDFS_USER_ROOT_PATH] try to create hdfs dir,cmd is: hdfs dfs -mkdir -p $localRootDir/$deployUser"
-     hdfs dfs -mkdir -p $localRootDir/$deployUser
-   else
-     echo "[HDFS_USER_ROOT_PATH] does not support $HDFS_USER_ROOT_PATH filesystem types"
-   fi
-
-   isSuccess "create HDFS_USER_ROOT_PATH: $HDFS_USER_ROOT_PATH directory"
-
- fi
-
-
-
-echo "[RESULT_SET_ROOT_PATH] try to create directory"
- if [ "$RESULT_SET_ROOT_PATH" != "" ]
- then
-   localRootDir=$RESULT_SET_ROOT_PATH
-   if [[ $RESULT_SET_ROOT_PATH == file://* ]];then
-     localRootDir=${RESULT_SET_ROOT_PATH#file://}
-     echo "[RESULT_SET_ROOT_PATH] try to create local dir,cmd is: mkdir -p $localRootDir/$deployUser"
-     mkdir -p $localRootDir/$deployUser
-     sudo chmod -R 775 $localRootDir/$deployUser
-   elif [[ $RESULT_SET_ROOT_PATH == hdfs://* ]];then
-     localRootDir=${RESULT_SET_ROOT_PATH#hdfs://}
-     echo "[RESULT_SET_ROOT_PATH] try to create hdfs dir,cmd is: hdfs dfs -mkdir -p $localRootDir/$deployUser"
-     hdfs dfs -mkdir -p $localRootDir
-     hdfs dfs -chmod 775 $localRootDir
-   else
-     echo "[RESULT_SET_ROOT_PATH] does not support $RESULT_SET_ROOT_PATH filesystem types"
-   fi
-
-   isSuccess "create RESULT_SET_ROOT_PATH: $RESULT_SET_ROOT_PATH directory"
-
- fi
-
-
+########################  init LINKIS related env  ################################
 if [ "$LINKIS_HOME" = "" ]
 then
   export LINKIS_HOME=${workDir}/LinkisInstall
@@ -170,6 +102,79 @@ fi
 
 cp ${LINKIS_CONFIG_PATH} $LINKIS_HOME/conf
 
+common_conf=$LINKIS_HOME/conf/linkis.properties
+
+echo "======= Step 3: Create necessary directory =========="
+
+echo "[WORKSPACE_USER_ROOT_PATH] try to create directory"
+if [ "$WORKSPACE_USER_ROOT_PATH" != "" ]
+then
+  localRootDir=$WORKSPACE_USER_ROOT_PATH
+  if [[ $WORKSPACE_USER_ROOT_PATH == file://* ]];then
+    localRootDir=${WORKSPACE_USER_ROOT_PATH#file://}
+    echo "[WORKSPACE_USER_ROOT_PATH] try to create local dir,cmd is: mkdir -p $localRootDir/$deployUser"
+    mkdir -p $localRootDir/$deployUser
+    sudo chmod -R 775 $localRootDir/$deployUser
+  elif [[ $WORKSPACE_USER_ROOT_PATH == hdfs://* ]];then
+    localRootDir=${WORKSPACE_USER_ROOT_PATH#hdfs://}
+    echo "[WORKSPACE_USER_ROOT_PATH] try to create hdfs dir,cmd is: hdfs dfs -mkdir -p $localRootDir/$deployUser"
+    hdfs dfs -mkdir -p $localRootDir/$deployUser
+    hdfs dfs -chmod -R 775 $localRootDir/$deployUser
+  else
+    echo "[WORKSPACE_USER_ROOT_PATH] does not support $WORKSPACE_USER_ROOT_PATH filesystem types"
+  fi
+  isSuccess "create WORKSPACE_USER_ROOT_PATH: $WORKSPACE_USER_ROOT_PATH directory"
+fi
+
+
+
+########################  init hdfs and db  ################################
+echo "[HDFS_USER_ROOT_PATH] try to create directory"
+ if [ "$HDFS_USER_ROOT_PATH" != "" ]
+ then
+     localRootDir=$HDFS_USER_ROOT_PATH
+   if [[ $HDFS_USER_ROOT_PATH == file://* ]];then
+     sed -i ${txt}  "s#wds.linkis.bml.is.hdfs.*#wds.linkis.bml.is.hdfs=false#g" $common_conf
+     sed -i ${txt}  "s#\#wds.linkis.bml.local.prefix.*#wds.linkis.bml.local.prefix=$HDFS_USER_ROOT_PATH#g" $common_conf
+     localRootDir=${HDFS_USER_ROOT_PATH#file://}
+     echo "[HDFS_USER_ROOT_PATH] try to create local dir,cmd is: mkdir -p $localRootDir/$deployUser"
+     mkdir -p $localRootDir/$deployUser
+     sudo chmod -R 775 $localRootDir/$deployUser
+   elif [[ $HDFS_USER_ROOT_PATH == hdfs://* ]];then
+     sed -i ${txt}  "s#\#wds.linkis.bml.hdfs.prefix.*#wds.linkis.bml.hdfs.prefix=$HDFS_USER_ROOT_PATH#g" $common_conf
+     localRootDir=${HDFS_USER_ROOT_PATH#hdfs://}
+     echo "[HDFS_USER_ROOT_PATH] try to create hdfs dir,cmd is: hdfs dfs -mkdir -p $localRootDir/$deployUser"
+     hdfs dfs -mkdir -p $localRootDir/$deployUser
+   else
+     echo "[HDFS_USER_ROOT_PATH] does not support $HDFS_USER_ROOT_PATH filesystem types"
+   fi
+
+   isSuccess "create HDFS_USER_ROOT_PATH: $HDFS_USER_ROOT_PATH directory"
+
+ fi
+
+
+echo "[RESULT_SET_ROOT_PATH] try to create directory"
+ if [ "$RESULT_SET_ROOT_PATH" != "" ]
+ then
+   localRootDir=$RESULT_SET_ROOT_PATH
+   if [[ $RESULT_SET_ROOT_PATH == file://* ]];then
+     localRootDir=${RESULT_SET_ROOT_PATH#file://}
+     echo "[RESULT_SET_ROOT_PATH] try to create local dir,cmd is: mkdir -p $localRootDir/$deployUser"
+     mkdir -p $localRootDir/$deployUser
+     sudo chmod -R 775 $localRootDir/$deployUser
+   elif [[ $RESULT_SET_ROOT_PATH == hdfs://* ]];then
+     localRootDir=${RESULT_SET_ROOT_PATH#hdfs://}
+     echo "[RESULT_SET_ROOT_PATH] try to create hdfs dir,cmd is: hdfs dfs -mkdir -p $localRootDir/$deployUser"
+     hdfs dfs -mkdir -p $localRootDir
+     hdfs dfs -chmod 775 $localRootDir
+   else
+     echo "[RESULT_SET_ROOT_PATH] does not support $RESULT_SET_ROOT_PATH filesystem types"
+   fi
+
+   isSuccess "create RESULT_SET_ROOT_PATH: $RESULT_SET_ROOT_PATH directory"
+
+ fi
 
 
 echo "======= Step 4: Create linkis table =========="
@@ -188,7 +193,6 @@ else
   sed -i ${txt}  "s#@KERBEROS_ENABLE#false#g" $LINKIS_HOME/db/linkis_dml.sql
 fi
 
-common_conf=$LINKIS_HOME/conf/linkis.properties
 SERVER_IP=$local_host
 
 ##Label set start
@@ -292,8 +296,6 @@ sed -i ${txt}  "s#wds.linkis.home.*#wds.linkis.home=$LINKIS_HOME#g" $common_conf
 
 sed -i ${txt}  "s#wds.linkis.filesystem.root.path.*#wds.linkis.filesystem.root.path=$WORKSPACE_USER_ROOT_PATH#g" $common_conf
 sed -i ${txt}  "s#wds.linkis.filesystem.hdfs.root.path.*#wds.linkis.filesystem.hdfs.root.path=$HDFS_USER_ROOT_PATH#g" $common_conf
-
-sed -i ${txt}  "s#wds.linkis.bml.hdfs.prefix.*#wds.linkis.bml.hdfs.prefix=$HDFS_USER_ROOT_PATH#g" $common_conf
 
 ##gateway
 gateway_conf=$LINKIS_HOME/conf/linkis-mg-gateway.properties

--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -77,13 +77,13 @@ fi
 
 if [  -d $LINKIS_HOME ] && [ "$LINKIS_HOME" != "$workDir" ];then
    echo "LINKIS_HOME: $LINKIS_HOME is alread exists and will be backed up"
-   if [  -d $LINKIS_HOME-bak ];then
-    rm -r $LINKIS_HOME-bak
-   fi
 
-   echo "mv  $LINKIS_HOME  $LINKIS_HOME-bak"
-   mv  $LINKIS_HOME  $LINKIS_HOME-bak
-   isSuccess "back up old LINKIS_HOME:$LINKIS_HOME to $LINKIS_HOME-bak"
+   ## Every time, backup the old linkis home with timestamp and not clean them.
+   ## If you want to clean them, please delete them manually.
+   curTs=`date +'%s'`
+   echo "mv  $LINKIS_HOME  $LINKIS_HOME-$curTs"
+   mv  $LINKIS_HOME  $LINKIS_HOME-$curTs
+   isSuccess "back up old LINKIS_HOME:$LINKIS_HOME to $LINKIS_HOME-$curTs"
 fi
 echo "try to create dir LINKIS_HOME: $LINKIS_HOME"
 sudo mkdir -p $LINKIS_HOME;sudo chown -R $deployUser:$deployUser $LINKIS_HOME


### PR DESCRIPTION
### What is the purpose of the change
Support BML Service deploy in localFs mode

for issue: https://github.com/apache/incubator-linkis/issues/1810

### Brief change log
- modify install script to support deploy BML in local fs mode

### Verifying this change
- manually modify the config `HDFS_USER_ROOT_PATH` in file `linkis-env.sh` to a value starts with 'file:///' and some other necessary config, such as db
- execute `install.sh` to install 
- start all the service
- send a request to BML Service and upload the resource

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: ( no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)

### Documentation
- Does this pull request introduce a new feature? (yes )
- If yes, how is the feature documented? ( docs )
- docs will be late be submitted to linkis-website