### PR TITLE
Linkis tasks support automatic retry

### DIFF
--- a/db/linkis_dml.sql
+++ b/db/linkis_dml.sql
@@ -448,6 +448,7 @@ INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hos
 INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('VALIDATOR-AUTH','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
 INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('LINKISCLI-AUTH','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
 INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('DSM-AUTH','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
+INSERT INTO `linkis_mg_gateway_auth_token`(`token_name`,`legal_users`,`legal_hosts`,`business_owner`,`create_time`,`update_time`,`elapse_day`,`update_by`) VALUES ('LINKIS_CLI_TEST','*','*','BDP',curdate(),curdate(),-1,'LINKIS');
 
 INSERT INTO `linkis_ps_dm_datasource_type` (`name`, `description`, `option`, `classifier`, `icon`, `layers`) VALUES ('mysql', 'mysql数据库', 'mysql数据库', '关系型数据库', '', 3);
 INSERT INTO `linkis_ps_dm_datasource_type` (`name`, `description`, `option`, `classifier`, `icon`, `layers`) VALUES ('kafka', 'kafka', 'kafka', '消息队列', '', 2);

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/LinkisJobBuilder.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/LinkisJobBuilder.scala
@@ -161,7 +161,7 @@ object LinkisJobBuilder {
   private var ujesClient: UJESClient = _
   private var threadPool: ScheduledThreadPoolExecutor = Utils.defaultScheduler
   private var serverUrl: String = _
-  private var authTokenValue: String = "BML-AUTH" // This is the default authToken, we usually suggest set different ones for users.
+  private var authTokenValue: String = "LINKIS_CLI_TEST" // This is the default authToken, we usually suggest set different ones for users.
 
   def setDefaultClientConfig(clientConfig: DWSClientConfig): Unit = this.clientConfig = clientConfig
 

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/interactive/InteractiveJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/interactive/InteractiveJob.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.computation.client.interactive
 
 import org.apache.linkis.computation.client.{LinkisJobBuilder, ResultSetIterable}
@@ -23,6 +23,7 @@ import org.apache.linkis.ujes.client.UJESClient
 import org.apache.linkis.ujes.client.request.JobSubmitAction
 import org.apache.linkis.ujes.client.response.{JobInfoResult, JobLogResult, JobProgressResult}
 
+import java.util
 import scala.collection.mutable.ArrayBuffer
 
 
@@ -31,8 +32,8 @@ trait InteractiveJob extends StorableLinkisJob {
   private var resultSetList: Array[String] = _
   private val logListeners: ArrayBuffer[LogListener] = new ArrayBuffer[LogListener]()
   private val progressListeners: ArrayBuffer[ProgressListener] = new ArrayBuffer[ProgressListener]()
-  private var lastJobLogResult: JobLogResult = _
-  private var lastProgress: JobProgressResult = _
+  protected var lastJobLogResult: JobLogResult = _
+  protected var lastProgress: JobProgressResult = _
 
   def existResultSets: Boolean = wrapperId {
     resultSetList = getJobInfoResult.getResultSetList(ujesClient)
@@ -40,7 +41,7 @@ trait InteractiveJob extends StorableLinkisJob {
   }
 
   def getResultSetIterables: Array[ResultSetIterable] = {
-    if(!existResultSets) return Array.empty
+    if (!existResultSets) return Array.empty
     resultSetList.map(new ResultSetIterable(ujesClient, getJobSubmitResult.getUser, _, getJobMetrics))
   }
 
@@ -55,20 +56,78 @@ trait InteractiveJob extends StorableLinkisJob {
   }
 
   override protected def getJobInfoResult: JobInfoResult = {
-    lastJobLogResult = if(lastJobLogResult == null) ujesClient.log(getJobSubmitResult, 0, 1) else ujesClient.log(getJobSubmitResult, lastJobLogResult)
+    lastJobLogResult = if (lastJobLogResult == null) ujesClient.log(getJobSubmitResult, 0, 1) else ujesClient.log(getJobSubmitResult, lastJobLogResult)
     logListeners.foreach(_.onLogUpdate(lastJobLogResult.getLog))
     val progress = ujesClient.progress(getJobSubmitResult)
-    if(lastProgress == null || progress.getProgress > lastProgress.getProgress) {
+    if (lastProgress == null || progress.getProgress > lastProgress.getProgress) {
       lastProgress = progress
       progressListeners.foreach(_.onProgressUpdate(lastProgress.getProgress, lastProgress.getProgressInfo))
     }
     super.getJobInfoResult
   }
+
+  def getLogListeners: ArrayBuffer[LogListener] = logListeners
+
+  def getProgressListener: ArrayBuffer[ProgressListener] = progressListeners
+
+
 }
 
 class SubmittableInteractiveJob(ujesClient: UJESClient,
                                 jobSubmitAction: JobSubmitAction)
-  extends StorableSubmittableLinkisJob(ujesClient, jobSubmitAction) with InteractiveJob
+  extends StorableSubmittableLinkisJob(ujesClient, jobSubmitAction) with InteractiveJob {
+
+  private var maxRetry = 0
+  private var retryNumber = 0
+
+  private var finishedJobInfoResult: JobInfoResult = _
+
+
+  override protected def getJobInfoResult: JobInfoResult = {
+    lastJobLogResult = if (lastJobLogResult == null) ujesClient.log(getJobSubmitResult, 0, 1) else ujesClient.log(getJobSubmitResult, lastJobLogResult)
+    getLogListeners.foreach(_.onLogUpdate(lastJobLogResult.getLog))
+    val progress = ujesClient.progress(getJobSubmitResult)
+    if (lastProgress == null || progress.getProgress > lastProgress.getProgress) {
+      lastProgress = progress
+      getProgressListener.foreach(_.onProgressUpdate(lastProgress.getProgress, lastProgress.getProgressInfo))
+    }
+    if (finishedJobInfoResult != null) return finishedJobInfoResult
+    val startTime = System.currentTimeMillis
+    val oldJobSubmitResult = getJobSubmitResult
+    val jobInfoResult = wrapperId(ujesClient.getJobInfo(getJobSubmitResult))
+    getJobMetrics.addClientGetJobInfoTime(System.currentTimeMillis - startTime)
+    if (jobInfoResult.isCompleted) {
+      if (jobInfoResult.isFailed && jobInfoResult.canRetry && getRetryNumber < getMaxRetry) {
+        val retryMsg = s"Task ${oldJobSubmitResult.taskID} failed to run, retrying automatically, retry number: ${getRetryNumber}"
+        logger.info(retryMsg)
+        this.submit()
+        addRetryNumber
+        val logs = new util.ArrayList[String]()
+        val retrySucceedMsg = s"The task has been retried, and the new task id is: ${getJobSubmitResult.taskID}"
+        logs.add(retryMsg)
+        logs.add(retrySucceedMsg)
+        getLogListeners.foreach(_.onLogUpdate(logs))
+        logger.info(retrySucceedMsg)
+        return getJobInfoResult
+      }
+      getJobMetrics.setClientFinishedTime(System.currentTimeMillis)
+      finishedJobInfoResult = jobInfoResult
+      info(s"Job-$getId is completed with status " + finishedJobInfoResult.getJobStatus)
+      getJobListeners.foreach(_.onJobFinished(this))
+    } else if (jobInfoResult.isRunning) getJobListeners.foreach(_.onJobRunning(this))
+    jobInfoResult
+  }
+
+
+  def getMaxRetry: Int = maxRetry
+
+  def setMaxRetry(maxRetry: Int): Unit = this.maxRetry = maxRetry
+
+  def addRetryNumber: Unit = retryNumber = retryNumber + 1
+
+  def getRetryNumber: Int = retryNumber
+
+}
 
 class ExistingInteractiveJob(ujesClient: UJESClient,
                              execId: String,
@@ -80,19 +139,21 @@ object InteractiveJob {
   def builder(): InteractiveJobBuilder = new InteractiveJobBuilder
 
   /**
-    * When use this method to create a InteractiveJob, ProgressListener and LogListener cannot be used, because execID is not exists.
-    * @param taskId the id of InteractiveJob
-    * @param user the execute user of InteractiveJob
-    * @return
-    */
+   * When use this method to create a InteractiveJob, ProgressListener and LogListener cannot be used, because execID is not exists.
+   *
+   * @param taskId the id of InteractiveJob
+   * @param user   the execute user of InteractiveJob
+   * @return
+   */
   def build(taskId: String, user: String): InteractiveJob = new ExistingInteractiveJob(LinkisJobBuilder.getDefaultUJESClient, null, taskId, user)
 
   /**
-    * Use this method to create a InteractiveJob, it is equivalent with [[builder]].
-    * @param execId the execId of InteractiveJob
-    * @param taskId the taskId of InteractiveJob
-    * @param user the execute user of InteractiveJob
-    * @return
-    */
+   * Use this method to create a InteractiveJob, it is equivalent with [[builder]].
+   *
+   * @param execId the execId of InteractiveJob
+   * @param taskId the taskId of InteractiveJob
+   * @param user   the execute user of InteractiveJob
+   * @return
+   */
   def build(execId: String, taskId: String, user: String): InteractiveJob = new ExistingInteractiveJob(LinkisJobBuilder.getDefaultUJESClient, null, taskId, user)
 }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/interactive/InteractiveJobBuilder.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/interactive/InteractiveJobBuilder.scala
@@ -30,6 +30,8 @@ class InteractiveJobBuilder private[interactive]()
 
   private var creator: String = _
 
+  private var maxRetry = 0
+
   override def addExecuteUser(executeUser: String): this.type = super.addExecuteUser(executeUser)
 
   def setEngineType(engineType: String): this.type = addLabel(LabelKeyUtils.ENGINE_TYPE_LABEL_KEY, engineType)
@@ -45,6 +47,11 @@ class InteractiveJobBuilder private[interactive]()
 
   def setRunTypeStr(runType: String): this.type = addJobContent("runType", runType)
 
+  def setMaxRetry(maxRetry: Int): this.type = {
+    this.maxRetry = maxRetry
+    this
+  }
+
   override protected def validate(): Unit = {
     if (labels != null && !labels.containsKey(LabelKeyUtils.USER_CREATOR_LABEL_KEY)
       && StringUtils.isNotBlank(creator)) {
@@ -54,6 +61,10 @@ class InteractiveJobBuilder private[interactive]()
   }
 
   override protected def createLinkisJob(ujesClient: UJESClient,
-                                         jobSubmitAction: JobSubmitAction): SubmittableInteractiveJob = new SubmittableInteractiveJob(ujesClient, jobSubmitAction)
+                                         jobSubmitAction: JobSubmitAction): SubmittableInteractiveJob = {
+    val job = new SubmittableInteractiveJob(ujesClient, jobSubmitAction)
+    job.setMaxRetry(this.maxRetry)
+    job
+  }
 
 }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/job/AbstractLinkisJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/job/AbstractLinkisJob.scala
@@ -51,12 +51,12 @@ trait AbstractLinkisJob extends LinkisJob with Logging {
     initJobDaemon()
   }
 
-  protected def initJobDaemon(): Unit = if(future == null) jobListeners synchronized {
-    if(future == null) future = LinkisJobBuilder.getThreadPoolExecutor.scheduleAtFixedRate(new Runnable {
+  protected def initJobDaemon(): Unit = if (future == null) jobListeners synchronized {
+    if (future == null) future = LinkisJobBuilder.getThreadPoolExecutor.scheduleAtFixedRate(new Runnable {
       private var failedNum = 0
       override def run(): Unit = {
         var exception: Throwable = null
-        val isJobCompleted = Utils.tryCatch(isCompleted){t =>
+        val isJobCompleted = Utils.tryCatch(isCompleted) {t =>
           exception = t
           failedNum += 1
           if(failedNum >= maxFailedNum) {
@@ -98,8 +98,8 @@ trait AbstractLinkisJob extends LinkisJob with Logging {
   @throws(classOf[TimeoutException])
   @throws(classOf[InterruptedException])
   override def waitFor(mills: Long): Unit = {
-    val duration = if(mills > 0) Duration(mills, TimeUnit.MILLISECONDS) else Duration.Inf
-    Utils.waitUntil(() => killed || isCompleted,  duration, 500, 5000)
+    val duration = if (mills > 0) Duration(mills, TimeUnit.MILLISECONDS) else Duration.Inf
+    Utils.waitUntil(() => killed || isCompleted, duration, 500, 5000)
     if(killed) throw new UJESJobException(s"$getId is killed!")
   }
 

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/job/StorableLinkisJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/job/StorableLinkisJob.scala
@@ -40,7 +40,7 @@ trait StorableLinkisJob extends AbstractLinkisJob {
   }
 
   protected def getJobInfoResult: JobInfoResult = {
-    if(completedJobInfoResult != null) return completedJobInfoResult
+    if (completedJobInfoResult != null) return completedJobInfoResult
     val startTime = System.currentTimeMillis
     val jobInfoResult = wrapperId(ujesClient.getJobInfo(getJobSubmitResult))
     getJobMetrics.addClientGetJobInfoTime(System.currentTimeMillis - startTime)
@@ -49,8 +49,7 @@ trait StorableLinkisJob extends AbstractLinkisJob {
       info(s"Job-$getId is completed with status " + completedJobInfoResult.getJobStatus)
       completedJobInfoResult = jobInfoResult
       getJobListeners.foreach(_.onJobFinished(this))
-    } else if(jobInfoResult.isRunning)
-      getJobListeners.foreach(_.onJobRunning(this))
+    } else if (jobInfoResult.isRunning) getJobListeners.foreach(_.onJobRunning(this))
     jobInfoResult
   }
 
@@ -76,6 +75,10 @@ abstract class StorableSubmittableLinkisJob(override protected val ujesClient: U
 
   private var taskId: String = _
   private var jobSubmitResult: JobSubmitResult = _
+  private var maxRetry = 0
+  private var retryNumber = 0
+
+  private var finishedJobInfoResult: JobInfoResult = _
 
   override def getId: String = taskId
 
@@ -93,6 +96,36 @@ abstract class StorableSubmittableLinkisJob(override protected val ujesClient: U
     }
     info("Job submitted with taskId: " + taskId)
   }
+
+  override protected def getJobInfoResult: JobInfoResult = {
+    if (finishedJobInfoResult != null) return finishedJobInfoResult
+    val startTime = System.currentTimeMillis
+    val oldJobSubmitResult = getJobSubmitResult
+    val jobInfoResult = wrapperId(ujesClient.getJobInfo(getJobSubmitResult))
+    getJobMetrics.addClientGetJobInfoTime(System.currentTimeMillis - startTime)
+    if(jobInfoResult.isCompleted) {
+      if (jobInfoResult.isFailed && jobInfoResult.canRetry && getRetryNumber < getMaxRetry) {
+        logger.info(s"Task ${oldJobSubmitResult.taskID} failed to run, retrying automatically, retry number: ${getRetryNumber}")
+        this.submit()
+        addRetryNumber
+        logger.info(s"The task has been retried, and the new task id is: ${getJobSubmitResult.taskID}")
+        return  getJobInfoResult
+      }
+      getJobMetrics.setClientFinishedTime(System.currentTimeMillis)
+      finishedJobInfoResult = jobInfoResult
+      info(s"Job-$getId is completed with status " + finishedJobInfoResult.getJobStatus)
+      getJobListeners.foreach(_.onJobFinished(this))
+    } else if (jobInfoResult.isRunning) getJobListeners.foreach(_.onJobRunning(this))
+    jobInfoResult
+  }
+
+  def getMaxRetry: Int = maxRetry
+
+  def setMaxRetry(maxRetry: Int): Unit = this.maxRetry = maxRetry
+
+  def addRetryNumber: Unit = retryNumber = retryNumber + 1
+
+  def getRetryNumber: Int = retryNumber
 
 }
 

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/JobInfoResult.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/ujes/client/response/JobInfoResult.scala
@@ -19,7 +19,6 @@ package org.apache.linkis.ujes.client.response
 
 import java.util
 import java.util.Date
-
 import org.apache.linkis.common.utils.Utils
 import org.apache.linkis.governance.common.entity.task.RequestPersistTask
 import org.apache.linkis.httpclient.dws.annotation.DWSHttpMessageResult
@@ -71,16 +70,25 @@ class JobInfoResult extends DWSResult with UserAction with Status {
   }
 
   def getResultSetList(ujesClient: UJESClient): Array[String] = {
-    if(isSucceed && resultSetList == null) synchronized {
-      if(resultSetList != null) return resultSetList
+    if (isSucceed && resultSetList == null) synchronized {
+      if (resultSetList != null) return resultSetList
       resultSetList = ujesClient.executeUJESJob(ResultSetListAction.builder().set(this).build()) match {
         case resultSetList: ResultSetListResult => resultSetList.getResultSetList
       }
       resultSetList
-    } else if(resultSetList != null) resultSetList
-    else if(isFailed) throw new UJESJobException(requestPersistTask.getErrCode, requestPersistTask.getErrDesc)
+    } else if (resultSetList != null) resultSetList
+    else if (isFailed) throw new UJESJobException(requestPersistTask.getErrCode, requestPersistTask.getErrDesc)
     else throw new UJESJobException(s"job ${requestPersistTask.getTaskID} is still executing with state ${requestPersistTask.getStatus}.")
   }
 
   override def getJobStatus: String = requestPersistTask.getStatus
+
+  def canRetry: Boolean = {
+    val canRetryFlag = "canRetry"
+    if (null != task && task.containsKey(canRetryFlag)) {
+      task.get(canRetryFlag).asInstanceOf[Boolean]
+    } else {
+      false
+    }
+  }
 }

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/InteractiveJobTest.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/InteractiveJobTest.java
@@ -36,6 +36,7 @@ public class InteractiveJobTest {
                         .addExecuteUser("hadoop")
                         .setMaxRetry(2) // automatic retry number
                         .build();
+        job.addLogListener(new TestLogListener());
         // 3. Submit Job to Linkis
         job.submit();
         // 4. Wait for Job completed

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/InteractiveJobTest.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/InteractiveJobTest.java
@@ -24,12 +24,12 @@ public class InteractiveJobTest {
 
     public static void main(String[] args) {
         // TODO First, set the right gateway url.
-        LinkisJobClient.config().setDefaultServerUrl("http://127.0.0.1:9002");
+        LinkisJobClient.config().setDefaultServerUrl("http://127.0.0.1:9001");
         // TODO Secondly, please modify the executeUser
         SubmittableInteractiveJob job =
                 LinkisJobClient.interactive()
                         .builder()
-                        .setEngineType("hive")
+                        .setEngineType("hive-2.3.3")
                         .setRunTypeStr("sql")
                         .setCreator("IDE")
                         .setCode("show tables")

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/InteractiveJobTest.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/InteractiveJobTest.java
@@ -34,6 +34,7 @@ public class InteractiveJobTest {
                         .setCreator("IDE")
                         .setCode("show tables")
                         .addExecuteUser("hadoop")
+                        .setMaxRetry(2) // automatic retry number
                         .build();
         // 3. Submit Job to Linkis
         job.submit();

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/TestLogListener.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/TestLogListener.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.linkis.computation.client;
 
 import org.apache.linkis.computation.client.interactive.LogListener;

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/TestLogListener.java
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/test/java/org/apache/linkis/computation/client/TestLogListener.java
@@ -1,0 +1,18 @@
+package org.apache.linkis.computation.client;
+
+import org.apache.linkis.computation.client.interactive.LogListener;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+
+public class TestLogListener implements LogListener {
+
+    @Override
+    public void onLogUpdate(List<String> logs) {
+        String log = logs.get(3);
+        if (StringUtils.isNoneBlank(log)) {
+            System.out.println(log);
+        }
+    }
+}

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
@@ -29,6 +29,7 @@ import org.apache.linkis.scheduler.queue.{Job, SchedulerEventState}
 import org.apache.linkis.server.conf.ServerConfiguration
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.commons.lang3.StringUtils
+import org.apache.linkis.entrance.cs.CSEntranceHelper
 import org.apache.linkis.entrance.utils.JobHistoryHelper
 import org.apache.linkis.protocol.constants.TaskConstant
 
@@ -59,7 +60,7 @@ abstract class EntranceServer extends Logging {
     var jobRequest = getEntranceContext.getOrCreateEntranceParser().parseToTask(params)
     // tod multi entrance instances
     jobRequest.setInstances(Sender.getThisInstance)
-
+    Utils.tryAndWarn(CSEntranceHelper.resetCreator(jobRequest))
     //After parse the map into a jobRequest, we need to store it in the database, and the jobRequest can get a unique taskID.
     //将map parse 成 jobRequest 之后，我们需要将它存储到数据库中，task可以获得唯一的taskID
     getEntranceContext.getOrCreatePersistenceManager().createPersistenceEngine().persist(jobRequest)

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
@@ -29,6 +29,10 @@ import org.apache.linkis.scheduler.queue.{Job, SchedulerEventState}
 import org.apache.linkis.server.conf.ServerConfiguration
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.commons.lang3.StringUtils
+import org.apache.linkis.entrance.utils.JobHistoryHelper
+import org.apache.linkis.protocol.constants.TaskConstant
+
+import java.util
 
 
 abstract class EntranceServer extends Logging {
@@ -79,6 +83,10 @@ abstract class EntranceServer extends Logging {
           t.setErrorDesc(error.getDesc)
           t.setStatus(SchedulerEventState.Failed.toString)
           t.setProgress(EntranceJob.JOB_COMPLETED_PROGRESS.toString)
+          val infoMap = new  util.HashMap[String, Object]
+          infoMap.put(TaskConstant.ENGINE_INSTANCE, "NULL")
+          infoMap.put("message", "Task interception failed and cannot be retried")
+          JobHistoryHelper.updateJobRequestMetrics(jobRequest, null, infoMap)
         case _ =>
       }
       getEntranceContext.getOrCreatePersistenceManager().createPersistenceEngine().updateIfNeeded(jobRequest)

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/conf/EntranceConfiguration.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/conf/EntranceConfiguration.scala
@@ -124,7 +124,7 @@ object EntranceConfiguration {
 
   val FLOW_EXECUTION_CREATOR = CommonVars("wds.linkis.entrance.flow.creator", "nodeexecution")
 
-  val SCHEDULER_CREATOR = CommonVars("wds.linkis.entrance.scheduler.creator", "scheduler")
+  val SCHEDULER_CREATOR = CommonVars("wds.linkis.entrance.scheduler.creator", "Schedulis")
 
 
   val SKIP_AUTH = CommonVars("wds.linkis.entrance.skip.auth", false)

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-common/src/main/java/org/apache/linkis/cs/common/utils/CSCommonUtils.java
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-common/src/main/java/org/apache/linkis/cs/common/utils/CSCommonUtils.java
@@ -42,7 +42,7 @@ public class CSCommonUtils {
             CommonVars.apply("wds.linkis.dev.contextID.env", "BDP_DEV").getValue();
 
     public static final String CONTEXT_ENV_PROD =
-            CommonVars.apply("wds.linkis.production.contextID.env", "BDP_PRODUCTION").getValue();
+            CommonVars.apply("wds.linkis.production.contextID.env", "BDAP_PROD").getValue();
 
     public static final String CS_TMP_TABLE_PREFIX = "cs_tmp_";
 

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/entity/QueryTaskVO.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/entity/QueryTaskVO.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 
 public class QueryTaskVO {
+
     private Long taskID;
     private String instance;
     private String execId;
@@ -51,6 +52,8 @@ public class QueryTaskVO {
     private Date engineStartTime;
 
     private List<String> labels;
+
+    private boolean canRetry;
 
     public List<SubJobDetail> getSubJobs() {
         return subJobs;
@@ -260,5 +263,13 @@ public class QueryTaskVO {
 
     public void setLabels(List<String> labels) {
         this.labels = labels;
+    }
+
+    public boolean isCanRetry() {
+        return canRetry;
+    }
+
+    public void setCanRetry(boolean canRetry) {
+        this.canRetry = canRetry;
     }
 }

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/conversions/TaskConversions.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/conversions/TaskConversions.scala
@@ -282,7 +282,7 @@ object TaskConversions extends Logging {
         } else {
           taskVO.setCostTime(System.currentTimeMillis() - createTime.getTime)
         }
-      } else{
+      } else {
         taskVO.setCostTime(System.currentTimeMillis() - createTime.getTime)
       }
     }
@@ -290,6 +290,7 @@ object TaskConversions extends Logging {
       val engineMap = metrics.get(TaskConstant.ENTRANCEJOB_ENGINECONN_MAP).asInstanceOf[util.Map[String, Object]]
       if (null != engineMap && !engineMap.isEmpty) {
         taskVO.setEngineInstance(engineMap.map(_._1).toList.mkString(","))
+        taskVO.setCanRetry(true)
       }
     } else {
       taskVO.setEngineInstance("EngineInstance not ready in metrics.")

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/conversions/TaskConversions.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/conversions/TaskConversions.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.jobhistory.conversions
 
 import org.apache.linkis.common.utils.{Logging, Utils}
@@ -290,10 +290,9 @@ object TaskConversions extends Logging {
       val engineMap = metrics.get(TaskConstant.ENTRANCEJOB_ENGINECONN_MAP).asInstanceOf[util.Map[String, Object]]
       if (null != engineMap && !engineMap.isEmpty) {
         taskVO.setEngineInstance(engineMap.map(_._1).toList.mkString(","))
-        taskVO.setCanRetry(true)
       }
-    } else {
-      taskVO.setEngineInstance("EngineInstance not ready in metrics.")
+    } else if (TaskStatus.Failed.toString.equals(job.getStatus)) {
+      taskVO.setCanRetry(true)
     }
 
     val entranceName = JobhistoryConfiguration.ENTRANCE_SPRING_NAME.getValue
@@ -304,7 +303,7 @@ object TaskConversions extends Logging {
       taskVO.setExecutionCode(job.getExecutionCode)
     }
     // Do not attach subjobs for performance
-//    taskVO.setSubJobs(subjobs)
+    //    taskVO.setSubJobs(subjobs)
     taskVO.setSourceJson(job.getSource)
     if (StringUtils.isNotBlank(job.getSource)) {
       Utils.tryCatch {
@@ -326,13 +325,14 @@ object TaskConversions extends Logging {
     labels
   }
 
-  def dealString2Date(strDate : String) : Date = {
+  def dealString2Date(strDate: String): Date = {
     val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
-    Utils.tryCatch{
+    Utils.tryCatch {
       val date = df.parse(strDate)
       date
     } {
-      _ => warn("String to Date deserialization failed.")
+      _ =>
+        warn("String to Date deserialization failed.")
         null
     }
   }


### PR DESCRIPTION
### What is the purpose of the change
close #2218
close #2219 

### Brief change log
- Linkis task support returns whether the label can be retried.
- Linkis Java SDK supports automatic task retry.

```
# sdk usage
SubmittableInteractiveJob job =
                LinkisJobClient.interactive()
                        .builder()
                        .setEngineType("hive")
                        .setRunTypeStr("sql")
                        .setCreator("IDE")
                        .setCode("show tables")
                        .addExecuteUser("hadoop")
                        .setMaxRetry(2) // automatic retry number
                        .build();
```