### PR TITLE
add undone job query cache and add api /listundone

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis-ps-publicservice.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis-ps-publicservice.properties
@@ -29,6 +29,8 @@ hive.meta.user=
 hive.meta.password=
 # associated with the logged-in user when querying metadata:default value is true
 #linkis.metadata.hive.permission.with-login-user-enabled
+#wds.linkis.jobhistory.undone.job.minimum.id=0
+#wds.linkis.jobhistory.undone.job.refreshtime.daily=00:15
 
 ##Spring
 spring.server.port=9105

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/cache/QueryCacheManager.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/cache/QueryCacheManager.java
@@ -26,4 +26,6 @@ public interface QueryCacheManager {
     void cleanAll();
 
     void refreshAll();
+
+    void refreshUndoneTask();
 }

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/cache/impl/ScheduledRefreshUndoneJob.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/cache/impl/ScheduledRefreshUndoneJob.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.jobhistory.cache.impl;
+
+import org.apache.linkis.jobhistory.cache.QueryCacheManager;
+
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScheduledRefreshUndoneJob extends QuartzJobBean {
+    private static Logger logger = LoggerFactory.getLogger(ScheduledRefreshUndoneJob.class);
+
+    @Override
+    protected void executeInternal(JobExecutionContext jobExecutionContext)
+            throws JobExecutionException {
+        logger.info("Started cache refresh job.");
+        QueryCacheManager queryCacheManager =
+                (QueryCacheManager)
+                        jobExecutionContext
+                                .getJobDetail()
+                                .getJobDataMap()
+                                .get(QueryCacheManager.class.getName());
+        queryCacheManager.refreshUndoneTask();
+        logger.info("Finished cache refresh undone job.");
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/conf/JobHistoryConfiguration.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/conf/JobHistoryConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.jobhistory.conf;
+
+import org.apache.linkis.common.conf.CommonVars;
+
+public class JobHistoryConfiguration {
+    public static CommonVars<Long> UNDONE_JOB_MINIMUM_ID =
+            CommonVars.apply("wds.linkis.jobhistory.undone.job.minimum.id", 0L);
+
+    public static CommonVars<String> UNDONE_JOB_REFRESH_TIME_DAILY =
+            CommonVars.apply("wds.linkis.jobhistory.undone.job.refreshtime.daily", "00:15");
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/dao/JobHistoryMapper.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/dao/JobHistoryMapper.java
@@ -38,6 +38,15 @@ public interface JobHistoryMapper {
             @Param("status") List<String> status,
             @Param("startDate") Date startDate,
             @Param("endDate") Date endDate,
+            @Param("engineType") String engineType,
+            @Param("startId") Long startId);
+
+    List<JobHistory> searchWithIdOrderAsc(
+            @Param("id") Long id,
+            @Param("umUser") String username,
+            @Param("status") List<String> status,
+            @Param("startDate") Date startDate,
+            @Param("endDate") Date endDate,
             @Param("engineType") String engineType);
 
     List<JobHistory> searchWithUserCreator(
@@ -48,7 +57,8 @@ public interface JobHistoryMapper {
             @Param("status") List<String> status,
             @Param("startDate") Date startDate,
             @Param("endDate") Date endDate,
-            @Param("engineType") String engineType);
+            @Param("engineType") String engineType,
+            @Param("startId") Long startId);
 
     List<JobHistory> searchWithCreatorOnly(
             @Param("id") Long id,
@@ -58,7 +68,8 @@ public interface JobHistoryMapper {
             @Param("status") List<String> status,
             @Param("startDate") Date startDate,
             @Param("endDate") Date endDate,
-            @Param("engineType") String engineType);
+            @Param("engineType") String engineType,
+            @Param("startId") Long startId);
 
     String selectJobHistoryStatusForUpdate(Long jobId);
 }

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/dao/impl/JobHistoryMapper.xml
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/dao/impl/JobHistoryMapper.xml
@@ -96,7 +96,7 @@
     <select id="searchWithIdOrderAsc" useCache="true" resultMap="jobHistoryMap" >
         /*slave*/ SELECT * FROM linkis_ps_job_history_group_history
         <where>
-            <if test="id != null">id = #{id}</if>
+            <if test="id != null">id >= #{id}</if>
             <if test="umUser != null">and submit_user = #{umUser}</if>
             <if test="engineType != null">and engine_type = #{engineType}</if>
             <if test="startDate != null">and created_time >= #{startDate} AND created_time <![CDATA[<=]]> #{endDate}</if>

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/dao/impl/JobHistoryMapper.xml
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/dao/impl/JobHistoryMapper.xml
@@ -88,8 +88,21 @@
             <if test="engineType != null">and engine_type = #{engineType}</if>
             <if test="startDate != null">and created_time >= #{startDate} AND created_time <![CDATA[<=]]> #{endDate}</if>
             <if test="status != null">and <foreach collection="status" item="element" close=")" separator="," open="status in (">#{element}</foreach></if>
+            <if test="startId != null">and id >= #{startId}</if>
         </where>
         ORDER BY linkis_ps_job_history_group_history.created_time DESC
+    </select>
+
+    <select id="searchWithIdOrderAsc" useCache="true" resultMap="jobHistoryMap" >
+        /*slave*/ SELECT * FROM linkis_ps_job_history_group_history
+        <where>
+            <if test="id != null">id = #{id}</if>
+            <if test="umUser != null">and submit_user = #{umUser}</if>
+            <if test="engineType != null">and engine_type = #{engineType}</if>
+            <if test="startDate != null">and created_time >= #{startDate} AND created_time <![CDATA[<=]]> #{endDate}</if>
+            <if test="status != null">and <foreach collection="status" item="element" close=")" separator="," open="status in (">#{element}</foreach></if>
+        </where>
+        ORDER BY linkis_ps_job_history_group_history.id
     </select>
 
     <select id="searchWithUserCreator" useCache="true" resultMap="jobHistoryMap" >
@@ -103,6 +116,7 @@
             <if test="userCreatorKey != null and userCreatorValue != null">
                 and  LOCATE('"${userCreatorKey}":"${userCreatorValue}', labels) > 0
             </if>
+            <if test="startId != null">and id >= #{startId}</if>
         </where>
         ORDER BY linkis_ps_job_history_group_history.created_time DESC
     </select>
@@ -118,6 +132,7 @@
             <if test="userCreatorKey != null and creator != null">
                 and labels like '%"${userCreatorKey}":"%-${creator}%'
             </if>
+            <if test="startId != null">and id >= #{startId}</if>
         </where>
         ORDER BY linkis_ps_job_history_group_history.created_time DESC
     </select>

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
@@ -210,7 +210,7 @@ public class QueryRestfulApi {
             throws IOException, QueryException {
         String username = SecurityFilter.getLoginUsername(req);
         if (StringUtils.isEmpty(status)) {
-            status = null;
+            status = "Running,Inited,Scheduled";
         }
         if (StringUtils.isEmpty(pageNow)) {
             pageNow = 1;

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
@@ -19,6 +19,7 @@ package org.apache.linkis.jobhistory.restful.api;
 
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 import org.apache.linkis.governance.common.entity.job.QueryException;
+import org.apache.linkis.jobhistory.cache.impl.DefaultQueryCacheManager;
 import org.apache.linkis.jobhistory.conf.JobhistoryConfiguration;
 import org.apache.linkis.jobhistory.conversions.TaskConversions;
 import org.apache.linkis.jobhistory.dao.JobDetailMapper;
@@ -52,6 +53,8 @@ public class QueryRestfulApi {
 
     @Autowired private JobHistoryQueryService jobHistoryQueryService;
     @Autowired private JobDetailMapper jobDetailMapper;
+
+    @Autowired private DefaultQueryCacheManager queryCacheManager;
 
     @RequestMapping(path = "/governanceStationAdmin", method = RequestMethod.GET)
     public Message governanceStationAdmin(HttpServletRequest req) {
@@ -163,7 +166,8 @@ public class QueryRestfulApi {
                             creator,
                             sDate,
                             eDate,
-                            executeApplicationName);
+                            executeApplicationName,
+                            null);
         } finally {
             PageHelper.clearPage();
         }
@@ -185,6 +189,77 @@ public class QueryRestfulApi {
                 }
                 break;
             }*/
+        }
+        return Message.ok()
+                .data(TaskConstant.TASKS, vos)
+                .data(JobRequestConstants.TOTAL_PAGE(), total);
+    }
+
+    /** Method list should not contain subjob, which may cause performance problems. */
+    @RequestMapping(path = "/listundone", method = RequestMethod.GET)
+    public Message listundone(
+            HttpServletRequest req,
+            @RequestParam(value = "startDate", required = false) Long startDate,
+            @RequestParam(value = "endDate", required = false) Long endDate,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "pageNow", required = false) Integer pageNow,
+            @RequestParam(value = "pageSize", required = false) Integer pageSize,
+            @RequestParam(value = "startTaskID", required = false) Long taskID,
+            @RequestParam(value = "engineType", required = false) String engineType,
+            @RequestParam(value = "creator", required = false) String creator)
+            throws IOException, QueryException {
+        String username = SecurityFilter.getLoginUsername(req);
+        if (StringUtils.isEmpty(status)) {
+            status = null;
+        }
+        if (StringUtils.isEmpty(pageNow)) {
+            pageNow = 1;
+        }
+        if (StringUtils.isEmpty(pageSize)) {
+            pageSize = 20;
+        }
+        if (endDate == null) {
+            endDate = System.currentTimeMillis();
+        }
+        if (startDate == null) {
+            startDate = 0L;
+        }
+        if (StringUtils.isEmpty(creator)) {
+            creator = null;
+        }
+        Date sDate = new Date(startDate);
+        Date eDate = new Date(endDate);
+        if (sDate.getTime() == eDate.getTime()) {
+            Calendar instance = Calendar.getInstance();
+            instance.setTimeInMillis(endDate);
+            instance.add(Calendar.DAY_OF_MONTH, 1);
+            eDate = new Date(instance.getTime().getTime()); // todo check
+        }
+        List<JobHistory> queryTasks = null;
+        PageHelper.startPage(pageNow, pageSize);
+        try {
+            queryTasks =
+                    jobHistoryQueryService.search(
+                            taskID,
+                            username,
+                            status,
+                            creator,
+                            sDate,
+                            eDate,
+                            engineType,
+                            queryCacheManager.getUndoneTaskMinId());
+        } finally {
+            PageHelper.clearPage();
+        }
+
+        PageInfo<JobHistory> pageInfo = new PageInfo<>(queryTasks);
+        List<JobHistory> list = pageInfo.getList();
+        long total = pageInfo.getTotal();
+        List<QueryTaskVO> vos = new ArrayList<>();
+        for (JobHistory jobHistory : list) {
+            QueryUtils.exchangeExecutionCode(jobHistory);
+            QueryTaskVO taskVO = TaskConversions.jobHistory2TaskVO(jobHistory, null);
+            vos.add(taskVO);
         }
         return Message.ok()
                 .data(TaskConstant.TASKS, vos)

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/JobHistoryQueryService.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/JobHistoryQueryService.java
@@ -38,7 +38,7 @@ public interface JobHistoryQueryService {
 
     JobHistory getJobHistoryByIdAndName(Long jobID, String userName);
 
-    List<JobHistory> search(Long jobId, String username, String creator, String status, Date sDate, Date eDate, String executionApplicationName);
+    List<JobHistory> search(Long jobId, String username, String creator, String status, Date sDate, Date eDate, String executionApplicationName, Long startJobId);
 
     JobHistory searchOne(Long jobId, Date sDate, Date eDate);
 

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
@@ -214,14 +214,14 @@ class JobHistoryQueryServiceImpl extends JobHistoryQueryService with Logging {
     if (jobHistoryList.isEmpty) null else jobHistoryList.get(0)
   }
 
-  override def search(jobId: java.lang.Long, username: String, status: String, creator: String, sDate: Date, eDate: Date, engineType: String): util.List[JobHistory] = {
+  override def search(jobId: java.lang.Long, username: String, status: String, creator: String, sDate: Date, eDate: Date, engineType: String, startJobId: java.lang.Long): util.List[JobHistory] = {
     import scala.collection.JavaConversions._
     val split: util.List[String] = if (status != null) status.split(",").toList else null
     val result = if (StringUtils.isBlank(creator)) {
-      jobHistoryMapper.search(jobId, username, split, sDate, eDate, engineType)
+      jobHistoryMapper.search(jobId, username, split, sDate, eDate, engineType, startJobId)
     } else if(StringUtils.isBlank(username)) {
       val fakeLabel = new UserCreatorLabel
-      jobHistoryMapper.searchWithCreatorOnly(jobId, username, fakeLabel.getLabelKey, creator, split, sDate, eDate, engineType)
+      jobHistoryMapper.searchWithCreatorOnly(jobId, username, fakeLabel.getLabelKey, creator, split, sDate, eDate, engineType, startJobId)
     } else {
       val fakeLabel = new UserCreatorLabel
       fakeLabel.setUser(username)
@@ -231,7 +231,7 @@ class JobHistoryQueryServiceImpl extends JobHistoryQueryService with Logging {
         t => info("input user or creator is not correct", t)
           throw t
       }
-      jobHistoryMapper.searchWithUserCreator(jobId, username, fakeLabel.getLabelKey, userCreator, split, sDate, eDate, engineType)
+      jobHistoryMapper.searchWithUserCreator(jobId, username, fakeLabel.getLabelKey, userCreator, split, sDate, eDate, engineType, startJobId)
     }
     result
   }
@@ -251,7 +251,7 @@ class JobHistoryQueryServiceImpl extends JobHistoryQueryService with Logging {
 
   override def searchOne(jobId: lang.Long, sDate: Date, eDate: Date): JobHistory = {
     Iterables.getFirst(
-      jobHistoryMapper.search(jobId, null, null, sDate, eDate, null),
+      jobHistoryMapper.search(jobId, null, null, sDate, eDate, null, null),
       {
         val queryJobHistory = new QueryJobHistory
         queryJobHistory.setId(jobId)


### PR DESCRIPTION
### What is the purpose of the change
refer issue: https://github.com/apache/incubator-linkis/issues/1935

### Brief change log
- Add daily scheduled refresh undone job at 00:15:00 to get the minimum id of undone job
- add api /listundone to get the undone job list, and this api will use the minimum id of undone job
