### PR TITLE
FIX [Bug-1911] Linkis-computation-client failed to submit jobs

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/job/StorableLinkisJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/job/StorableLinkisJob.scala
@@ -35,7 +35,7 @@ trait StorableLinkisJob extends AbstractLinkisJob {
 
   protected def getJobSubmitResult: JobSubmitResult
 
-  override protected def wrapperObj[T](obj: Object, errorMsg: String)(op: => T): T = wrapperId {
+  override protected def wrapperObj[T](obj: Object, errorMsg: String)(op: => T): T = {
     super.wrapperObj(obj, errorMsg)(op)
   }
 
@@ -46,8 +46,8 @@ trait StorableLinkisJob extends AbstractLinkisJob {
     getJobMetrics.addClientGetJobInfoTime(System.currentTimeMillis - startTime)
     if(jobInfoResult.isCompleted) {
       getJobMetrics.setClientFinishedTime(System.currentTimeMillis)
-      info(s"Job-$getId is completed with status " + completedJobInfoResult.getJobStatus)
       completedJobInfoResult = jobInfoResult
+      info(s"Job-$getId is completed with status " + completedJobInfoResult.getJobStatus)
       getJobListeners.foreach(_.onJobFinished(this))
     } else if(jobInfoResult.isRunning)
       getJobListeners.foreach(_.onJobRunning(this))


### PR DESCRIPTION
FIX [Bug-1911] Linkis-computation-client failed to submit jobs

Brief change log
Modify the wrapperObj method;
Modify the getJobInfoResult method.
Related issues: #1911 . 