### PR TITLE
Use the Task id as the trace id of the log 

### DIFF
--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/JobUtils.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/JobUtils.scala
@@ -18,7 +18,6 @@
 package org.apache.linkis.governance.common.utils
 
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants
-import org.apache.linkis.protocol.utils.TaskUtils
 
 import java.util;
 
@@ -29,6 +28,16 @@ object JobUtils {
       val value = map.get(JobRequestConstants.JOB_ID)
       if (null != value) {
         return value.toString
+      }
+    }
+    null
+  }
+
+  def getJobIdFromStringMap(map: util.Map[String, String]): String = {
+    if (null != map && map.containsKey(JobRequestConstants.JOB_ID)) {
+      val value = map.get(JobRequestConstants.JOB_ID)
+      if (null != value) {
+        return value
       }
     }
     null

--- a/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/utils/JobUtilsTest.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/utils/JobUtilsTest.scala
@@ -29,7 +29,7 @@ class JobUtilsTest {
   def testGetJobIdFromMap(): Unit = {
     val map: util.Map[String, Object] = new util.HashMap[String, Object]()
     Assertions.assertNull(JobUtils.getJobIdFromMap(map))
-    map.put(JobRequestConstants.JOB_ID, 100L)
+    map.put(JobRequestConstants.JOB_ID, "100")
     Assertions.assertNotNull(JobUtils.getJobIdFromMap(map))
   }
 

--- a/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/utils/JobUtilsTest.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/test/scala/org/apache/linkis/governance/common/utils/JobUtilsTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.governance.common.utils
+
+import org.apache.linkis.governance.common.constant.job.JobRequestConstants
+import org.junit.jupiter.api.{Assertions, DisplayName, Test}
+
+import java.util
+
+class JobUtilsTest {
+
+  @Test
+  @DisplayName("testGetJobIdFromMap")
+  def testGetJobIdFromMap(): Unit = {
+    val map: util.Map[String, Object] = new util.HashMap[String, Object]()
+    Assertions.assertNull(JobUtils.getJobIdFromMap(map))
+    map.put(JobRequestConstants.JOB_ID, 100L)
+    Assertions.assertNotNull(JobUtils.getJobIdFromMap(map))
+  }
+
+  @Test
+  @DisplayName("getJobIdFromStringMap")
+  def testGetJobIdFromStringMap(): Unit = {
+    val map: util.Map[String, String] = new util.HashMap[String, String]()
+    Assertions.assertNull(JobUtils.getJobIdFromStringMap(map))
+    map.put(JobRequestConstants.JOB_ID, "100")
+    Assertions.assertNotNull(JobUtils.getJobIdFromStringMap(map))
+  }
+
+}

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
@@ -108,7 +108,7 @@ abstract class EntranceServer extends Logging {
        * */
       Utils.tryAndWarn(job.getJobListener.foreach(_.onJobInited(job)))
       getEntranceContext.getOrCreateScheduler().submit(job)
-      val msg = s"Job with jobId : ${job.getId} and execID : ${job.getId()} submitted "
+      val msg = s"Job with jobId : ${jobRequest.getId} and execID : ${job.getId()} submitted "
       logger.info(msg)
 
       job match {

--- a/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/utils/EngineTypeLabelCreator.java
+++ b/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/utils/EngineTypeLabelCreator.java
@@ -35,6 +35,10 @@ public class EngineTypeLabelCreator {
 
     private static Map<String, String> defaultVersion = null;
 
+    static {
+        init();
+    }
+
     private static void init() {
         if (null == defaultVersion) {
             synchronized (EngineTypeLabelCreator.class) {

--- a/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/service/ComputationTaskExecutionReceiver.scala
+++ b/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/service/ComputationTaskExecutionReceiver.scala
@@ -162,7 +162,7 @@ class ComputationTaskExecutionReceiver extends TaskExecutionReceiver with Loggin
     val serviceInstance = RPCUtils.getServiceInstanceFromSender(sender)
     codeExecTaskExecutorManager.getByEngineConnAndTaskId(serviceInstance, responseTaskError.execId).foreach { codeExecutor =>
       val event = TaskErrorResponseEvent(codeExecutor.getExecTask, responseTaskError.errorMsg)
-      logger.info(s"From engineConn receive responseTaskError  info$responseTaskError, now post to listenerBus event: $event")
+      logger.info(s"From engineConn receive responseTaskError  info${responseTaskError.execId}, now post to listenerBus event: ${event.execTask.getIDInfo()}")
       codeExecutor.getExecTask.getPhysicalContext.broadcastSyncEvent(event)
       codeExecutor.getEngineConnExecutor.updateLastUpdateTime()
       isExist = true

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/converter/AbstractConverter.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/converter/AbstractConverter.scala
@@ -40,7 +40,7 @@ trait AbstractConverter extends Converter with Logging{
     debug(s"Start to convert JobReq(${jobReq.getId}) to AstJob.")
     val job = converterTransforms.collectFirst { case transform => transform(jobReq, context) }
       .getOrElse(throw new OrchestratorErrorException(OrchestratorErrorCodeSummary.CONVERTER_FOR_NOT_SUPPORT_ERROR_CODE, "Cannot convert jobReq " + jobReq))
-    info(s"Finished to convert JobReq(${jobReq.getId}) to AstJob(${job.getId}).")
+    info(s"Finished to convert JobReq(${jobReq.getId}) to AstJob(${job.getIDInfo()}).")
     job
   }
 

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/listener/task/TaskInfoEvent.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/listener/task/TaskInfoEvent.scala
@@ -55,7 +55,7 @@ case class TaskResultSetSizeEvent(execTask: ExecTask, resultSize: Int) extends T
 
 case class TaskErrorResponseEvent(execTask: ExecTask, errorMsg: String) extends TaskInfoEvent with OrchestratorSyncEvent {
   override def toString: String = {
-    s"task ${execTask.getIDInfo()}, errorMsg ${errorMsg}"
+    s"task ${execTask.getIDInfo()}"
   }
 }
 

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/ast/Job.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/ast/Job.scala
@@ -17,6 +17,8 @@
  
 package org.apache.linkis.orchestrator.plans.ast
 
+import org.apache.commons.lang.StringUtils
+import org.apache.linkis.governance.common.utils.JobUtils
 import org.apache.linkis.orchestrator.utils.OrchestratorIDCreator
 
 /**
@@ -27,6 +29,8 @@ trait Job extends ASTOrchestration[Job] {
   private var visited: Boolean = false
 
   private var id: String = _
+
+  private var idInfo: String = _
 
   override def isVisited: Boolean = visited
 
@@ -40,7 +44,7 @@ trait Job extends ASTOrchestration[Job] {
 
   def copyWithNewStages(stages: Array[Stage]): Job
 
-  override def getId: String =  {
+  override def getId: String = {
     if (null == id) synchronized {
       if (null == id) {
         id = OrchestratorIDCreator.getAstJobIDCreator.nextID("astJob")
@@ -49,4 +53,23 @@ trait Job extends ASTOrchestration[Job] {
     id
   }
 
+  def getIDInfo(): String = {
+    if (null == idInfo) synchronized {
+      if (null == idInfo) {
+        val context = getASTContext
+        if (null != context && null != context.getParams && null != context.getParams.getRuntimeParams && null != context.getParams.getRuntimeParams.toMap) {
+          val runtimeMap = context.getParams.getRuntimeParams.toMap
+          val taskId = JobUtils.getJobIdFromMap(runtimeMap)
+          if (StringUtils.isNotBlank(taskId)) {
+            idInfo = s"TaskID_${taskId}_otJobId_${getId}"
+          } else {
+            idInfo = getId
+          }
+        } else {
+          idInfo = getId
+        }
+      }
+    }
+    idInfo
+  }
 }

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/ast/Job.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/ast/Job.scala
@@ -32,6 +32,9 @@ trait Job extends ASTOrchestration[Job] {
 
   private var idInfo: String = _
 
+  private val idLock = new Array[Byte](0)
+  private val idInfoLock = new Array[Byte](0)
+
   override def isVisited: Boolean = visited
 
   override def setVisited(): Unit = this.visited = true
@@ -45,7 +48,7 @@ trait Job extends ASTOrchestration[Job] {
   def copyWithNewStages(stages: Array[Stage]): Job
 
   override def getId: String = {
-    if (null == id) synchronized {
+    if (null == id) idLock synchronized {
       if (null == id) {
         id = OrchestratorIDCreator.getAstJobIDCreator.nextID("astJob")
       }
@@ -54,7 +57,7 @@ trait Job extends ASTOrchestration[Job] {
   }
 
   def getIDInfo(): String = {
-    if (null == idInfo) synchronized {
+    if (null == idInfo) idInfoLock synchronized {
       if (null == idInfo) {
         val context = getASTContext
         if (null != context && null != context.getParams && null != context.getParams.getRuntimeParams && null != context.getParams.getRuntimeParams.toMap) {

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/ast/Job.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/ast/Job.scala
@@ -56,6 +56,12 @@ trait Job extends ASTOrchestration[Job] {
     id
   }
 
+  /**
+   * JonIDINFO generation method:
+   * 1. If taskID exists in startUp, use taskID as prefix
+   * 2. If the taskID does not exist or is empty, use the job id directly
+   * @return
+   */
   def getIDInfo(): String = {
     if (null == idInfo) idInfoLock synchronized {
       if (null == idInfo) {

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/physical/ExecTask.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/plans/physical/ExecTask.scala
@@ -45,9 +45,9 @@ trait ExecTask extends PhysicalOrchestration[ExecTask] {
     val desc = getTaskDesc
     val jobID = desc.getOrigin.getASTOrchestration match {
       case job: Job =>
-        job.getId
+        job.getIDInfo()
       case stage: Stage =>
-        stage.getJob.getId
+        stage.getJob.getIDInfo()
       case _ => ""
     }
     jobID + "_" + getId


### PR DESCRIPTION
### What is the purpose of the change
#2058 

### Brief change log

- Add taskID to job idinfo 
- ecm prints entrance taskID log
- add getJobIdFromStringMap method
- entrance prints entrance taskID log
- am prints entrance taskID log
