### PR TITLE
Dev 1.2.0 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Linkis
 ==========
 
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![codecov](https://codecov.io/gh/apache/incubator-linkis/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-linkis/branch/master)
 
 [English](README.md) | [中文](README_CN.md)
 
@@ -70,6 +71,23 @@ Since the first release of Linkis in 2019, it has accumulated more than **700** 
 Please go to the [Linkis Releases Page](https://github.com/apache/incubator-linkis/releases) to download a compiled distribution or a source code package of Linkis.
 
 # Compile and deploy
+
+```shell
+
+## compile backend
+### Mac OS/Linux
+./mvnw -N install
+./mvnw  clean install -Dmaven.javadoc.skip=true -Dmaven.test.skip=true
+
+### Windows
+mvnw.cmd -N install
+mvnw.cmd clean install -Dmaven.javadoc.skip=true -Dmaven.test.skip=true
+
+## compile web
+cd incubator-linkis/web
+npm install
+npm run build
+```
 Please follow [Compile Guide](https://linkis.apache.org/docs/latest/development/linkis_compile_and_package) to compile Linkis from source code.  
 Please refer to [Deployment Documents](https://linkis.apache.org/docs/latest/deployment/quick_deploy) to do the deployment.
 
@@ -102,9 +120,9 @@ For code and documentation contributions, please follow the [contribution guide]
 # Contact Us
 
 Any questions or suggestions please kindly submit an issue.  
-You can scan the QR code below to join our WeChat and QQ group to get more immediate response.
+You can scan the QR code below to join our WeChat group to get more immediate response.
 
-![introduction05](https://user-images.githubusercontent.com/7869972/148767386-0663f833-547d-4c30-8876-081bb966ffb8.png)
+![WeChat](https://user-images.githubusercontent.com/11496700/173569063-8615c259-59ef-477a-9cee-825d28b54e7b.png)
 
 Meetup videos on [Bilibili](https://space.bilibili.com/598542776?from=search&seid=14344213924133040656).
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,6 +2,7 @@ Linkis
 ============
 
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![codecov](https://codecov.io/gh/apache/incubator-linkis/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-linkis/branch/master)
 
 [English](README.md) | [中文](README_CN.md)
 
@@ -63,6 +64,22 @@ Linkis 自2019年开源发布以来，已累计积累了700多家试验企业和
 请前往[Linkis releases 页面](https://github.com/apache/incubator-linkis/releases) 下载Linkis 的已编译版本或源码包。
 
 # 编译和安装部署
+```shell
+
+## 后端编译
+### Mac OS/Linux
+./mvnw -N install
+./mvnw  clean install -Dmaven.javadoc.skip=true -Dmaven.test.skip=true
+
+### Windows
+mvnw.cmd -N install
+mvnw.cmd clean install -Dmaven.javadoc.skip=true -Dmaven.test.skip=true
+
+## 前端编译
+cd incubator-linkis/web
+npm install
+npm run build
+```
 请参照[编译指引](https://linkis.apache.org/zh-CN/docs/latest/development/linkis_compile_and_package) 来编译Linkis 源码。  
 请参考[安装部署文档](https://linkis.apache.org/zh-CN/docs/latest/deployment/quick_deploy) 来部署Linkis。
 
@@ -108,8 +125,8 @@ Linkis 基于微服务架构开发，其服务可以分为3类:计算治理服�
 # 联系我们
 
 对Linkis 的任何问题和建议，敬请提交issue，以便跟踪处理和经验沉淀共享。  
-您也可以扫描下面的二维码，加入我们的微信/QQ群，以获得更快速的响应。
-![introduction05](https://user-images.githubusercontent.com/7869972/148767386-0663f833-547d-4c30-8876-081bb966ffb8.png)
+您也可以扫描下面的二维码，加入我们的微信群，以获得更快速的响应。
+![WeChat](https://user-images.githubusercontent.com/11496700/173569063-8615c259-59ef-477a-9cee-825d28b54e7b.png)
 
 Meetup 视频 [Bilibili](https://space.bilibili.com/598542776?from=search&seid=14344213924133040656).
 

--- a/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-core/src/test/java/org/apache/linkis/cli/core/exception/handler/CommandExceptionHandlerTest.java
+++ b/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-core/src/test/java/org/apache/linkis/cli/core/exception/handler/CommandExceptionHandlerTest.java
@@ -23,6 +23,7 @@ import org.apache.linkis.cli.core.exception.CommandException;
 import org.apache.linkis.cli.core.exception.error.CommonErrMsg;
 import org.apache.linkis.cli.core.interactor.command.TestCmdType;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -30,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 public class CommandExceptionHandlerTest {
     ExceptionHandler handler = new CommandExceptionHandler();
 
+    // todo
+    @Disabled
     @Test
     public void handle() throws Exception {
         CommandException cmdException =

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/conf/HiveEngineConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/conf/HiveEngineConfiguration.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.engineplugin.hive.conf
 
 import org.apache.linkis.common.conf.CommonVars
@@ -22,7 +22,9 @@ import org.apache.linkis.common.conf.CommonVars
 object HiveEngineConfiguration {
 
   val HIVE_LIB_HOME = CommonVars[String]("hive.lib", CommonVars[String]("HIVE_LIB", "/appcom/Install/hive/lib").getValue)
-  val ENABLE_FETCH_BASE64 = CommonVars[Boolean]("wds.linkis.hive.enable.fetch.base64",false).getValue
-  val BASE64_SERDE_CLASS =  CommonVars[String]("wds.linkis.hive.base64.serde.class","org.apache.linkis.engineplugin.hive.serde.CustomerDelimitedJSONSerDe").getValue
+  val ENABLE_FETCH_BASE64 = CommonVars[Boolean]("wds.linkis.hive.enable.fetch.base64", false).getValue
+  val BASE64_SERDE_CLASS = CommonVars[String]("wds.linkis.hive.base64.serde.class", "org.apache.linkis.engineplugin.hive.serde.CustomerDelimitedJSONSerDe").getValue
   val HIVE_AUX_JARS_PATH = CommonVars[String]("hive.aux.jars.path", CommonVars[String]("HIVE_AUX_JARS_PATH", "").getValue).getValue
+  //根据HIVE_ENGINE_TYPE中选择引擎的不同，控制scripts中cancel任务时调用的逻辑，目前枚举值为mr,tez
+  val HIVE_ENGINE_TYPE = CommonVars[String]("wds.linkis.hive.engine.type", "mr").getValue
 }

--- a/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/test/resources/application.properties
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-configuration/src/test/resources/application.properties
@@ -51,6 +51,12 @@ spring.main.web-application-type=servlet
 server.port=1234
 spring.h2.console.enabled=true
 
+
+#disable eureka discovery client
+spring.cloud.service-registry.auto-registration.enabled=false
+eureka.client.enabled=false
+eureka.client.serviceUrl.registerWithEureka=false
+
 mybatis-plus.mapper-locations=classpath:org/apache/linkis/configuration/dao/impl/*.xml
 mybatis-plus.type-aliases-package=org.apache.linkis.configuration.entity
 mybatis-plus.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl

--- a/linkis-public-enhancements/linkis-publicservice/linkis-variable/src/test/resources/application.properties
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-variable/src/test/resources/application.properties
@@ -51,6 +51,11 @@ spring.main.web-application-type=servlet
 server.port=1234
 spring.h2.console.enabled=true
 
+#disable eureka discovery client
+spring.cloud.service-registry.auto-registration.enabled=false
+eureka.client.enabled=false
+eureka.client.serviceUrl.registerWithEureka=false
+
 mybatis-plus.mapper-locations=classpath:org/apache/linkis/variable/dao/impl/*.xml
 mybatis-plus.type-aliases-package=org.apache.linkis.configuration.entity
 mybatis-plus.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl


### PR DESCRIPTION
fix(linkis-engineplugin-hive): support cancel hive on tez task and engineconn is no longer busy

1.HiveEngineConfiguration中增加wds.linkis.hive.engine.type配置来控制cancel时的操作,目前支持mr和tez
2.HiveEngineConnExecutor中killtask时对于hive on tez进行了close driver的操作，确保engineconn不会卡在busy状态
1. Add wds.linkis.hive.engine.type configuration to HiveEngineConfiguration to control the cancel operation, currently supports mr and tez
2. When killing task in HiveEngineConnExecutor, close driver is performed on hive on tez to ensure that engineconn will not be stuck in busy state

Closes #2321