### PR TITLE
Refactor resultset path in linkis-entrance

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/StorePathEntranceInterceptor.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/StorePathEntranceInterceptor.scala
@@ -52,7 +52,7 @@ class StorePathEntranceInterceptor extends EntranceInterceptor with Logging {
       val labelJson = BDPJettyServerHelper.gson.toJson(jobReq.getLabels.asScala.filter(_ != null).map(_.toString))
       throw new EntranceErrorException(EntranceErrorCode.LABEL_PARAMS_INVALID.getErrCode, s"UserCreator cannot be empty in labels : ${labelJson} of job with id : ${jobReq.getId}")
     }
-    parentPath += DateFormatUtils.format(System.currentTimeMillis, "yyyyMMdd_HHmmss") + "/" +
+    parentPath += DateFormatUtils.format(System.currentTimeMillis, "yyyy/MM-dd/HHmmss") + "/" +
       userCreator._2 + "/" + jobReq.getId
     val paramsMap = {
       val map = new util.HashMap[String, Any]()

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/StorePathEntranceInterceptor.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/StorePathEntranceInterceptor.scala
@@ -52,7 +52,8 @@ class StorePathEntranceInterceptor extends EntranceInterceptor with Logging {
       val labelJson = BDPJettyServerHelper.gson.toJson(jobReq.getLabels.asScala.filter(_ != null).map(_.toString))
       throw new EntranceErrorException(EntranceErrorCode.LABEL_PARAMS_INVALID.getErrCode, s"UserCreator cannot be empty in labels : ${labelJson} of job with id : ${jobReq.getId}")
     }
-    parentPath += DateFormatUtils.format(System.currentTimeMillis, "yyyy/MM-dd/HHmmss") + "/" +
+    // multi linkis cluster should not use same root folder , in which case result file may be overwrite
+    parentPath += DateFormatUtils.format(System.currentTimeMillis, "yyyy-MM-dd/HHmmss") + "/" +
       userCreator._2 + "/" + jobReq.getId
     val paramsMap = {
       val map = new util.HashMap[String, Any]()


### PR DESCRIPTION
### What is the purpose of the change
#2124
Refactor resultset path in linkis-entrance

### Brief change log
(for example:)
- Refactor resultset path in linkis-entrance

### Verifying this change
(Please pick either of the following options)  

This change added tests and can be verified as follows:  
(example:)  
- Added tests for submit and execute all kinds of jobs to go through and verify the lifecycles of different EngineConns.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (o)
- Anything that affects deployment: (no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)