### PR TITLE
[Feature-2043] Rollback #1925, the SQL comment clearing logic in SQLCodeParser is duplicated with the SQL comment uninterceptor function

### DIFF
--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
@@ -216,29 +216,19 @@ class SQLCodeParser extends SingleCodeParser with Logging  {
     if (StringUtils.isBlank(code)) {
       return codeBuffer.toArray
     }
-    val codeAfterClearComment = clearSqlComment(code)
 
     def appendStatement(sqlStatement: String): Unit = {
       codeBuffer.append(sqlStatement)
     }
-    val indices = findRealSemicolonIndex(codeAfterClearComment)
+    val indices = findRealSemicolonIndex(code)
     var oldIndex = 0
     indices.foreach {
       index =>
-        val singleCode = codeAfterClearComment.substring(oldIndex, index)
+        val singleCode = code.substring(oldIndex, index)
         oldIndex = index + 1
         if (StringUtils.isNotBlank(singleCode)) appendStatement(singleCode)
     }
     codeBuffer.toArray
-  }
-
-  def clearSqlComment(code: String): String = {
-    if (StringUtils.isBlank(code)) {
-      return ""
-    }
-    val p = Pattern.compile("(?ms)('(?:''|[^'])*')|--.*?$|/\\*.*?\\*/")
-    val sql = p.matcher(code).replaceAll("$1")
-    sql.trim
   }
 
   def isSelectCmdNoLimit(cmd: String): Boolean = {

--- a/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/paser/SQLCodeParserTest.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/paser/SQLCodeParserTest.scala
@@ -20,8 +20,6 @@ package org.apache.linkis.governance.common.paser
 import org.junit.jupiter.api.{DisplayName, Test}
 import org.junit.jupiter.api.Assertions.assertTrue
 
-import java.util.regex.Pattern
-
 class SQLCodeParserTest {
 
   @Test
@@ -39,33 +37,4 @@ class SQLCodeParserTest {
     assertTrue(strings.length == 2)
   }
 
-  @Test
-  @DisplayName("testParseSql")
-  def testParseSql(): Unit = {
-    val parser = new SQLCodeParser
-    val sqlString: String =
-      """
-        |-- select device_id, client_id, stats_uv_day,
-        |-- stats_uv_week,
-        |-- stats_uv_month
-        |-- from kbase.test1 limit 10;
-        |-- select device_id,
-        |-- stats_uv
-        |-- from kbase.test1 limit 10;
-        |select *
-        |-- 这是一条注释
-        |from test.test_table3
-        |limit 10;
-        |select * from test.leo_test
-        |-- 这是注释;
-        |/** 这也是注释 **/
-        |limit 10
-        |""".stripMargin
-    // sqlString = "select * from test.leo_test"
-    val p = Pattern.compile("(?ms)('(?:''|[^'])*')|--.*?$|/\\*.*?\\*/")
-    // val p = Pattern.compile("(?ms)('(?:''|[^'])*')|--.*?$|//.*?$|/\\*.*?\\*/|#.*?$|")
-    // val result = p.matcher(sqlString).replaceAll("$1")
-    val strings = parser.parse(sqlString)
-    assertTrue(strings.length == 2)
-  }
 }

--- a/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/paser/SQLCodeParserTest.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/paser/SQLCodeParserTest.scala
@@ -25,6 +25,21 @@ import java.util.regex.Pattern
 class SQLCodeParserTest {
 
   @Test
+  @DisplayName("testParseSqlWithSemicolon")
+  def testParseSqlWithSemicolon(): Unit = {
+    val parser = new SQLCodeParser
+    val sqlString: String =
+      """
+        |select * from test.table1;
+        |select
+        | *
+        | from test.table2 where name like ';_'
+        |""".stripMargin
+    val strings = parser.parse(sqlString)
+    assertTrue(strings.length == 2)
+  }
+
+  @Test
   @DisplayName("testParseSql")
   def testParseSql(): Unit = {
     val parser = new SQLCodeParser


### PR DESCRIPTION
https://github.com/apache/incubator-linkis/issues/2043