### PR TITLE
Entrance adds restful interface to support modifying routelabel 

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis-cg-entrance.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis-cg-entrance.properties
@@ -20,6 +20,8 @@ wds.linkis.server.socket.mode=false
 #wds.linkis.entrance.config.log.path=hdfs:///tmp/linkis/
 wds.linkis.resultSet.store.path=hdfs:///tmp/linkis
 
+wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,/api/rest_j/v1/offline,/api/rest_j/v1/entrance/operation
+
 ## enable entrance label registration
 #spring.eureka.instance.metadata-map.route=et1
 ##Spring

--- a/assembly-combined-package/assembly-combined/conf/linkis.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis.properties
@@ -51,7 +51,7 @@ wds.linkis.home=/appcom/Install/LinkisInstall
 #Linkis governance station administrators
 wds.linkis.governance.station.admin=hadoop
 wds.linkis.gateway.conf.publicservice.list=query,jobhistory,application,configuration,filesystem,udf,variable,microservice,errorcode,bml,datasource
-wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,/api/rest_j/v1/offline,/api/rest_j/v1/entrance/api/metrics/runningtask
+wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,/api/rest_j/v1/offline
 
 wds.linkis.gateway.conf.metadataquery.list=metadatamanager,metadataquery
 spring.spring.servlet.multipart.max-file-size=500MB

--- a/linkis-commons/linkis-protocol/src/main/java/org/apache/linkis/protocol/label/InsLabelRefreshRequest.java
+++ b/linkis-commons/linkis-protocol/src/main/java/org/apache/linkis/protocol/label/InsLabelRefreshRequest.java
@@ -22,7 +22,7 @@ import org.apache.linkis.common.ServiceInstance;
 import java.util.HashMap;
 import java.util.Map;
 
-public class InsLabelRefreshRequest {
+public class InsLabelRefreshRequest implements LabelRequest {
 
     /** Service instance */
     private ServiceInstance serviceInstance;

--- a/linkis-commons/linkis-protocol/src/main/java/org/apache/linkis/protocol/label/InsLabelRefreshRequest.java
+++ b/linkis-commons/linkis-protocol/src/main/java/org/apache/linkis/protocol/label/InsLabelRefreshRequest.java
@@ -19,13 +19,37 @@ package org.apache.linkis.protocol.label;
 
 import org.apache.linkis.common.ServiceInstance;
 
+import java.util.HashMap;
 import java.util.Map;
 
-public class InsLabelRefreshRequest extends InsLabelAttachRequest {
+public class InsLabelRefreshRequest {
+
+    /** Service instance */
+    private ServiceInstance serviceInstance;
+
+    /** Labels stored as map structure */
+    private Map<String, Object> labels = new HashMap<>();
 
     public InsLabelRefreshRequest() {}
 
     public InsLabelRefreshRequest(ServiceInstance serviceInstance, Map<String, Object> labels) {
-        super(serviceInstance, labels);
+        this.serviceInstance = serviceInstance;
+        this.labels = labels;
+    }
+
+    public ServiceInstance getServiceInstance() {
+        return serviceInstance;
+    }
+
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    public Map<String, Object> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, Object> labels) {
+        this.labels = labels;
     }
 }

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceLabelRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceLabelRestfulApi.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.entrance.restful;
+
+import org.apache.linkis.instance.label.client.InstanceLabelClient;
+import org.apache.linkis.manager.label.constant.LabelKeyConstant;
+import org.apache.linkis.protocol.label.InsLabelRefreshRequest;
+import org.apache.linkis.rpc.Sender;
+import org.apache.linkis.server.Message;
+
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "/entrance/operation/label")
+public class EntranceLabelRestfulApi {
+
+    private static final Logger logger = LoggerFactory.getLogger(EntranceLabelRestfulApi.class);
+
+    @RequestMapping(path = "/update", method = RequestMethod.POST)
+    public Message updateRouteLabel(HttpServletRequest req, @RequestBody JsonNode jsonNode) {
+        String routeLabel = jsonNode.get("routeLabel").textValue();
+        Map<String, Object> labels = new HashMap<String, Object>();
+        logger.info("Prepare to update entrance label {}", routeLabel);
+        labels.put(LabelKeyConstant.ROUTE_KEY, routeLabel);
+        InsLabelRefreshRequest insLabelRefreshRequest = new InsLabelRefreshRequest();
+        insLabelRefreshRequest.setLabels(labels);
+        insLabelRefreshRequest.setServiceInstance(Sender.getThisServiceInstance());
+        InstanceLabelClient.getInstance().refreshLabelsToInstance(insLabelRefreshRequest);
+        logger.info("Finished to update entrance label {}", routeLabel);
+        return Message.ok();
+    }
+
+    @RequestMapping(path = "/markoffline", method = RequestMethod.GET)
+    public Message updateRouteLabel(HttpServletRequest req) {
+        Map<String, Object> labels = new HashMap<String, Object>();
+        logger.info("Prepare to modify the routelabel of entry to offline");
+        labels.put(LabelKeyConstant.ROUTE_KEY, "offline");
+        InsLabelRefreshRequest insLabelRefreshRequest = new InsLabelRefreshRequest();
+        insLabelRefreshRequest.setLabels(labels);
+        insLabelRefreshRequest.setServiceInstance(Sender.getThisServiceInstance());
+        InstanceLabelClient.getInstance().refreshLabelsToInstance(insLabelRefreshRequest);
+        logger.info("Finished to modify the routelabel of entry to offline");
+        return Message.ok();
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/org/apache/linkis/instance/label/client/EurekaInstanceLabelClient.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/org/apache/linkis/instance/label/client/EurekaInstanceLabelClient.scala
@@ -17,18 +17,18 @@
  
 package org.apache.linkis.instance.label.client
 
-import java.util
-
-import org.apache.linkis.common.utils.Logging
-import org.apache.linkis.protocol.label.{InsLabelAttachRequest, InsLabelRemoveRequest}
-import org.apache.linkis.rpc.Sender
-import javax.annotation.PostConstruct
 import org.apache.commons.lang3.StringUtils
+import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.manager.label.constant.LabelKeyConstant
+import org.apache.linkis.protocol.label.{InsLabelRefreshRequest, InsLabelRemoveRequest}
+import org.apache.linkis.rpc.Sender
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cloud.client.serviceregistry.Registration
 import org.springframework.context.event.{ContextClosedEvent, EventListener}
 import org.springframework.stereotype.Component
+
+import java.util
+import javax.annotation.PostConstruct
 
 
 @Component
@@ -48,10 +48,10 @@ class EurekaInstanceLabelClient extends Logging {
       info(s"Start to register label for instance $metadata")
       val labels = new util.HashMap[String, Object]()
       labels.put(LabelKeyConstant.ROUTE_KEY, metadata.get(LabelKeyConstant.ROUTE_KEY))
-      val insLabelAttachRequest = new InsLabelAttachRequest
-      insLabelAttachRequest.setLabels(metadata.asInstanceOf[java.util.Map[String, Object]])
-      insLabelAttachRequest.setServiceInstance(Sender.getThisServiceInstance)
-      InstanceLabelClient.getInstance.attachLabelsToInstance(insLabelAttachRequest)
+      val insLabelRefreshRequest = new InsLabelRefreshRequest
+      insLabelRefreshRequest.setLabels(metadata.asInstanceOf[java.util.Map[String, Object]])
+      insLabelRefreshRequest.setServiceInstance(Sender.getThisServiceInstance)
+      InstanceLabelClient.getInstance.attachLabelsToInstance(insLabelRefreshRequest)
     }
   }
 

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/org/apache/linkis/instance/label/client/EurekaInstanceLabelClient.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/org/apache/linkis/instance/label/client/EurekaInstanceLabelClient.scala
@@ -51,7 +51,7 @@ class EurekaInstanceLabelClient extends Logging {
       val insLabelRefreshRequest = new InsLabelRefreshRequest
       insLabelRefreshRequest.setLabels(metadata.asInstanceOf[java.util.Map[String, Object]])
       insLabelRefreshRequest.setServiceInstance(Sender.getThisServiceInstance)
-      InstanceLabelClient.getInstance.attachLabelsToInstance(insLabelRefreshRequest)
+      InstanceLabelClient.getInstance.refreshLabelsToInstance(insLabelRefreshRequest)
     }
   }
 

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/org/apache/linkis/instance/label/client/InstanceLabelClient.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/org/apache/linkis/instance/label/client/InstanceLabelClient.scala
@@ -23,7 +23,7 @@ import org.apache.linkis.common.utils.{Logging, Utils}
 import org.apache.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
 import org.apache.linkis.manager.label.entity.Label
 import org.apache.linkis.manager.label.utils.LabelUtils
-import org.apache.linkis.protocol.label.{InsLabelAttachRequest, InsLabelQueryRequest, InsLabelQueryResponse, InsLabelRemoveRequest, LabelInsQueryRequest, LabelInsQueryResponse}
+import org.apache.linkis.protocol.label.{InsLabelAttachRequest, InsLabelQueryRequest, InsLabelQueryResponse, InsLabelRefreshRequest, InsLabelRemoveRequest, LabelInsQueryRequest, LabelInsQueryResponse}
 import org.apache.linkis.rpc.Sender
 import org.apache.linkis.rpc.conf.RPCConfiguration.PUBLIC_SERVICE_APPLICATION_NAME
 import org.apache.linkis.server.BDPJettyServerHelper
@@ -36,12 +36,16 @@ class InstanceLabelClient extends Logging {
 
   val labelBuilderFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
 
-  def attachLabelsToInstance(insLabelAttachRequest: InsLabelAttachRequest): Unit = {
-    getSender().send(insLabelAttachRequest)
+  def refreshLabelsToInstance(insLabelRefreshRequest: InsLabelRefreshRequest): Unit = {
+    getSender().send(insLabelRefreshRequest)
   }
 
   def removeLabelsFromInstance(insLabelRemoveRequest: InsLabelRemoveRequest): Unit = {
     getSender().send(insLabelRemoveRequest)
+  }
+
+  def attachLabelsToInstance(insLabelAttachRequest: InsLabelAttachRequest): Unit = {
+    getSender().send(insLabelAttachRequest)
   }
 
   def getSender(): Sender = {


### PR DESCRIPTION
### What is the purpose of the change
#2320

### Brief change log
- Entrance adds restful interface to support modifying routelabel 

```
## mark offline label
- Get
http://127.0.0.0.1:9205/api/rest_j/v1/entrance/operation/label/markoffline

## update entrance route label
- Post
http://127.0.0.0.1:9205/api/rest_j/v1/entrance/operation/label/update
Params:
{
    "routeLabel": "test"
}
```