### PR TITLE
When a GatewaySSOUtils user successfully logs in to generate a cookie, it does not directly set the second-level domain name, but adds a configuration switch. The default configuration is false. 

### DIFF
--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/config/GatewayConfiguration.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/config/GatewayConfiguration.scala
@@ -70,7 +70,8 @@ object GatewayConfiguration {
   val GATEWAY_HEADER_ALLOW_METHOD = CommonVars("wds.linkis.gateway.header.allow.methods", "POST, GET, OPTIONS, PUT, HEAD, DELETE")
 
 
-  val GATEWAY_DOMAIN_LEVEL  = CommonVars("wds.linkis.gateway.domain.level", 3)
+  val GATEWAY_DOMAIN_LEVEL = CommonVars("wds.linkis.gateway.domain.level", 3)
+  val GATEWAY_COOKIE_DOMAIN_SETUP_SWITCH = CommonVars("wds.linkis.gateway.cookie.domain.setup.switch", false)
 
   // Use regex to match against URLs, if matched, let them pass anyway(even if not currently logged in), Use "()" and "|" to match against multiple URLs
   val GATEWAY_NO_AUTH_URL_REGEX = CommonVars("wds.linkis.gateway.no.auth.url.regex", ".*visualis.*share.*")

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/GatewaySSOUtils.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/GatewaySSOUtils.scala
@@ -33,6 +33,7 @@ object GatewaySSOUtils extends Logging {
   private val IP_REGEX = "([^:]+):.+".r
 
   private val level = GatewayConfiguration.GATEWAY_DOMAIN_LEVEL.getValue
+  private val cookieDomainSetupSwitch = GatewayConfiguration.GATEWAY_COOKIE_DOMAIN_SETUP_SWITCH.getValue
 
   /**
     * "dss.com" -> "dss.com"
@@ -69,8 +70,10 @@ object GatewaySSOUtils extends Logging {
   def setLoginUser(gatewayContext: GatewayContext, username: String): Unit = {
     val proxyUser = ProxyUserUtils.getProxyUser(username)
     SSOUtils.setLoginUser(c => {
-      val host = gatewayContext.getRequest.getHeaders.get("Host")
-      if(host != null && host.nonEmpty) c.setDomain(getCookieDomain(host.head))
+      if (cookieDomainSetupSwitch) {
+        val host = gatewayContext.getRequest.getHeaders.get("Host")
+        if(host != null && host.nonEmpty) c.setDomain(getCookieDomain(host.head))
+      }
       gatewayContext.getResponse.addCookie(c)
     }, proxyUser)
   }


### PR DESCRIPTION
新增Cookie domain的设置开关配置，默认值false。
Added the setting switch configuration of Cookie domain, the default value is false