### PR TITLE
Added interface for getEntrance task metrics

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
@@ -49,13 +49,13 @@ public class EntranceMetricRestfulApi {
     }
 
     @RequestMapping(path = "/taskinfo", method = RequestMethod.GET)
-    public Message status(
+    public Message taskinfo(
             HttpServletRequest req,
             @RequestParam(value = "user", required = false) String user,
             @RequestParam(value = "creator", required = false) String creator,
             @RequestParam(value = "engineTypeLabel", required = false)
                     String engineTypeLabelValue) {
-        String userName = ModuleUserUtils.getOperationUser(req, "taskcount");
+        String userName = ModuleUserUtils.getOperationUser(req, "taskinfo");
         String queryUser = user;
         if (!Configuration.isAdmin(userName)) {
             if (StringUtils.isBlank(queryUser)) {
@@ -66,7 +66,7 @@ public class EntranceMetricRestfulApi {
             }
         }
         String filterWords = creator;
-        if (StringUtils.isNoneBlank(filterWords) && StringUtils.isNoneBlank(queryUser)) {
+        if (StringUtils.isNotBlank(filterWords) && StringUtils.isNotBlank(queryUser)) {
             filterWords = filterWords + "_" + queryUser;
         } else if (StringUtils.isBlank(creator)) {
             filterWords = queryUser;
@@ -78,7 +78,7 @@ public class EntranceMetricRestfulApi {
 
         if (null != undoneTasks) {
             for (EntranceJob task : undoneTasks) {
-                if (StringUtils.isNoneBlank(engineTypeLabelValue)) {
+                if (StringUtils.isNotBlank(engineTypeLabelValue)) {
                     EngineTypeLabel engineTypeLabel =
                             LabelUtil.getEngineTypeLabel(task.getJobRequest().getLabels());
                     // Task types do not match, do not count

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.entrance.restful;
+
+import org.apache.linkis.common.conf.Configuration;
+import org.apache.linkis.entrance.EntranceServer;
+import org.apache.linkis.entrance.annotation.EntranceServerBeanAnnotation;
+import org.apache.linkis.entrance.execute.EntranceJob;
+import org.apache.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.apache.linkis.manager.label.utils.LabelUtil;
+import org.apache.linkis.server.Message;
+import org.apache.linkis.server.utils.ModuleUserUtils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RestController
+@RequestMapping(path = "/entrance/api/metrics")
+public class EntranceMetricRestfulApi {
+
+    private EntranceServer entranceServer;
+
+    private static final Logger logger = LoggerFactory.getLogger(EntranceMetricRestfulApi.class);
+
+    @EntranceServerBeanAnnotation.EntranceServerAutowiredAnnotation
+    public void setEntranceServer(EntranceServer entranceServer) {
+        this.entranceServer = entranceServer;
+    }
+
+    @RequestMapping(path = "/taskinfo", method = RequestMethod.GET)
+    public Message status(
+            HttpServletRequest req,
+            @RequestParam(value = "user", required = false) String user,
+            @RequestParam(value = "creator", required = false) String creator,
+            @RequestParam(value = "engineTypeLabel", required = false)
+                    String engineTypeLabelValue) {
+        String userName = ModuleUserUtils.getOperationUser(req, "taskcount");
+        String queryUser = user;
+        if (!Configuration.isAdmin(userName)) {
+            if (StringUtils.isBlank(queryUser)) {
+                queryUser = userName;
+            } else if (!userName.equalsIgnoreCase(queryUser)) {
+                return Message.error(
+                        "Non-administrators cannot view other users' task information");
+            }
+        }
+        String filterWords = creator;
+        if (StringUtils.isNoneBlank(filterWords) && StringUtils.isNoneBlank(queryUser)) {
+            filterWords = filterWords + "_" + queryUser;
+        } else if (StringUtils.isBlank(creator)) {
+            filterWords = queryUser;
+        }
+        EntranceJob[] undoneTasks = entranceServer.getAllUndoneTask(filterWords);
+        int taskNumber = 0;
+        int runningNumber = 0;
+        int queuedNumber = 0;
+
+        if (null != undoneTasks) {
+            for (EntranceJob task : undoneTasks) {
+                if (StringUtils.isNoneBlank(engineTypeLabelValue)) {
+                    EngineTypeLabel engineTypeLabel =
+                            LabelUtil.getEngineTypeLabel(task.getJobRequest().getLabels());
+                    // Task types do not match, do not count
+                    if (null == engineTypeLabel
+                            || !engineTypeLabelValue.equalsIgnoreCase(
+                                    engineTypeLabel.getStringValue())) {
+                        continue;
+                    }
+                }
+                taskNumber++;
+                if (task.isRunning()) {
+                    runningNumber++;
+                } else {
+                    queuedNumber++;
+                }
+            }
+        }
+        return Message.ok("success")
+                .data("taskNumber", taskNumber)
+                .data("runningNumber", runningNumber)
+                .data("queuedNumber", queuedNumber);
+    }
+}

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
@@ -28,6 +28,7 @@ import org.apache.linkis.rpc.Sender
 import org.apache.linkis.scheduler.queue.{Job, SchedulerEventState}
 import org.apache.linkis.server.conf.ServerConfiguration
 import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.commons.lang3.StringUtils
 
 
 abstract class EntranceServer extends Logging {
@@ -162,6 +163,18 @@ abstract class EntranceServer extends Logging {
     }
     entranceWebSocketService
   } else None
+
+  def getAllUndoneTask(filterWords: String): Array[EntranceJob] = {
+    val consumers = getEntranceContext.getOrCreateScheduler().getSchedulerContext.getOrCreateConsumerManager.listConsumers().toSet
+    val filterConsumer = if (StringUtils.isNoneBlank(filterWords)) {
+      consumers.filter(_.getGroup.getGroupName.contains(filterWords))
+    } else {
+      consumers
+    }
+    filterConsumer.flatMap { consumer =>
+      consumer.getRunningEvents ++ consumer.getConsumeQueue.getWaitingEvents
+    }.filter(job => job != null && job.isInstanceOf[EntranceJob]).map(_.asInstanceOf[EntranceJob]).toArray
+  }
 
 }
 object EntranceServer {

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
@@ -166,7 +166,7 @@ abstract class EntranceServer extends Logging {
 
   def getAllUndoneTask(filterWords: String): Array[EntranceJob] = {
     val consumers = getEntranceContext.getOrCreateScheduler().getSchedulerContext.getOrCreateConsumerManager.listConsumers().toSet
-    val filterConsumer = if (StringUtils.isNoneBlank(filterWords)) {
+    val filterConsumer = if (StringUtils.isNotBlank(filterWords)) {
       consumers.filter(_.getGroup.getGroupName.contains(filterWords))
     } else {
       consumers

--- a/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
@@ -313,7 +313,7 @@ class ConfigurationService extends Logging {
     val configMap = new util.HashMap[String, String]()
     if (null != defaultEngineConfigs) {
       defaultEngineConfigs.asScala.foreach{ keyValue =>
-        if (StringUtils.isNoneBlank(keyValue.getKey) && StringUtils.isNotEmpty(keyValue.getConfigValue)) {
+        if (StringUtils.isNotBlank(keyValue.getKey) && StringUtils.isNotEmpty(keyValue.getConfigValue)) {
           configMap.put(keyValue.getKey, keyValue.getConfigValue)
         }
       }

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-server-support/src/main/scala/org/apache/linkis/gateway/ujes/parser/EntranceRequestGatewayParser.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-server-support/src/main/scala/org/apache/linkis/gateway/ujes/parser/EntranceRequestGatewayParser.scala
@@ -52,7 +52,10 @@ class EntranceRequestGatewayParser extends AbstractGatewayParser {
 }
 
 object EntranceRequestGatewayParser {
+
   val ENTRANCE_REQUEST_REGEX = (ENTRANCE_HEADER + "([^/]+)/.+").r
+
   val API_REQUEST = "api"
+
   val INSTANCE = "instance"
 }


### PR DESCRIPTION
### What is the purpose of the change
close #2222
close #2258
close #2257
### Brief change log
- LinkisEntrance task metrics collection.
- Added feature to clean up running tasks when the Entrance process exits normally.
- Gateway supports forwarding non-execution related requests of Entrance. 