### PR TITLE
feat: make sure the ldap url end with '/', avoid problems due to conf…

### DIFF
--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/LDAPUtils.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/LDAPUtils.scala
@@ -14,23 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.common.utils
 
-import java.util.Hashtable
-
+import org.apache.commons.lang3.StringUtils
 import org.apache.linkis.common.conf.CommonVars
+
+import java.util.Hashtable
 import javax.naming.Context
 import javax.naming.ldap.InitialLdapContext
-import org.apache.commons.lang.StringUtils
-
-
 
 object LDAPUtils extends Logging {
 
-  val url =  CommonVars("wds.linkis.ldap.proxy.url", "").getValue
+  // make sure the url end with '/', otherwise may get error providerUrl
+  var url: String = CommonVars("wds.linkis.ldap.proxy.url", "").getValue
+  if (!url.endsWith("/")) {
+    url = url + "/"
+  }
+
   val baseDN = CommonVars("wds.linkis.ldap.proxy.baseDN", "").getValue
   val userNameFormat = CommonVars("wds.linkis.ldap.proxy.userNameFormat", "").getValue
+
   def login(userID: String, password: String): Unit = {
     val env = new Hashtable[String, String]()
     val bindDN = if (StringUtils.isBlank(userNameFormat)) userID else {
@@ -42,14 +46,10 @@ object LDAPUtils extends Logging {
     env.put(Context.PROVIDER_URL, url + baseDN)
     env.put(Context.SECURITY_PRINCIPAL, bindDN)
     env.put(Context.SECURITY_CREDENTIALS, bindPassword)
-    //    Utils.tryCatch {
+
     new InitialLdapContext(env, null)
-    info(s"user $userID login success.")
-    //      true
-    //    } { e =>
-    //        error(s"user $userID login failed.", e)
-    //        false
-    //    }
+    logger.info(s"user $userID login success.")
+
   }
 }
 


### PR DESCRIPTION
…iguration

### What is the purpose of the change
when config the ladp url property, it may be miss the end slash
so and the judge for the slash to avoid the problem

### Brief change log
- add url endsWidth '/' 

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)