### PR TITLE
When Orchestrator task is retried, creator judgment supports multiple judgments

### DIFF
--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
@@ -52,7 +52,7 @@ object OrchestratorConfiguration {
 
   val TASK_MAX_PERSIST_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.persist.wait.max", new TimeType("5m"))
 
-  val RETRY_TASK_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.retry.wait.time", 10000)
+  val RETRY_TASK_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.retry.wait.time", 30000)
 
   val SCHEDULER_RETRY_TASK_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.scheduler.retry.wait.time", 100000)
 
@@ -64,7 +64,7 @@ object OrchestratorConfiguration {
 
   val ORCHESTRATOR_USER_MAX_RUNNING = CommonVars("wds.linkis.task.user.max.running", 5)
 
-  val SCHEDULIS_CREATOR = CommonVars("wds.linkis.orchestrator.task.schedulis.creator", "schedulis")
+  val SCHEDULIS_CREATOR = CommonVars("wds.linkis.orchestrator.task.schedulis.creator", "schedulis,nodeexecution").getValue
 
   val ORCHESTRATOR_METRIC_LOG = CommonVars("wds.linkis.orchestrator.metric.log.enable", true)
 

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/physical/RetryExecTask.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/physical/RetryExecTask.scala
@@ -45,7 +45,7 @@ class RetryExecTask(private val originTask: ExecTask, private val age: Int = 1) 
   private  def getMaxWaitTime(): Long = {
     val userCreatorLabel = LabelUtil.getUserCreatorLabel(getLabels)
     var waitTime: Long = OrchestratorConfiguration.RETRY_TASK_WAIT_TIME.getValue
-    if (null != userCreatorLabel && OrchestratorConfiguration.SCHEDULIS_CREATOR.getValue.equalsIgnoreCase(userCreatorLabel.getCreator)) {
+    if (null != userCreatorLabel && OrchestratorConfiguration.SCHEDULIS_CREATOR.contains(userCreatorLabel.getCreator)) {
       waitTime = OrchestratorConfiguration.SCHEDULER_RETRY_TASK_WAIT_TIME.getValue
     }
     val reTryTimeOutLabel = LabelUtil.getLabelFromList[RetryWaitTimeOutLabel](getLabels)


### PR DESCRIPTION
### What is the purpose of the change
close #1936

### Brief change log
- creator judgment supports multiple judgments #1936