### PR TITLE
[Feature-2212] Add the default DWSClientConfig constructor for LinkisDataSourceRemoteClient to simplify the client API for internal microservices to call data source services

### DIFF
--- a/db/linkis_dml.sql
+++ b/db/linkis_dml.sql
@@ -447,6 +447,7 @@ INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hos
 INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('QUALITIS-AUTH','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
 INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('VALIDATOR-AUTH','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
 INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('LINKISCLI-AUTH','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
+INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('DSM-AUTH','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
 
 INSERT INTO `linkis_ps_dm_datasource_type` (`name`, `description`, `option`, `classifier`, `icon`, `layers`) VALUES ('mysql', 'mysql数据库', 'mysql数据库', '关系型数据库', '', 3);
 INSERT INTO `linkis_ps_dm_datasource_type` (`name`, `description`, `option`, `classifier`, `icon`, `layers`) VALUES ('kafka', 'kafka', 'kafka', '消息队列', '', 2);

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/DataSourceRemoteClient.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/DataSourceRemoteClient.scala
@@ -24,6 +24,7 @@ trait DataSourceRemoteClient extends RemoteClient {
   def getAllDataSourceTypes(action: GetAllDataSourceTypesAction): GetAllDataSourceTypesResult
   def queryDataSourceEnv(action: QueryDataSourceEnvAction): QueryDataSourceEnvResult
   def getInfoByDataSourceId(action: GetInfoByDataSourceIdAction): GetInfoByDataSourceIdResult
+  def getInfoByDataSourceName(action: GetInfoByDataSourceNameAction): GetInfoByDataSourceNameResult
   def queryDataSource(action: QueryDataSourceAction): QueryDataSourceResult
   def getConnectParams(action: GetConnectParamsByDataSourceIdAction): GetConnectParamsByDataSourceIdResult
   def createDataSource(action: CreateDataSourceAction): CreateDataSourceResult

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/config/DatasourceClientConfig.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/config/DatasourceClientConfig.scala
@@ -24,4 +24,16 @@ object DatasourceClientConfig {
 
   var DATA_SOURCE_SERVICE_MODULE: CommonVars[String] = CommonVars.apply("wds.linkis.server.dsm.module.name", "data-source-manager")
 
+  val AUTH_TOKEN_KEY: CommonVars[String] = CommonVars[String]("wds.linkis.server.dsm.auth.token.key", "Token-Code")
+
+  val AUTH_TOKEN_VALUE: CommonVars[String] = CommonVars[String]("wds.linkis.server.dsm.auth.token.value", "DSM-AUTH")
+
+  val DATA_SOURCE_SERVICE_CLIENT_NAME: CommonVars[String] = CommonVars[String]("wds.linkis.server.dsm.client.name", "DataSource-Client")
+
+  val CONNECTION_MAX_SIZE: CommonVars[Int] = CommonVars[Int]("wds.linkis.server.dsm.connection.max.size", 10)
+
+  val CONNECTION_TIMEOUT: CommonVars[Int] = CommonVars[Int]("wds.linkis.server.dsm.connection.timeout", 30000)
+
+  val CONNECTION_READ_TIMEOUT: CommonVars[Int] = CommonVars[Int]("wds.linkis.server.dsm.connection.read.timeout", 10 * 60 * 1000)
+
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetInfoByDataSourceNameAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetInfoByDataSourceNameAction.scala
@@ -17,31 +17,27 @@
 
 package org.apache.linkis.datasource.client.request
 
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-
-import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
 import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
 import org.apache.linkis.httpclient.request.GetAction
-/**
-  * Get version parameters from data source
- */
-class GetConnectParamsByDataSourceNameAction extends GetAction with DataSourceAction{
+
+
+class GetInfoByDataSourceNameAction extends GetAction with DataSourceAction {
   private var dataSourceName: String = _
+
+  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "info", "name", dataSourceName)
 
   private var user: String = _
 
-  override def suffixURLs: Array[String] = Array(DATA_SOURCE_SERVICE_MODULE.getValue, "name", dataSourceName, "connect-params")
-
   override def setUser(user: String): Unit = this.user = user
 
-  override def getUser: String = user
+  override def getUser: String = this.user
 }
 
-object GetConnectParamsByDataSourceNameAction{
+object GetInfoByDataSourceNameAction {
   def builder(): Builder = new Builder
 
-  class Builder private[GetConnectParamsByDataSourceNameAction]() {
+  class Builder private[GetInfoByDataSourceNameAction]() {
     private var dataSourceName: String = _
     private var system: String = _
     private var user: String = _
@@ -61,23 +57,19 @@ object GetConnectParamsByDataSourceNameAction{
       this
     }
 
-    def build(): GetConnectParamsByDataSourceNameAction = {
+    def build(): GetInfoByDataSourceNameAction = {
       if (dataSourceName == null) throw new DataSourceClientBuilderException("dataSourceName is needed!")
-      if(system == null) throw new DataSourceClientBuilderException("system is needed!")
-      if(user == null) throw new DataSourceClientBuilderException("user is needed!")
-      // Use URIEncoder to encode the datSourceName
-      var requestDataSourceName = this.dataSourceName
-      try {
-        requestDataSourceName = URLEncoder.encode(dataSourceName, StandardCharsets.UTF_8.name())
-      } catch {
-        case e: Exception =>
-          throw new DataSourceClientBuilderException(s"Cannot encode the name of data source:[$dataSourceName] for request", e)
-      }
-      val getConnectParamsByDataSourceNameAction = new GetConnectParamsByDataSourceNameAction
-      getConnectParamsByDataSourceNameAction.dataSourceName = requestDataSourceName
-      getConnectParamsByDataSourceNameAction.setParameter("system", system)
-      getConnectParamsByDataSourceNameAction.setUser(user)
-      getConnectParamsByDataSourceNameAction
+      if (system == null) throw new DataSourceClientBuilderException("system is needed!")
+      if (user == null) throw new DataSourceClientBuilderException("user is needed!")
+
+      val getInfoByDataSourceNameAction = new GetInfoByDataSourceNameAction
+      getInfoByDataSourceNameAction.dataSourceName = this.dataSourceName
+      getInfoByDataSourceNameAction.setParameter("system", system)
+      getInfoByDataSourceNameAction.setUser(user)
+      getInfoByDataSourceNameAction
     }
   }
+
 }
+
+

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/GetInfoByDataSourceNameResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/GetInfoByDataSourceNameResult.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.response
+
+import org.apache.linkis.datasourcemanager.common.domain.DataSource
+import org.apache.linkis.httpclient.dws.DWSHttpClient
+import org.apache.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import org.apache.linkis.httpclient.dws.response.DWSResult
+
+import scala.beans.BeanProperty
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/data-source-manager/info/name/(\\S+)")
+class GetInfoByDataSourceNameResult extends DWSResult {
+  @BeanProperty var info: java.util.Map[String, Any] = _
+
+  def getDataSource: DataSource = {
+    val str = DWSHttpClient.jacksonJson.writeValueAsString(info)
+    DWSHttpClient.jacksonJson.readValue(str, classOf[DataSource])
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/test/java/org/apache/linkis/datasource/client/TestDataSourceClient.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/test/java/org/apache/linkis/datasource/client/TestDataSourceClient.scala
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit
 object TestDataSourceClient {
   def main(args: Array[String]): Unit = {
     val clientConfig = DWSClientConfigBuilder.newBuilder()
-      .addServerUrl("http://192.168.28.98:9001") //set linkis-mg-gateway url: http://{ip}:{port}
+      .addServerUrl("http://127.0.0.1:9001") //set linkis-mg-gateway url: http://{ip}:{port}
       .connectionTimeout(30000) //connection timtout
       .discoveryEnabled(false) //disable discovery
       .discoveryFrequency(1, TimeUnit.MINUTES)  // discovery frequency

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/test/java/org/apache/linkis/datasource/client/TestDataSourceClient.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/test/java/org/apache/linkis/datasource/client/TestDataSourceClient.scala
@@ -19,7 +19,7 @@ package org.apache.linkis.datasource.client
 
 import org.apache.linkis.datasource.client.impl.LinkisDataSourceRemoteClient
 import org.apache.linkis.datasource.client.request._
-import org.apache.linkis.httpclient.dws.authentication.StaticAuthenticationStrategy
+import org.apache.linkis.httpclient.dws.authentication.{StaticAuthenticationStrategy, TokenAuthenticationStrategy}
 import org.apache.linkis.httpclient.dws.config.DWSClientConfigBuilder
 
 import java.util.concurrent.TimeUnit
@@ -27,7 +27,22 @@ import java.util.concurrent.TimeUnit
 object TestDataSourceClient {
   def main(args: Array[String]): Unit = {
     val clientConfig = DWSClientConfigBuilder.newBuilder()
-      .addServerUrl("http://127.0.0.1:9001")
+      .addServerUrl("http://192.168.28.98:9001") //set linkis-mg-gateway url: http://{ip}:{port}
+      .connectionTimeout(30000) //connection timtout
+      .discoveryEnabled(false) //disable discovery
+      .discoveryFrequency(1, TimeUnit.MINUTES)  // discovery frequency
+      .loadbalancerEnabled(false) // enable loadbalance
+      .maxConnectionSize(5) // set max Connection
+      .retryEnabled(false) // set retry
+      .readTimeout(30000) //set read timeout
+      .setAuthenticationStrategy(new TokenAuthenticationStrategy()) //AuthenticationStrategy Linkis authen suppory static and Token
+      .setAuthTokenKey("Token-Code")  // set submit user
+      .setAuthTokenValue("DSM-AUTH") // set passwd or token
+      .setDWSVersion("v1") //linkis rest version v1
+      .build()
+
+    /*val clientConfig = DWSClientConfigBuilder.newBuilder()
+      .addServerUrl("http://192.168.28.98:9001")
       .connectionTimeout(30000)
       .discoveryEnabled(false)
       .discoveryFrequency(1, TimeUnit.MINUTES)
@@ -36,14 +51,19 @@ object TestDataSourceClient {
       .retryEnabled(false)
       .readTimeout(30000)
       .setAuthenticationStrategy(new StaticAuthenticationStrategy())
-      .setAuthTokenKey("hadoop")
-      .setAuthTokenValue("hadoop")
+      .setAuthTokenKey("linkis")
+      .setAuthTokenValue("123456")
       .setDWSVersion("v1")
-      .build()
+      .build()*/
 
     val dataSourceClient = new LinkisDataSourceRemoteClient(clientConfig)
 
-    val getAllDataSourceTypesResult = dataSourceClient.getAllDataSourceTypes(GetAllDataSourceTypesAction.builder().setUser("hadoop").build()).getAllDataSourceType
+    val getDataSourceByName = dataSourceClient.getInfoByDataSourceName(GetInfoByDataSourceNameAction.builder()
+    .setDataSourceName("test_mysql")
+    .setUser("linkis")
+    .setSystem("").build()).getDataSource
+
+    val getAllDataSourceTypesResult = dataSourceClient.getAllDataSourceTypes(GetAllDataSourceTypesAction.builder().setUser("linkis").build()).getAllDataSourceType
 
     val queryDataSourceEnvResult = dataSourceClient.queryDataSourceEnv(
                                         QueryDataSourceEnvAction.builder()


### PR DESCRIPTION
https://github.com/apache/incubator-linkis/issues/2212

[Feature-2212] Add the default DWSClientConfig constructor for LinkisDataSourceRemoteClient to simplify the client API for internal microservices to call data source services