### PR TITLE
add RetryCountLabel and retrycount param

### DIFF
--- a/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/constant/LabelKeyConstant.java
+++ b/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/constant/LabelKeyConstant.java
@@ -53,6 +53,7 @@ public class LabelKeyConstant {
 
     public static final String RETRY_TIMEOUT_KEY = "jobRetryTimeout";
 
+    public static final String RETRY_COUNT_KEY = "jobRetryCount";
     public static final String EXECUTE_ONCE_KEY = "executeOnce";
 
     public static final String LOAD_BALANCE_KEY = "loadBalance";

--- a/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/entrance/RetryCountLabel.java
+++ b/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/entrance/RetryCountLabel.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.linkis.manager.label.entity.entrance;
 
 import org.apache.linkis.manager.label.constant.LabelKeyConstant;

--- a/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/entrance/RetryCountLabel.java
+++ b/linkis-computation-governance/linkis-manager/label-common/src/main/java/org/apache/linkis/manager/label/entity/entrance/RetryCountLabel.java
@@ -1,0 +1,29 @@
+package org.apache.linkis.manager.label.entity.entrance;
+
+import org.apache.linkis.manager.label.constant.LabelKeyConstant;
+import org.apache.linkis.manager.label.entity.GenericLabel;
+import org.apache.linkis.manager.label.entity.annon.ValueSerialNum;
+
+import java.util.HashMap;
+
+public class RetryCountLabel extends GenericLabel implements JobStrategyLabel {
+
+    public RetryCountLabel() {
+        setLabelKey(LabelKeyConstant.RETRY_COUNT_KEY);
+    }
+
+    public Integer getJobRetryCount() {
+        if (null == getValue()) {
+            return -1;
+        }
+        return Integer.parseInt(getValue().getOrDefault(LabelKeyConstant.RETRY_COUNT_KEY, "-1"));
+    }
+
+    @ValueSerialNum(0)
+    public void setJobRetryCount(String count) {
+        if (null == getValue()) {
+            setValue(new HashMap<>());
+        }
+        getValue().put(LabelKeyConstant.RETRY_COUNT_KEY, count);
+    }
+}

--- a/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/catalyst/reheater/PruneTaskReheaterTransform.scala
+++ b/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/catalyst/reheater/PruneTaskReheaterTransform.scala
@@ -30,6 +30,9 @@ import org.apache.linkis.orchestrator.listener.task.TaskLogEvent
 import org.apache.linkis.orchestrator.plans.physical.{ExecTask, PhysicalContext, PhysicalOrchestration, ReheatableExecTask, RetryExecTask}
 import org.apache.linkis.orchestrator.strategy.ExecTaskStatusInfo
 
+import java.util
+import scala.collection.JavaConverters.mapAsScalaMapConverter
+
 /**
  * Transform physical tree by pruning it's nodes
  *
@@ -52,7 +55,15 @@ class PruneTaskRetryTransform extends ReheaterTransform with Logging{
                   Utils.tryCatch{
                     task match {
                       case retryExecTask: RetryExecTask => {
-                        if (retryExecTask.getAge() < ComputationOrchestratorConf.RETRYTASK_MAXIMUM_AGE.getValue) {
+                        val runtimeMap = new util.HashMap[String, String]()
+                        Utils.tryAndWarn {
+                          retryExecTask.getTaskDesc.getOrigin.getASTOrchestration.getASTContext.getParams.getRuntimeParams.toMap.asScala.foreach(kv => {
+                            if (kv._2.isInstanceOf[String]) {
+                              runtimeMap.put(kv._1, kv._2.asInstanceOf[String])
+                            }
+                          })
+                        }
+                        if (retryExecTask.getAge() < ComputationOrchestratorConf.RETRYTASK_MAXIMUM_AGE.getValue(runtimeMap)) {
                           val newTask = new RetryExecTask(retryExecTask.getOriginTask, retryExecTask.getAge() + 1)
                           newTask.initialize(retryExecTask.getPhysicalContext)
                           TreeNodeUtil.replaceNode(retryExecTask, newTask)

--- a/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/catalyst/reheater/PruneTaskReheaterTransform.scala
+++ b/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/catalyst/reheater/PruneTaskReheaterTransform.scala
@@ -55,15 +55,7 @@ class PruneTaskRetryTransform extends ReheaterTransform with Logging{
                   Utils.tryCatch{
                     task match {
                       case retryExecTask: RetryExecTask => {
-                        val runtimeMap = new util.HashMap[String, String]()
-                        Utils.tryAndWarn {
-                          retryExecTask.getTaskDesc.getOrigin.getASTOrchestration.getASTContext.getParams.getRuntimeParams.toMap.asScala.foreach(kv => {
-                            if (kv._2.isInstanceOf[String]) {
-                              runtimeMap.put(kv._1, kv._2.asInstanceOf[String])
-                            }
-                          })
-                        }
-                        if (retryExecTask.getAge() < ComputationOrchestratorConf.RETRYTASK_MAXIMUM_AGE.getValue(runtimeMap)) {
+                        if (retryExecTask.getAge() < retryExecTask.getMaxRetryCount()) {
                           val newTask = new RetryExecTask(retryExecTask.getOriginTask, retryExecTask.getAge() + 1)
                           newTask.initialize(retryExecTask.getPhysicalContext)
                           TreeNodeUtil.replaceNode(retryExecTask, newTask)

--- a/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/conf/ComputationOrchestratorConf.scala
+++ b/linkis-orchestrator/linkis-computation-orchestrator/src/main/scala/org/apache/linkis/orchestrator/computation/conf/ComputationOrchestratorConf.scala
@@ -47,8 +47,6 @@ object ComputationOrchestratorConf {
 
   val LOG_LEN = CommonVars("wds.linkis.computation.orchestrator.log.len", 100)
 
-  val RETRYTASK_MAXIMUM_AGE = CommonVars("wds.linkis.computation.orchestrator.retry.max.age", 10)
-
 
   val ENGINECONN_LASTUPDATE_TIMEOUT = CommonVars("wds.linkis.orchestrator.engine.lastupdate.timeout", new TimeType("5s"))
   val ENGINECONN_ACTIVITY_TIMEOUT = CommonVars("wds.linkis.orchestrator.engine.timeout", new TimeType("10s"))

--- a/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
+++ b/linkis-orchestrator/linkis-orchestrator-core/src/main/scala/org/apache/linkis/orchestrator/conf/OrchestratorConfiguration.scala
@@ -54,6 +54,8 @@ object OrchestratorConfiguration {
 
   val RETRY_TASK_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.retry.wait.time", 30000)
 
+  val RETRYTASK_MAXIMUM_AGE = CommonVars("wds.linkis.computation.orchestrator.retry.max.age", 10)
+
   val SCHEDULER_RETRY_TASK_WAIT_TIME = CommonVars("wds.linkis.orchestrator.task.scheduler.retry.wait.time", 100000)
 
   val TASK_SCHEDULER_THREAD_POOL = CommonVars("wds.linkis.orchestrator.task.scheduler.thread.pool", 200)


### PR DESCRIPTION
### What is the purpose of the change
issue #2154

### Brief change log
(for example:)
- Add RetryCountLabel
- Add runtime param wds.linkis.computation.orchestrator.retry.max.age

### Verifying this change
(Please pick either of the following options)  
This change added tests and can be verified as follows:  
(example:)  
- Submit a task with ether RetryCountLabel or runtime param "wds.linkis.computation.orchestrator.retry.max.age" , and requiring more than left resource , then see the retry count in log.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs)