### PR TITLE
use python3 the "/appcom/Install/anaconda3/bin/python" not found

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/conf/PythonEngineConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/conf/PythonEngineConfiguration.scala
@@ -24,7 +24,7 @@ object PythonEngineConfiguration {
 
   val PYTHON_CONSOLE_OUTPUT_LINE_LIMIT = CommonVars("wds.linkis.python.line.limit", 10)
   val PY4J_HOME = CommonVars("wds.linkis.python.py4j.home", this.getClass.getResource("/conf").getPath)
-  val PYTHON_VERSION = CommonVars("pythonVersion", "/appcom/Install/anaconda3/bin/python")
+  val PYTHON_VERSION = CommonVars("pythonVersion", "python3")
 
   val PYTHON_PATH:CommonVars[String] = CommonVars[String]("python.path", "", "Specify Python's extra path, which only accepts shared storage paths（指定Python额外的path，该路径只接受共享存储的路径）.")
 


### PR DESCRIPTION
use python3 the "/appcom/Install/anaconda3/bin/python" not found
![image](https://user-images.githubusercontent.com/19589632/167258066-8f0f06c9-51c3-4941-9d1c-6de4ae4a2ad1.png)

If modified like this, both python and python3 can be used