### PR TITLE
下载csv格式数据时，字段值为json数据格式，会被英文逗号切割导致数据列错乱问题改善

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/csv/CSVFsWriter.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/csv/CSVFsWriter.scala
@@ -25,9 +25,10 @@ import org.apache.linkis.common.io.FsWriter
 abstract class CSVFsWriter extends FsWriter {
   val charset: String
   val separator: String
+  val quoteRetouchValue: Boolean
 }
 
 object CSVFsWriter {
-  def getCSVFSWriter(charset: String, separator: String, outputStream: OutputStream): CSVFsWriter = new StorageCSVWriter(charset, separator, outputStream)
+  def getCSVFSWriter(charset: String, separator: String, quoteRetouchValue: Boolean, outputStream: OutputStream): CSVFsWriter = new StorageCSVWriter(charset, separator, quoteRetouchValue, outputStream)
 }
 

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/csv/StorageCSVWriter.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/csv/StorageCSVWriter.scala
@@ -25,7 +25,7 @@ import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
 import org.apache.commons.io.IOUtils
 
 
-class StorageCSVWriter(val charset: String, val separator: String, val outputStream: OutputStream) extends CSVFsWriter with Logging {
+class StorageCSVWriter(val charset: String, val separator: String, val quoteRetouchValue: Boolean, val outputStream: OutputStream) extends CSVFsWriter with Logging {
 
   private val delimiter = separator match {
     case "," => ','
@@ -42,8 +42,18 @@ class StorageCSVWriter(val charset: String, val separator: String, val outputStr
   }
 
   private def compact(row: Array[String]): String = {
-    val tmp = row.foldLeft("")((l, r) => l + delimiter + r)
-    tmp.substring(1, tmp.length) + "\n"
+    val quotationMarks: String = "\""
+    def decorateValue(v: String): String = {
+      if (v == null || "".equals(v.trim)) v
+      else {
+        if (quoteRetouchValue) {
+          s"$quotationMarks${v.replaceAll(quotationMarks, "")}$quotationMarks"
+        }
+        else v
+      }
+    }
+
+    row.map(x => decorateValue(x)).toList.mkString(delimiter.toString) + "\n"
   }
 
   private def write(row: Array[String]) = {

--- a/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/scala/org/apache/linkis/manager/engineplugin/pipeline/conf/PipelineEngineConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/scala/org/apache/linkis/manager/engineplugin/pipeline/conf/PipelineEngineConfiguration.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.manager.engineplugin.pipeline.conf
 
 import org.apache.linkis.common.conf.CommonVars
-import org.apache.linkis.manager.engineplugin.pipeline.constant.PipeLineConstant.{PIPELINE_FIELD_SPLIT, PIPELINE_OUTPUT_CHARSET, PIPELINE_OUTPUT_ISOVERWRITE}
+import org.apache.linkis.manager.engineplugin.pipeline.constant.PipeLineConstant.{PIPELINE_FIELD_QUOTE_RETOUCH_CONF, PIPELINE_FIELD_SPLIT, PIPELINE_OUTPUT_CHARSET, PIPELINE_OUTPUT_ISOVERWRITE}
 
 object PipelineEngineConfiguration {
 
@@ -27,5 +27,7 @@ object PipelineEngineConfiguration {
   val PIPELINE_OUTPUT_CHARSET_STR = CommonVars(PIPELINE_OUTPUT_CHARSET, "UTF-8")
 
   val PIPELINE_FIELD_SPLIT_STR = CommonVars(PIPELINE_FIELD_SPLIT, " ")
+
+  val PIPELINE_FIELD_QUOTE_RETOUCH = CommonVars[Boolean](PIPELINE_FIELD_QUOTE_RETOUCH_CONF, false)
 
 }

--- a/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/scala/org/apache/linkis/manager/engineplugin/pipeline/constant/PipeLineConstant.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/scala/org/apache/linkis/manager/engineplugin/pipeline/constant/PipeLineConstant.scala
@@ -25,5 +25,7 @@ object PipeLineConstant {
   val PIPELINE_OUTPUT_SHUFFLE_NULL_TYPE = "wds.linkis.engine.pipeline.output.shuffle.null.type"
   val PIPELINE_OUTPUT_CHARSET = "wds.linkis.engine.pipeline.output.charset"
   val PIPELINE_FIELD_SPLIT = "wds.linkis.engine.pipeline.field.split"
+  val PIPELINE_FIELD_QUOTE_RETOUCH_CONF = "wds.linkis.engine.pipeline.field.quote.retoch"
+  val PIPELINE_FIELD_ = "wds.linkis.engine.pipeline.field.split"
   val BLANK = "BLANK"
 }

--- a/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/scala/org/apache/linkis/manager/engineplugin/pipeline/executor/CSVExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/scala/org/apache/linkis/manager/engineplugin/pipeline/executor/CSVExecutor.scala
@@ -18,10 +18,9 @@
 package org.apache.linkis.manager.engineplugin.pipeline.executor
 
 import java.io.OutputStream
-
 import org.apache.linkis.common.io.FsPath
 import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
-import org.apache.linkis.manager.engineplugin.pipeline.conf.PipelineEngineConfiguration.{PIPELINE_FIELD_SPLIT_STR, PIPELINE_OUTPUT_CHARSET_STR, PIPELINE_OUTPUT_ISOVERWRITE_SWITCH}
+import org.apache.linkis.manager.engineplugin.pipeline.conf.PipelineEngineConfiguration.{PIPELINE_FIELD_QUOTE_RETOUCH, PIPELINE_FIELD_SPLIT_STR, PIPELINE_OUTPUT_CHARSET_STR, PIPELINE_OUTPUT_ISOVERWRITE_SWITCH}
 import org.apache.linkis.manager.engineplugin.pipeline.constant.PipeLineConstant._
 import org.apache.linkis.manager.engineplugin.pipeline.exception.PipeLineErrorException
 import org.apache.linkis.scheduler.executer.ExecuteResponse
@@ -54,7 +53,7 @@ class CSVExecutor extends PipeLineExecutor {
     if (BLANK.equalsIgnoreCase(nullValue)) nullValue = ""
     val outputStream: OutputStream = destFs.write(destFsPath, PIPELINE_OUTPUT_ISOVERWRITE_SWITCH.getValue(options))
     OutputStreamCache.osCache.put(engineExecutionContext.getJobId.get, outputStream)
-    val cSVFsWriter = CSVFsWriter.getCSVFSWriter(PIPELINE_OUTPUT_CHARSET_STR.getValue(options), PIPELINE_FIELD_SPLIT_STR.getValue(options), outputStream)
+    val cSVFsWriter = CSVFsWriter.getCSVFSWriter(PIPELINE_OUTPUT_CHARSET_STR.getValue(options), PIPELINE_FIELD_SPLIT_STR.getValue(options), PIPELINE_FIELD_QUOTE_RETOUCH.getValue(options), outputStream)
     fileSource.addParams("nullValue", nullValue).write(cSVFsWriter)
     IOUtils.closeQuietly(cSVFsWriter)
     IOUtils.closeQuietly(fileSource)

--- a/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -486,7 +486,8 @@ public class FsRestfulApi {
             @RequestParam(value = "outputFileName", defaultValue = "downloadResultset")
                     String outputFileName,
             @RequestParam(value = "sheetName", defaultValue = "result") String sheetName,
-            @RequestParam(value = "nullValue", defaultValue = "NULL") String nullValue)
+            @RequestParam(value = "nullValue", defaultValue = "NULL") String nullValue,
+            @RequestParam(value = "quoteRetouch", required = false) boolean quoteRetouch)
             throws WorkSpaceException, IOException {
         ServletOutputStream outputStream = null;
         FsWriter fsWriter = null;
@@ -522,7 +523,7 @@ public class FsRestfulApi {
             switch (outputFileType) {
                 case "csv":
                     if (FileSource$.MODULE$.isTableResultSet(fileSource)) {
-                        fsWriter = CSVFsWriter.getCSVFSWriter(charset, csvSeperator, outputStream);
+                        fsWriter = CSVFsWriter.getCSVFSWriter(charset, csvSeperator, quoteRetouch, outputStream);
                     } else {
                         fsWriter =
                                 ScriptFsWriter.getScriptFsWriter(


### PR DESCRIPTION
https://github.com/apache/incubator-linkis/issues/1832

下载csv/excel格式数据时，字段值为json数据格式，会被英文逗号切割 错乱，数据在下载时，是否可以指定一个默认选项，让用户选择是否把每个字段的数据值用""包裹。

When downloading data in csv/excel format, the field value is in json data format, which will be divided by English commas. When downloading the data, can you specify a default option to let the user choose whether to wrap the data value of each field with ""?

数据下载接口resultsetToExcel 增加额外选项，quoteRetouch，默认false，如果为true会对结果集的数据进行英文双引号修饰，作为列识别符号。
如：原始数据
1,2,3,{"a": 1, "b": 2}
会被转变为
"1","2","3","{a: 1, b: 2}"

这样用户直接用Excel打开下载的csv文件时，不会出现列错乱切割的现象，最好对应DSS的下载前端，增加是否加双引号列限定符的配置。

<img width="555" alt="image" src="https://user-images.githubusercontent.com/27730211/160797357-3db48886-af09-4a4b-821a-3a291085e8e5.png">
