### PR TITLE
Dev 1.1.2 cat errorlog ->tail -1000 

### DIFF
--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/launch/ProcessEngineCommandBuilder.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/launch/ProcessEngineCommandBuilder.scala
@@ -73,7 +73,7 @@ class UnixProcessEngineCommandBuilder extends ShellProcessEngineCommandBuilder {
     newLine("linkis_engineconn_errorcode=$?")
     newLine("if [ $linkis_engineconn_errorcode -ne 0 ]")
     newLine("then")
-    newLine("  cat ${LOG_DIRS}/stderr")
+    newLine("  tail -1000 ${LOG_DIRS}/stderr")
     newLine("  exit $linkis_engineconn_errorcode")
     newLine("fi")
   }


### PR DESCRIPTION
ProcessEngineCommandBuilder
```
private def addErrorCheck(): Unit = {
    newLine("linkis_engineconn_errorcode=$?")
    newLine("if [ $linkis_engineconn_errorcode -ne 0 ]")
    newLine("then")
    newLine("  tail -1000 ${LOG_DIRS}/stderr")
    newLine("  exit $linkis_engineconn_errorcode")
    newLine("fi")
  }
```
For details  #1927 