### PR TITLE
fix install script for result set store path

### DIFF
--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -350,7 +350,7 @@ then
 fi
 if [ "$RESULT_SET_ROOT_PATH" != "" ]
 then
-  sed -i ${txt}  "s#wds.linkis.resultSet.store.path.*wds.linkis.resultSet.store.path=$RESULT_SET_ROOT_PATH#g" $entrance_conf
+  sed -i ${txt}  "s#wds.linkis.resultSet.store.path.*#wds.linkis.resultSet.store.path=$RESULT_SET_ROOT_PATH#g" $entrance_conf
 fi
 
 publicservice_conf=$LINKIS_HOME/conf/linkis-ps-publicservice.properties


### PR DESCRIPTION
### What is the purpose of the change
for issue: https://github.com/apache/incubator-linkis/issues/1845

### Brief change log
- minor fix

### Verifying this change
This change added can be verified as follows:  
- config the key 'wds.linkis.resultSet.store.path'
- deploy linkis


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: ( no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)

### Documentation
- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not applicable )