### PR TITLE
Script custom variable run type and suffix constraint configuration.

### DIFF
--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtils.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtils.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.utils
+
+import org.apache.linkis.common.conf.CommonVars
+
+object CodeAndRunTypeUtils {
+  private val CONF_LOCK = new Object()
+
+  val CODE_TYPE_AND_RUN_TYPE_RELATION = CommonVars("wds.linkis.codeType.runType.relation", "sql=>sql|hql|jdbc|hive|psql|fql,python=>python|py|pyspark,java=>java,scala=>scala,shell=>sh|shell")
+
+  val RUN_TYPE_SQL = "sql"
+  val RUN_TYPE_PYTHON = "python"
+  val RUN_TYPE_JAVA = "java"
+  val RUN_TYPE_SCALA = "scala"
+  val RUN_TYPE_SHELL = "shell"
+
+  private var codeTypeAndRunTypeRelationMap: Map[String, List[String]] = null
+
+  private def codeTypeAndRunTypeRelationMapParser(configV: String): Map[String, List[String]] = {
+    val confDelimiter = ","
+    if (configV == null || "".equals(configV)) Map()
+    else configV.split(confDelimiter).filter(x => x != null && !"".equals(x)).map(x => {
+      val confArr = x.split("=>")
+      if (confArr.length == 2) (confArr(0), for (x <- confArr(1).split("\\|").toList) yield x.trim) else null
+    }).filter(x => x != null).toMap
+  }
+
+  def getCodeTypeAndRunTypeRelationMap: Map[String, List[String]] = CONF_LOCK.synchronized {
+    if (null == codeTypeAndRunTypeRelationMap) {
+      codeTypeAndRunTypeRelationMap = codeTypeAndRunTypeRelationMapParser(CODE_TYPE_AND_RUN_TYPE_RELATION.getValue)
+    }
+    codeTypeAndRunTypeRelationMap
+  }
+
+  def getRunTypeAndCodeTypeRelationMap: Map[String, String] = {
+    val codeTypeAndRunTypeRelationMap = getCodeTypeAndRunTypeRelationMap
+    if (codeTypeAndRunTypeRelationMap.isEmpty) Map()
+    else codeTypeAndRunTypeRelationMap.flatMap(x => x._2.map(y => (y, x._1)))
+  }
+
+  def getSuffixBelongToRunTypeOrNot(suffix: String, runType: String): Boolean = {
+    val codeTypeAndRunTypeRelationMap = getCodeTypeAndRunTypeRelationMap
+    if (codeTypeAndRunTypeRelationMap.isEmpty) return false
+    val suffixListOfRunType = codeTypeAndRunTypeRelationMap.getOrElse(runType, List())
+    if (suffixListOfRunType.isEmpty) return false
+    if (suffixListOfRunType.contains(suffix)) return true
+    false
+  }
+}

--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtils.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtils.scala
@@ -41,9 +41,13 @@ object CodeAndRunTypeUtils {
     }).filter(x => x != null).toMap
   }
 
-  def getCodeTypeAndRunTypeRelationMap: Map[String, List[String]] = CONF_LOCK.synchronized {
-    if (null == codeTypeAndRunTypeRelationMap) {
-      codeTypeAndRunTypeRelationMap = codeTypeAndRunTypeRelationMapParser(CODE_TYPE_AND_RUN_TYPE_RELATION.getValue)
+  def getCodeTypeAndRunTypeRelationMap: Map[String, List[String]] = {
+    if (codeTypeAndRunTypeRelationMap == null) {
+      CONF_LOCK.synchronized {
+        if (codeTypeAndRunTypeRelationMap == null) {
+          codeTypeAndRunTypeRelationMap = codeTypeAndRunTypeRelationMapParser(CODE_TYPE_AND_RUN_TYPE_RELATION.getValue)
+        }
+      }
     }
     codeTypeAndRunTypeRelationMap
   }

--- a/linkis-commons/linkis-common/src/test/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtilsTest.scala
+++ b/linkis-commons/linkis-common/src/test/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtilsTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.utils
+import org.junit.{Assert, Test}
+
+@Test
+class CodeAndRunTypeUtilsTest extends Assert {
+
+  @Test
+  def testGetCodeTypeAndRunTypeRelationMap(): Unit = {
+    val codeTypeAndRunTypeRelationMap = CodeAndRunTypeUtils.getCodeTypeAndRunTypeRelationMap
+    assert(codeTypeAndRunTypeRelationMap.nonEmpty)
+    assert(codeTypeAndRunTypeRelationMap.keySet.contains("sql"))
+    assert(codeTypeAndRunTypeRelationMap("python").size == 2)
+  }
+
+  @Test
+  def testGetRunTypeAndCodeTypeRelationMap(): Unit = {
+    val runTypeAndCodeTypeRelationMap = CodeAndRunTypeUtils.getRunTypeAndCodeTypeRelationMap
+    assert(runTypeAndCodeTypeRelationMap.nonEmpty)
+    assert(CodeAndRunTypeUtils.RUN_TYPE_SHELL.equals(runTypeAndCodeTypeRelationMap("sh")))
+    assert(CodeAndRunTypeUtils.RUN_TYPE_SQL.equals(runTypeAndCodeTypeRelationMap("psql")))
+  }
+
+  @Test
+  def testGetSuffixBelongToRunTypeOrNot(): Unit = {
+    val shell = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot("sh", CodeAndRunTypeUtils.RUN_TYPE_SHELL)
+    assert(shell)
+    val sql = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot("jdbc", CodeAndRunTypeUtils.RUN_TYPE_SQL)
+    assert(sql)
+    val hql = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot("hql", CodeAndRunTypeUtils.RUN_TYPE_SQL)
+    assert(hql)
+    val python = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot("py", CodeAndRunTypeUtils.RUN_TYPE_PYTHON)
+    assert(python)
+    val scala = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot("java", CodeAndRunTypeUtils.RUN_TYPE_SCALA)
+    assert(!scala)
+  }
+}

--- a/linkis-commons/linkis-common/src/test/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtilsTest.scala
+++ b/linkis-commons/linkis-common/src/test/scala/org/apache/linkis/common/utils/CodeAndRunTypeUtilsTest.scala
@@ -26,7 +26,7 @@ class CodeAndRunTypeUtilsTest extends Assert {
     val codeTypeAndRunTypeRelationMap = CodeAndRunTypeUtils.getCodeTypeAndRunTypeRelationMap
     assert(codeTypeAndRunTypeRelationMap.nonEmpty)
     assert(codeTypeAndRunTypeRelationMap.keySet.contains("sql"))
-    assert(codeTypeAndRunTypeRelationMap("python").size == 2)
+    assert(codeTypeAndRunTypeRelationMap("python").size == 3)
   }
 
   @Test

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/ScriptFsWriter.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/ScriptFsWriter.scala
@@ -22,7 +22,7 @@ import java.io.{InputStream, OutputStream}
 import org.apache.linkis.common.io.{FsPath, FsWriter, MetaData}
 import org.apache.linkis.storage.LineRecord
 import org.apache.linkis.storage.script.compaction.{PYScriptCompaction, QLScriptCompaction, ScalaScriptCompaction, ShellScriptCompaction}
-import org.apache.linkis.storage.script.parser.{PYScriptParser, QLScriptParser, ScalaScriptParser}
+import org.apache.linkis.storage.script.parser.{PYScriptParser, QLScriptParser, ScalaScriptParser, ShellScriptParser}
 import org.apache.linkis.storage.script.writer.StorageScriptFsWriter
 
 abstract class ScriptFsWriter extends FsWriter {
@@ -41,11 +41,11 @@ object ScriptFsWriter {
 
 
 object ParserFactory {
-  def listParsers(): Array[Parser] = Array(PYScriptParser(), QLScriptParser(), ScalaScriptParser())
+  def listParsers(): Array[Parser] = Array(PYScriptParser(), QLScriptParser(), ScalaScriptParser(), ShellScriptParser())
 }
 
 object Compaction {
-  def listCompactions(): Array[Compaction] = Array(PYScriptCompaction(), QLScriptCompaction(), ScalaScriptCompaction(),ShellScriptCompaction())
+  def listCompactions(): Array[Compaction] = Array(PYScriptCompaction(), QLScriptCompaction(), ScalaScriptCompaction(), ShellScriptCompaction())
 }
 
 trait Parser {

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/PYScriptCompaction.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/PYScriptCompaction.scala
@@ -17,15 +17,12 @@
  
 package org.apache.linkis.storage.script.compaction
 
+import org.apache.linkis.common.utils.CodeAndRunTypeUtils
+
 
 class PYScriptCompaction private extends CommonScriptCompaction {
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "python"|"py"|"sh" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_PYTHON)
 
   override def prefix: String = "#@set"
 

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/ScalaScriptCompaction.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/ScalaScriptCompaction.scala
@@ -17,14 +17,13 @@
  
 package org.apache.linkis.storage.script.compaction
 
+import org.apache.linkis.common.utils.CodeAndRunTypeUtils
+
 
 class ScalaScriptCompaction private extends CommonScriptCompaction{
   override def prefix: String = "//@set"
 
-  override def belongTo(suffix: String): Boolean = suffix match {
-    case "scala" => true
-    case _ => false
-  }
+  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_SCALA)
 
   override def prefixConf: String = "//conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/ShellScriptCompaction.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/compaction/ShellScriptCompaction.scala
@@ -17,21 +17,18 @@
  
 package org.apache.linkis.storage.script.compaction
 
+import org.apache.linkis.common.utils.CodeAndRunTypeUtils
+
 
 class ShellScriptCompaction private extends CommonScriptCompaction{
   override def prefixConf: String = "#conf@set"
 
   override def prefix: String = "#@set"
 
-  override def belongTo(suffix: String): Boolean ={
-    suffix match {
-      case "sh"=>true
-      case _=>false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_SHELL)
 }
 object ShellScriptCompaction{
-  val shellScriptCompaction:ShellScriptCompaction=new ShellScriptCompaction
+  val shellScriptCompaction: ShellScriptCompaction = new ShellScriptCompaction
 
   def apply(): CommonScriptCompaction = shellScriptCompaction
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/PYScriptParser.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/PYScriptParser.scala
@@ -17,16 +17,12 @@
  
 package org.apache.linkis.storage.script.parser
 
+import org.apache.linkis.common.utils.CodeAndRunTypeUtils
 
 class PYScriptParser private extends CommonScriptParser {
   override def prefix: String = "#@set"
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "python"|"py"|"sh" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_PYTHON)
 
   override def prefixConf: String = "#conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/QLScriptParser.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/QLScriptParser.scala
@@ -17,17 +17,13 @@
  
 package org.apache.linkis.storage.script.parser
 
+import org.apache.linkis.common.utils.CodeAndRunTypeUtils
+
 
 class QLScriptParser private extends CommonScriptParser {
   override def prefix: String = "--@set"
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "sql" => true
-      case "hql" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_SQL)
 
   override def prefixConf: String = "--conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/ScalaScriptParser.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/ScalaScriptParser.scala
@@ -17,17 +17,14 @@
  
 package org.apache.linkis.storage.script.parser
 
+import org.apache.linkis.common.utils.CodeAndRunTypeUtils
+
 
 class ScalaScriptParser private extends CommonScriptParser {
   //todo To be determined(待定)
   override def prefix: String = "//@set"
 
-  override def belongTo(suffix: String): Boolean = {
-    suffix match {
-      case "scala" => true
-      case _ => false
-    }
-  }
+  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_SCALA)
 
   override def prefixConf: String = "//conf@set"
 }

--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/ShellScriptParser.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/script/parser/ShellScriptParser.scala
@@ -5,32 +5,32 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-package org.apache.linkis.storage.script.compaction
+
+package org.apache.linkis.storage.script.parser
 
 import org.apache.linkis.common.utils.CodeAndRunTypeUtils
 
+class ShellScriptParser private extends CommonScriptParser {
+  override def prefix: String = "#@set"
 
-class QLScriptCompaction private extends CommonScriptCompaction{
+  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_SHELL)
 
-  override def belongTo(suffix: String): Boolean = CodeAndRunTypeUtils.getSuffixBelongToRunTypeOrNot(suffix, CodeAndRunTypeUtils.RUN_TYPE_SQL)
-
-  override def prefix: String = "--@set"
-
-  override def prefixConf: String = "--conf@set"
+  override def prefixConf: String = "#conf@set"
 }
 
+object ShellScriptParser {
+  val shellScriptParser: ShellScriptParser = new ShellScriptParser
 
-object QLScriptCompaction{
-  val qLScriptCompaction: QLScriptCompaction = new QLScriptCompaction
-  def apply(): CommonScriptCompaction = qLScriptCompaction
+  def apply(): CommonScriptParser = shellScriptParser
+
 }
+

--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
@@ -20,9 +20,11 @@ package org.apache.linkis.governance.common.paser
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.governance.common.conf.GovernanceCommonConf
 import org.apache.linkis.governance.common.paser.CodeType.CodeType
+import org.apache.linkis.common.utils.CodeAndRunTypeUtils
 import org.apache.commons.lang.StringUtils
 import org.slf4j.{Logger, LoggerFactory}
 
+import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import java.util
@@ -300,12 +302,18 @@ object CodeType extends Enumeration {
   type CodeType = Value
   val Python, SQL, Scala, Shell, Other, Remain, JSON = Value
 
-  def getType(codeType: String): CodeType = codeType.toLowerCase() match {
-    case "python" | "pyspark" | "py" => Python
-    case "sql" | "hql" | "psql" => SQL
-    case "scala" => Scala
-    case "shell" | "sh" => Shell
-    case _ => Other
+  def getType(codeType: String): CodeType = {
+    val runTypeAndCodeTypeRelationMap: Map[String, String] = CodeAndRunTypeUtils.getRunTypeAndCodeTypeRelationMap
+    if (runTypeAndCodeTypeRelationMap.isEmpty) return Other
+    val runType = runTypeAndCodeTypeRelationMap.getOrDefault(codeType.toLowerCase, null)
+    if (runType == null) return Other
+    runType match {
+      case CodeAndRunTypeUtils.RUN_TYPE_PYTHON => Python
+      case CodeAndRunTypeUtils.RUN_TYPE_SQL => SQL
+      case CodeAndRunTypeUtils.RUN_TYPE_SCALA => Scala
+      case CodeAndRunTypeUtils.RUN_TYPE_SHELL => Shell
+      case _ => Other
+    }
   }
 }
 

--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
@@ -304,9 +304,9 @@ object CodeType extends Enumeration {
 
   def getType(codeType: String): CodeType = {
     val runTypeAndCodeTypeRelationMap: Map[String, String] = CodeAndRunTypeUtils.getRunTypeAndCodeTypeRelationMap
-    if (runTypeAndCodeTypeRelationMap.isEmpty) return Other
-    val runType = runTypeAndCodeTypeRelationMap.getOrDefault(codeType.toLowerCase, null)
-    if (runType == null) return Other
+    if (runTypeAndCodeTypeRelationMap.isEmpty || ! runTypeAndCodeTypeRelationMap.contains(codeType.toLowerCase)) return Other
+
+    val runType = runTypeAndCodeTypeRelationMap(codeType.toLowerCase)
     runType match {
       case CodeAndRunTypeUtils.RUN_TYPE_PYTHON => Python
       case CodeAndRunTypeUtils.RUN_TYPE_SQL => SQL


### PR DESCRIPTION
### What is the purpose of the change 
引擎类型、脚本类型自定义后，脚本中的变量解析异常，需要在源码中修改几个脚本，基于此，需要把此类配置抽取出来作为配置文件中的一个配置项。https://github.com/apache/incubator-linkis/issues/1751

After the engine type and script type are customized, the variable parsing in the script is abnormal, and several scripts need to be modified in the source code. Based on this, such configuration needs to be extracted as a configuration item in the configuration file. https://github.com/apache/incubator-linkis/issues/1751

### Brief change log
脚本类型与运行类型对应关系在org.apache.linkis.common.utils.CodeAndRunTypeUtils维护，

  val CODE_TYPE_AND_RUN_TYPE_RELATION = CommonVars("wds.linkis.codeType.runType.relation", "sql=>sql|hql|jdbc|hive|psql|fql,python=>python|py|pyspark,java=>java,scala=>scala,shell=>sh|shell")

工具方法

getCodeTypeAndRunTypeRelationMap

getRunTypeAndCodeTypeRelationMap

测试用例，已全部通过
org.apache.linkis.common.utils.CodeAndRunTypeUtilsTest


