### PR TITLE
[Feat][Common] Add common rest api /offline for all services

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis.properties
@@ -51,6 +51,7 @@ wds.linkis.home=/appcom/Install/LinkisInstall
 #Linkis governance station administrators
 wds.linkis.governance.station.admin=hadoop
 wds.linkis.gateway.conf.publicservice.list=query,jobhistory,application,configuration,filesystem,udf,variable,microservice,errorcode,bml,datasource
+wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,/api/rest_j/v1/offline
 
 spring.spring.servlet.multipart.max-file-size=500MB
 spring.spring.servlet.multipart.max-request-size=500MB

--- a/assembly-combined-package/bin/install.sh
+++ b/assembly-combined-package/bin/install.sh
@@ -405,7 +405,6 @@ if [ "true" == "$PROMETHEUS_ENABLE" ]
 then
   echo "prometheus is enabled"
   sed -i ${txt} '$a \wds.linkis.prometheus.enable={{ PROMETHEUS_ENABLE }}' $LINKIS_HOME/conf/linkis.properties
-  sed -i ${txt} '$a \wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,' $LINKIS_HOME/conf/linkis.properties
   sed -i ${txt}  '/eureka:/a \\  instance:\n    metadata-map:\n      prometheus.path: ${prometheus.path:${prometheus.endpoint}}' $LINKIS_HOME/conf/application-linkis.yml
   sed -i ${txt}  's#include: refresh,info#include: refresh,info,health,metrics,prometheus#g' $LINKIS_HOME/conf/application-linkis.yml
   sed -i ${txt} '/instance:/a \    metadata-map:\n      prometheus.path: ${prometheus.path:/actuator/prometheus}' $LINKIS_HOME/conf/application-eureka.yml

--- a/linkis-commons/linkis-module/src/main/java/org/apache/linkis/restful/CommonRestfulApi.java
+++ b/linkis-commons/linkis-module/src/main/java/org/apache/linkis/restful/CommonRestfulApi.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.restful;
+
+import org.apache.linkis.server.Message;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.netflix.discovery.DiscoveryManager;
+
+@RestController
+@RequestMapping(path = "/")
+public class CommonRestfulApi {
+    @Autowired private DiscoveryClient client;
+
+    @RequestMapping(path = "/offline", method = RequestMethod.GET)
+    public Message offline(HttpServletRequest req) {
+        DiscoveryManager.getInstance().shutdownComponent();
+        return Message.ok().data("msg", "Offline successfully.");
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change
issue ref: https://github.com/apache/incubator-linkis/issues/2191

### Brief change log
- add new offline api

### Verify
Before request the api, we can see all the services in Eureka.
<img width="1716" alt="image" src="https://user-images.githubusercontent.com/2370761/173232702-aba5ab06-6a86-4446-b1e1-63c8e56576c9.png">

After we call offline api
<img width="906" alt="image" src="https://user-images.githubusercontent.com/2370761/173232729-d251fe45-fdc2-4364-963c-eea487cb8dca.png">

we can see the service `engineconnmanager` has been offline
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/2370761/173232759-cde81dc0-ba2c-4b5f-9725-81b0625d9e98.png">


