### PR TITLE
Fix wrong desc in task with jobRunningTimeoutLabel 

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceJob.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceJob.scala
@@ -182,8 +182,10 @@ abstract class EntranceJob extends Job {
   }
 
   override def onFailure(errorMsg: String, t: Throwable): Unit = {
-    val generatedMsg = LogUtils.generateERROR(s"Sorry, your job executed failed with reason: $errorMsg")
-    getLogListener.foreach(_.onLogUpdate(this, generatedMsg))
+    if (!isCompleted) {
+      val generatedMsg = LogUtils.generateERROR(s"Sorry, your job executed failed with reason: $errorMsg")
+      getLogListener.foreach(_.onLogUpdate(this, generatedMsg))
+    }
     super.onFailure(errorMsg, t)
   }
 

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceJob.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceJob.scala
@@ -185,6 +185,15 @@ abstract class EntranceJob extends Job {
     if (!isCompleted) {
       val generatedMsg = LogUtils.generateERROR(s"Sorry, your job executed failed with reason: $errorMsg")
       getLogListener.foreach(_.onLogUpdate(this, generatedMsg))
+    } else {
+      val throwableMsg = {
+        if (null == t) {
+          null
+        } else {
+          t.getMessage
+        }
+      }
+      logger.warn(s"There are an method who calls onFailure while job is completed, errorMsg is : ${errorMsg}, throwableMsg is : ${throwableMsg}")
     }
     super.onFailure(errorMsg, t)
   }

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/timeout/JobTimeoutManager.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/timeout/JobTimeoutManager.scala
@@ -55,7 +55,6 @@ class JobTimeoutManager extends Logging {
     if (null != job) {
       info(s"Deleting Job: ${job.getId()}")
       synchronized {
-        job.kill()
         timeoutJobByName.remove(jobKey)
       }
     }


### PR DESCRIPTION
close #2033 

### What is the purpose of the change
Fix wrong desc in task with jobRunningTimeoutLabel 

### Brief change log
(for example:)
- entrance - fix delete method in JobTimeoutManager
- entrance - fix onFailure method in EntranceJob



### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)