### PR TITLE
Added query interface for unfinished tasks

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis.properties
@@ -51,7 +51,7 @@ wds.linkis.home=/appcom/Install/LinkisInstall
 #Linkis governance station administrators
 wds.linkis.governance.station.admin=hadoop
 wds.linkis.gateway.conf.publicservice.list=query,jobhistory,application,configuration,filesystem,udf,variable,microservice,errorcode,bml,datasource
-wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,/api/rest_j/v1/offline
+wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,/api/rest_j/v1/offline,/api/rest_j/v1/entrance/api/metrics/runningtask
 
 spring.spring.servlet.multipart.max-file-size=500MB
 spring.spring.servlet.multipart.max-request-size=500MB

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
@@ -101,4 +101,21 @@ public class EntranceMetricRestfulApi {
                 .data("runningNumber", runningNumber)
                 .data("queuedNumber", queuedNumber);
     }
+
+    @RequestMapping(path = "/runningtask", method = RequestMethod.GET)
+    public Message status(HttpServletRequest req) {
+
+        EntranceJob[] undoneTasks = entranceServer.getAllUndoneTask("");
+        Boolean isCompleted = false;
+        if (null == undoneTasks || undoneTasks.length < 1) {
+            isCompleted = true;
+        }
+        int runningTaskNumber = 0;
+        if (undoneTasks != null) {
+            runningTaskNumber = undoneTasks.length;
+        }
+        return Message.ok("success")
+                .data("runningTaskNumber", runningTaskNumber)
+                .data("isCompleted", isCompleted);
+    }
 }


### PR DESCRIPTION
### What is the purpose of the change
close #2288

### Brief change log
- Added query interface for unfinished tasks

### add restful
request url: `/api/rest_j/v1/entrance/api/metrics/runningtask`
response:
```
{
    "method": "/api/entrance/api/metrics/runningtask",
    "status": 0,
    "message": "success",
    "data": {
        "runningTaskNumber": 0,
        "isCompleted": true
    }
}
```
