### PR TITLE
Script custom variable run type and suffix constraint configuration.

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/PYScriptCompaction.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/PYScriptCompaction.scala
@@ -17,15 +17,12 @@
  
 package org.apache.linkis.storage.script.compaction
 
+import org.apache.linkis.storage.utils.StorageConfiguration
+
 
 class PYScriptCompaction private extends CommonScriptCompaction {
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "python"|"py"|"sh" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = StorageConfiguration.getSuffixBelongToRunTypeOrNot(suffix, StorageConfiguration.RUN_TYPE_PYTHON)
 
   override def prefix: String = "#@set"
 

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/QLScriptCompaction.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/QLScriptCompaction.scala
@@ -17,16 +17,12 @@
  
 package org.apache.linkis.storage.script.compaction
 
+import org.apache.linkis.storage.utils.StorageConfiguration
 
-class QLScriptCompaction private extends CommonScriptCompaction{
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "sql" => true
-      case "hql" => true
-      case _ => false
-    }
-  }
+class QLScriptCompaction private extends CommonScriptCompaction {
+
+  override def belongTo(suffix: String): Boolean = StorageConfiguration.getSuffixBelongToRunTypeOrNot(suffix, StorageConfiguration.RUN_TYPE_SQL)
 
   override def prefix: String = "--@set"
 

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/ScalaScriptCompaction.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/ScalaScriptCompaction.scala
@@ -17,14 +17,13 @@
  
 package org.apache.linkis.storage.script.compaction
 
+import org.apache.linkis.storage.utils.StorageConfiguration
+
 
 class ScalaScriptCompaction private extends CommonScriptCompaction{
   override def prefix: String = "//@set"
 
-  override def belongTo(suffix: String): Boolean = suffix match {
-    case "scala" => true
-    case _ => false
-  }
+  override def belongTo(suffix: String): Boolean = StorageConfiguration.getSuffixBelongToRunTypeOrNot(suffix, StorageConfiguration.RUN_TYPE_SCALA)
 
   override def prefixConf: String = "//conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/PYScriptParser.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/PYScriptParser.scala
@@ -17,16 +17,13 @@
  
 package org.apache.linkis.storage.script.parser
 
+import org.apache.linkis.storage.utils.StorageConfiguration
+
 
 class PYScriptParser private extends CommonScriptParser {
   override def prefix: String = "#@set"
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "python"|"py"|"sh" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = StorageConfiguration.getSuffixBelongToRunTypeOrNot(suffix, StorageConfiguration.RUN_TYPE_PYTHON)
 
   override def prefixConf: String = "#conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/QLScriptParser.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/QLScriptParser.scala
@@ -17,17 +17,13 @@
  
 package org.apache.linkis.storage.script.parser
 
+import org.apache.linkis.storage.utils.StorageConfiguration
+
 
 class QLScriptParser private extends CommonScriptParser {
   override def prefix: String = "--@set"
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "sql" => true
-      case "hql" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = StorageConfiguration.getSuffixBelongToRunTypeOrNot(suffix, StorageConfiguration.RUN_TYPE_SQL)
 
   override def prefixConf: String = "--conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/ScalaScriptParser.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/ScalaScriptParser.scala
@@ -17,17 +17,14 @@
  
 package org.apache.linkis.storage.script.parser
 
+import org.apache.linkis.storage.utils.StorageConfiguration
+
 
 class ScalaScriptParser private extends CommonScriptParser {
   //todo To be determined(待定)
   override def prefix: String = "//@set"
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "scala" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = StorageConfiguration.getSuffixBelongToRunTypeOrNot(suffix, StorageConfiguration.RUN_TYPE_SCALA)
 
   override def prefixConf: String = "//conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/utils/StorageConfiguration.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/utils/StorageConfiguration.scala
@@ -66,4 +66,32 @@ object StorageConfiguration {
 
   val HDFS_PATH_PREFIX_REMOVE = CommonVars[Boolean]("wds.linkis.storage.hdfs.prefxi.remove", true)
 
+  val CODE_TYPE_AND_RUN_TYPE_RELATION = CommonVars("wds.linkis.storage.codeType.runType.relation", "sql=>hql|sql|jdbc|hive|psql|sh|shell,python=>python|py,java=>java,scala=>scala")
+
+  val RUN_TYPE_SQL = "sql"
+  val RUN_TYPE_PYTHON = "python"
+  val RUN_TYPE_JAVA = "java"
+  val RUN_TYPE_SCALA = "scala"
+
+  def getCodeTypeAndRunTypeRelationMap: Map[String, List[String]] = {
+    if (CODE_TYPE_AND_RUN_TYPE_RELATION.getValue == null || "".equals(CODE_TYPE_AND_RUN_TYPE_RELATION.getValue)) {
+      return Map()
+    }
+
+    CODE_TYPE_AND_RUN_TYPE_RELATION.getValue.split(",")
+      .filter(x => x != null && !"".equals(x))
+      .map(x => {
+        val confArr = x.split("=>")
+        if (confArr.length == 2) (confArr(0), for (x <- confArr(1).split("\\|").toList) yield x.trim) else null
+      }).filter(x => x != null).toMap
+  }
+
+  def getSuffixBelongToRunTypeOrNot(suffix: String, runType: String): Boolean = {
+    val codeTypeAndRunTypeRelationMap = getCodeTypeAndRunTypeRelationMap
+    if (codeTypeAndRunTypeRelationMap.isEmpty) return false
+    val suffixListOfRunType = codeTypeAndRunTypeRelationMap.getOrElse(runType, List())
+    if (suffixListOfRunType.isEmpty) return false
+    if (suffixListOfRunType.contains(suffix)) return true
+    false
+  }
 }


### PR DESCRIPTION
### What is the purpose of the change 
引擎类型、脚本类型自定义后，脚本中的变量解析异常，需要在源码中修改几个脚本，基于此，需要把此类配置抽取出来作为配置文件中的一个配置项。https://github.com/apache/incubator-linkis/issues/1751

After the engine type and script type are customized, the variable parsing in the script is abnormal, and several scripts need to be modified in the source code. Based on this, such configuration needs to be extracted as a configuration item in the configuration file. https://github.com/apache/incubator-linkis/issues/1751

### Brief change log
增加配置项，以及对应的配置解析工具方法, Add configuration items, and the corresponding configuration parsing tool method

  val CODE_TYPE_AND_RUN_TYPE_RELATION = CommonVars("wds.linkis.storage.codeType.runType.relation", "sql=>hql|sql|jdbc|hive|psql|sh|shell,python=>python|py,java=>java,scala=>scala")

```java
  def getCodeTypeAndRunTypeRelationMap: Map[String, List[String]] = {
    if (CODE_TYPE_AND_RUN_TYPE_RELATION.getValue == null || "".equals(CODE_TYPE_AND_RUN_TYPE_RELATION.getValue)) {
      return Map()
    }

    CODE_TYPE_AND_RUN_TYPE_RELATION.getValue.split(",")
      .filter(x => x != null && !"".equals(x))
      .map(x => {
        val confArr = x.split("=>")
        if (confArr.length == 2) (confArr(0), for (x <- confArr(1).split("\\|").toList) yield x.trim) else null
      }).filter(x => x != null).toMap
  }
```
只是还有几个问题需要确认：
1. 对应配置项CODE_TYPE_AND_RUN_TYPE_RELATION 的定义是否合理，放在StorageConfiguration中是否合适？
2. CustomVariableUtils文件中，runType匹配关系如下
```java
    runType match {
      case "hql" | "sql" | "jdbc" | "hive"| "psql" => codeType = SQL_TYPE
      case "python" | "py" => codeType = PY_TYPE
      case "java" => codeType = JAVA_TYPE
      case "scala" => codeType = SCALA_TYPE
      case "sh" | "shell" => codeType = SQL_TYPE
      case _ => return (false, code)
    }
```
其中sh shell类型对应的codeType SQL_TYPE 这样是否合理？
3. orchestrator模块中有一个文件也叫CustomVariableUtils，其中用到了上述配置，但是缺少linkis-storage模块依赖，
```xml
       <dependency>
            <groupId>org.apache.linkis</groupId>
            <artifactId>linkis-storage</artifactId>
            <version>${linkis.version}</version>
            <scope>provided</scope>
        </dependency>
```
是否可以直接加呢？会不会引起依赖冲突



