### PR TITLE
The python plt show method directly supports display 

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceMetricRestfulApi.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @RestController
-@RequestMapping(path = "/entrance/api/metrics")
+@RequestMapping(path = "/entrance/operation/metrics")
 public class EntranceMetricRestfulApi {
 
     private EntranceServer entranceServer;

--- a/linkis-engineconn-plugins/engineconn-plugins/python/src/main/resources/python/python.py
+++ b/linkis-engineconn-plugins/engineconn-plugins/python/src/main/resources/python/python.py
@@ -87,10 +87,22 @@ sys.stdout = linkisOutput
 sys.stderr = errorOutput
 intp = gateway.entry_point
 
-def show_matplotlib(p, fmt="png", width="auto", height="auto",
+def show_matplotlib(p=None,fmt="png", width="auto", height="auto",
                     **kwargs):
   """Matplotlib show function
   """
+
+  if p==None:
+    try:
+      import matplotlib
+      matplotlib.use('Agg')
+      import matplotlib.pyplot
+      p=matplotlib.pyplot
+    except Exception as e:
+      print("Failed to import matplotlib")
+      print(e)
+      return
+
   if fmt == "png":
     img = BytesIO()
     p.savefig(img, format=fmt)
@@ -177,6 +189,20 @@ class PythonContext(object):
       matplotlib.use('Agg')
     except ImportError:
       return
+
+def setup_plt_show():
+    """Override plt.show to show_matplotlib method
+    """
+    try:
+      import matplotlib
+      matplotlib.use('Agg')
+      import matplotlib.pyplot
+      matplotlib.pyplot.show=show_matplotlib
+    except Exception as e:
+      print(e)
+      return
+
+setup_plt_show()
 
 show = __show__ = PythonContext(intp)
 __show__._setup_matplotlib()


### PR DESCRIPTION
### What is the purpose of the change
close #2216

### Brief change log
- update python ec override plt.show to show_matplotlib method
- update pyspark override plt.show to show_matplotlib method

```
## The web supports directly displaying the html results of plt.show
import matplotlib
import matplotlib.pyplot as plt

plt.figure(1)
plt.figure(2)
ax1 = plt.subplot(211)
ax2 = plt.subplot(212)
ax1.set_title(U"test")
x = np.linspace(0, 3, 100)
for i in range(5):
    plt.figure(1)
    plt.plot(x, np.exp(i*x/3))
    plt.sca(ax1)
    plt.plot(x, np.sin(i*x))
    plt.sca(ax2)
    plt.plot(x, np.cos(i*x))
plt.show
```