### PR TITLE
Fix the issue that the JDBC Engine console configuration cannot take effect immediately after modification

### DIFF
--- a/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/conf/RPCConfiguration.scala
+++ b/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/conf/RPCConfiguration.scala
@@ -52,4 +52,5 @@ object RPCConfiguration {
 
   val REFLECTIONS = new Reflections(SERVICE_SCAN_PACKAGE, new MethodAnnotationsScanner(), new TypeAnnotationsScanner(), new SubTypesScanner())
 
+  val BDP_RPC_CACHE_CONF_EXPIRE_TIME = CommonVars("wds.linkis.rpc.cache.expire.time", 120000L)
 }

--- a/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/interceptor/common/CacheableRPCInterceptor.scala
+++ b/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/interceptor/common/CacheableRPCInterceptor.scala
@@ -23,6 +23,7 @@ import com.google.common.cache.{Cache, CacheBuilder, RemovalListener, RemovalNot
 import org.apache.linkis.common.exception.WarnException
 import org.apache.linkis.common.utils.{Logging, Utils}
 import org.apache.linkis.protocol.CacheableProtocol
+import org.apache.linkis.rpc.conf.RPCConfiguration
 import org.apache.linkis.rpc.interceptor.{RPCInterceptor, RPCInterceptorChain, RPCInterceptorExchange}
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils
@@ -33,7 +34,7 @@ import scala.tools.scalap.scalax.util.StringUtil
 class CacheableRPCInterceptor extends RPCInterceptor with Logging{
 
   private val guavaCache: Cache[Any, Any] = CacheBuilder.newBuilder().concurrencyLevel(5)
-    .expireAfterAccess(120000, TimeUnit.MILLISECONDS).initialCapacity(20)  //TODO Make parameters(做成参数)
+    .expireAfterAccess(RPCConfiguration.BDP_RPC_CACHE_CONF_EXPIRE_TIME.getValue, TimeUnit.MILLISECONDS).initialCapacity(20)  //TODO Make parameters(做成参数)
     .maximumSize(1000).recordStats().removalListener(new RemovalListener[Any, Any] {
     override def onRemoval(removalNotification: RemovalNotification[Any, Any]): Unit = {
       debug(s"CacheSender removed key => ${removalNotification.getKey}, value => ${removalNotification.getValue}.")

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/resources/linkis-engineconn.properties
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/resources/linkis-engineconn.properties
@@ -20,3 +20,4 @@ wds.linkis.engineconn.debug.enable=true
 wds.linkis.engineconn.plugin.default.class=org.apache.linkis.manager.engineplugin.jdbc.JDBCEngineConnPlugin
 #wds.linkis.engine.io.opts=" -Dfile.encoding=UTF-8  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=49100 "
 wds.linkis.engineconn.support.parallelism=true
+wds.linkis.rpc.cache.expire.time=0


### PR DESCRIPTION
This problem is caused by the JDBC engine caching JDBC engine configuration. The solution is to modify the cache expiration time to configurable

The purpose is to modify the JDBC engine configuration to take effect immediately when the JDBC cache expiration time configuration is set for a short time