### PR TITLE
optimize json4s dependency

### DIFF
--- a/linkis-commons/linkis-rpc/pom.xml
+++ b/linkis-commons/linkis-rpc/pom.xml
@@ -49,10 +49,6 @@
             <artifactId>spring-cloud-starter-openfeign</artifactId>
             <exclusions>
                 <exclusion>
-                    <artifactId>spring-boot-autoconfigure</artifactId>
-                    <groupId>org.springframework.boot</groupId>
-                </exclusion>
-                <exclusion>
                     <artifactId>spring-boot-starter-aop</artifactId>
                     <groupId>org.springframework.boot</groupId>
                 </exclusion>
@@ -84,10 +80,6 @@
                     <artifactId>spring-cloud-commons</artifactId>
                     <groupId>org.springframework.cloud</groupId>
                 </exclusion>
-                <exclusion>
-                    <artifactId>spring-cloud-starter-openfeign</artifactId>
-                    <groupId>org.springframework.cloud</groupId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -100,7 +92,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>io.protostuff</groupId>
             <artifactId>protostuff-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,12 +105,13 @@
         <spring.boot.version>2.3.12.RELEASE</spring.boot.version>
         <guava.version>30.0-jre</guava.version>
         <gson.version>2.8.5</gson.version>
-        <jackson-bom.version>2.13.2.1</jackson-bom.version>
         <scala.version>2.11.12</scala.version>
         <jdk.compile.version>1.8</jdk.compile.version>
         <plugin.scala.version>2.15.2</plugin.scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <netty.version>4.1.68.Final</netty.version>
+        <jackson-bom.version>2.13.2.1</jackson-bom.version>
+        <!-- spark2.4 use 3.5.3, spark3.2 use 3.7.0-M11 -->
         <json4s.version>3.5.3</json4s.version>
         <jersey.version>1.19.4</jersey.version>
         <jersey.servlet.version>2.23.1</jersey.servlet.version>
@@ -266,6 +267,32 @@
                 <version>${jackson-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.json4s</groupId>
+                <artifactId>json4s-core_${scala.binary.version}</artifactId>
+                <version>${json4s.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json4s</groupId>
+                <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+                <version>${json4s.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.json4s</groupId>
+                <artifactId>json4s-ast_${scala.binary.version}</artifactId>
+                <version>${json4s.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json4s</groupId>
+                <artifactId>json4s-scalap_${scala.binary.version}</artifactId>
+                <version>${json4s.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
What is the purpose of the change
Brief change log
(for example:)

unify json4s's version
add comment for spark version should use spec version of json4s
Verifying this change
Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
Anything that affects deployment: (no)
The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)
Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)