### PR TITLE
Fix FileReader and BufferedReader are not closed in final clause

### DIFF
--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-client/src/test/java/org/apache/linkis/cs/client/test/test_multiuser/TestChangeContext.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-client/src/test/java/org/apache/linkis/cs/client/test/test_multiuser/TestChangeContext.java
@@ -48,16 +48,17 @@ public class TestChangeContext {
                                 + " invalid.");
                 return;
             }
-            FileReader fr = new FileReader(file);
-            BufferedReader br = new BufferedReader(fr);
-            String contextIDStr = null;
-            StringBuilder builder = new StringBuilder("");
-            java.lang.String tmp = br.readLine();
-            while (null != tmp) {
-                builder.append(tmp);
-                tmp = br.readLine();
+
+            String contextIDStr;
+            StringBuilder builder = new StringBuilder();
+            try (FileReader fr = new FileReader(file);
+                BufferedReader br = new BufferedReader(fr)) {
+                java.lang.String tmp = br.readLine();
+                while (null != tmp) {
+                    builder.append(tmp);
+                    tmp = br.readLine();
+                }
             }
-            br.close();
             contextIDStr = builder.toString();
             System.out.println("Read contextID : " + contextIDStr);
 

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-client/src/test/java/org/apache/linkis/cs/client/test/test_multiuser/TestChangeContext.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-client/src/test/java/org/apache/linkis/cs/client/test/test_multiuser/TestChangeContext.java
@@ -52,7 +52,7 @@ public class TestChangeContext {
             String contextIDStr;
             StringBuilder builder = new StringBuilder();
             try (FileReader fr = new FileReader(file);
-                BufferedReader br = new BufferedReader(fr)) {
+                    BufferedReader br = new BufferedReader(fr)) {
                 java.lang.String tmp = br.readLine();
                 while (null != tmp) {
                     builder.append(tmp);


### PR DESCRIPTION
### What is the purpose of the change
Fix FileReader and BufferedReader are not closed in final clause. Related issues: #1878 .

### Brief change log
(for example:)
- Define the core abstraction and interfaces of the EngineConn Factory;
- Define the core abstraction and interfaces of Executor Manager.

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  
(or)  
This change is already covered by existing tests, such as (please describe tests).  
(or)  
This change added tests and can be verified as follows:  
(example:)  
- Added tests for submit and execute all kinds of jobs to go through and verify the lifecycles of different EngineConns.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

Close #1878 