### PR TITLE
Deliever original jobId in linkis-entrance module to EngineConn and LinkisManager 

### DIFF
--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/JobUtils.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/JobUtils.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.governance.common.utils
+
+import org.apache.linkis.governance.common.constant.job.JobRequestConstants
+import org.apache.linkis.protocol.utils.TaskUtils
+
+import java.util;
+
+object JobUtils {
+
+  def getJobIdFromMap(map: util.Map[String, Object]): String = {
+    if (null != map && map.containsKey(JobRequestConstants.JOB_ID)) {
+      val value = map.get(JobRequestConstants.JOB_ID)
+      if (null != value) {
+        return value.toString
+      }
+    }
+    null
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
@@ -42,6 +42,7 @@ import org.apache.linkis.engineconn.executor.listener.event.EngineConnSyncEvent
 import org.apache.linkis.governance.common.entity.ExecutionNodeStatus
 import org.apache.linkis.governance.common.exception.engineconn.{EngineConnExecutorErrorCode, EngineConnExecutorErrorException}
 import org.apache.linkis.governance.common.protocol.task._
+import org.apache.linkis.governance.common.utils.JobUtils
 import org.apache.linkis.manager.common.entity.enumeration.NodeStatus
 import org.apache.linkis.manager.common.protocol.resource.ResponseTaskYarnResource
 import org.apache.linkis.manager.label.entity.Label
@@ -130,6 +131,8 @@ class TaskExecutionServiceImpl extends TaskExecutionService with Logging with Re
       if (null != retry) retry.asInstanceOf[Boolean]
       else false
     }
+    val jobId = JobUtils.getJobIdFromMap(requestTask.getProperties)
+    logger.info(s"Received job with id ${jobId}.")
     val task = new CommonEngineConnTask(String.valueOf(taskId), retryAble)
     task.setCode(requestTask.getCode)
     task.setProperties(requestTask.getProperties)

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
@@ -187,7 +187,8 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
             runtimeMapOri = TaskUtils.getRuntimeMap(getParams());
         }
         if (!runtimeMapOri.containsKey(JobRequestConstants.JOB_ID())) {
-            runtimeMapOri.put(JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
+            runtimeMapOri.put(
+                    JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
         }
         Map<String, String> runtimeMapTmp = new HashMap<>();
         for (Map.Entry<String, Object> entry : runtimeMapOri.entrySet()) {

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
@@ -25,6 +25,7 @@ import org.apache.linkis.entrance.execute.EntranceJob;
 import org.apache.linkis.entrance.log.*;
 import org.apache.linkis.entrance.persistence.PersistenceManager;
 import org.apache.linkis.governance.common.conf.GovernanceCommonConf;
+import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 import org.apache.linkis.governance.common.entity.job.SubJobDetail;
 import org.apache.linkis.governance.common.entity.job.SubJobInfo;
 import org.apache.linkis.governance.common.protocol.task.RequestTask$;
@@ -169,6 +170,12 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
         // add resultSet path root
         Map<String, String> starupMapTmp = new HashMap<String, String>();
         Map<String, Object> starupMapOri = TaskUtils.getStartupMap(getParams());
+        if (starupMapOri.isEmpty()) {
+            TaskUtils.addStartupMap(getParams(), starupMapOri);
+        }
+        if (!starupMapOri.containsKey(JobRequestConstants.JOB_REQUEST_LIST())) {
+            starupMapOri.put(JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
+        }
         for (Map.Entry<String, Object> entry : starupMapOri.entrySet()) {
             if (null != entry.getKey() && null != entry.getValue()) {
                 starupMapTmp.put(entry.getKey(), entry.getValue().toString());
@@ -178,6 +185,9 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
         if (null == runtimeMapOri || runtimeMapOri.isEmpty()) {
             TaskUtils.addRuntimeMap(getParams(), new HashMap<>());
             runtimeMapOri = TaskUtils.getRuntimeMap(getParams());
+        }
+        if (!runtimeMapOri.containsKey(JobRequestConstants.JOB_ID())) {
+            runtimeMapOri.put(JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
         }
         Map<String, String> runtimeMapTmp = new HashMap<>();
         for (Map.Entry<String, Object> entry : runtimeMapOri.entrySet()) {


### PR DESCRIPTION
### What is the purpose of the change
close #1938 
Deliever original jobId in linkis-entrance module to EngineConn and LinkisManager.

### Brief change log
(for example:)
- put original jobId to both startup map and runtime map in linkis-entrance.
- get original jobId in linkis-computation-engineconn.

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  
(yes)  
This change is already covered by existing tests, such as (please describe tests).  
(no)  
This change added tests and can be verified as follows:  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (not applicable)