### PR TITLE
Fix: ECM page 'instance' display mistake.

### DIFF
--- a/web/src/apps/linkis/module/ECM/index.vue
+++ b/web/src/apps/linkis/module/ECM/index.vue
@@ -240,7 +240,7 @@ export default {
         }
         return data;
       }
-      return  v && (v.cores !== undefined || v.memonry !== undefined || v.instances !== undefined) ? `${calcCompany(v.cores)}cores,${calcCompany(v.memory, true)}G,${calcCompany(v.instances)}apps` : ''
+      return  v && (v.cores !== undefined || v.memonry !== undefined || v.instance !== undefined) ? `${calcCompany(v.cores)}cores,${calcCompany(v.memory, true)}G,${calcCompany(v.instance)}apps` : ''
     }
   },
   created() {


### PR DESCRIPTION
### What is the purpose of the change
fix:Ecm page 'instance' display mistake

### Brief change log
- Change table's param 'instances' into 'instance' in ECM page.
