### PR TITLE
Fix: ECM page 'instance' display mistake

### DIFF
--- a/web/src/apps/linkis/module/ECM/engineConn.vue
+++ b/web/src/apps/linkis/module/ECM/engineConn.vue
@@ -29,7 +29,7 @@
         </template>
         <template slot-scope="{row}" slot="usedResource">
           <!-- 后台未做返回时的处理，下面几个可按照处理 -->
-          <span v-if="row.usedResource">{{`${calcCompany(row.usedResource.cores)}cores,${calcCompany(row.usedResource.memory, true)}G,${calcCompany(row.usedResource.instances)}apps`}}</span>
+          <span v-if="row.usedResource">{{`${calcCompany(row.usedResource.cores)}cores,${calcCompany(row.usedResource.memory, true)}G,${calcCompany(row.usedResource.instance)}apps`}}</span>
           <span v-else>Null cores,Null G</span>
         </template>
         <!-- <template slot-scope="{row}" slot="maxResource">

--- a/web/src/apps/linkis/module/ECM/index.vue
+++ b/web/src/apps/linkis/module/ECM/index.vue
@@ -240,7 +240,7 @@ export default {
         }
         return data;
       }
-      return  v && (v.cores !== undefined || v.memonry !== undefined || v.instances !== undefined) ? `${calcCompany(v.cores)}cores,${calcCompany(v.memory, true)}G,${calcCompany(v.instances)}apps` : ''
+      return  v && (v.cores !== undefined || v.memonry !== undefined || v.instance !== undefined) ? `${calcCompany(v.cores)}cores,${calcCompany(v.memory, true)}G,${calcCompany(v.instance)}apps` : ''
     }
   },
   created() {


### PR DESCRIPTION
### What is the purpose of the change
Fix: ECM page 'instance' display mistake

### Brief change log
(for example:)
- Change table's param 'instances' into 'instance' in ECM page. 