### PR TITLE
Dev 1.2.0 issue 2321

### DIFF
--- a/linkis-commons/linkis-protocol/src/main/java/org/apache/linkis/protocol/label/InsLabelRefreshRequest.java
+++ b/linkis-commons/linkis-protocol/src/main/java/org/apache/linkis/protocol/label/InsLabelRefreshRequest.java
@@ -22,7 +22,7 @@ import org.apache.linkis.common.ServiceInstance;
 import java.util.HashMap;
 import java.util.Map;
 
-public class InsLabelRefreshRequest {
+public class InsLabelRefreshRequest implements LabelRequest {
 
     /** Service instance */
     private ServiceInstance serviceInstance;

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/resources/linkis-engineconn.properties
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/resources/linkis-engineconn.properties
@@ -23,5 +23,5 @@ wds.linkis.engine.connector.hooks=org.apache.linkis.engineconn.computation.execu
 
 wds.linkis.engineconn.maintain.enable=true
 
-#根据HIVE_ENGINE_TYPE中选择引擎的不同，控制scripts中cancel任务时调用的逻辑，目前枚举值为mr,tez
+#Depending on the engine selected in HIVE_ENGINE_TYPE, control the function called when canceling the task in scripts.
 wds.linkis.hive.engine.type=mr

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/resources/linkis-engineconn.properties
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/resources/linkis-engineconn.properties
@@ -22,3 +22,6 @@ wds.linkis.bdp.hive.init.sql.enable=true
 wds.linkis.engine.connector.hooks=org.apache.linkis.engineconn.computation.executor.hook.ComputationEngineConnHook,org.apache.linkis.engineplugin.hive.hook.HiveAddJarsEngineHook,org.apache.linkis.engineconn.computation.executor.hook.JarUdfEngineHook,org.apache.linkis.engineconn.computation.executor.hook.HiveUseDatabaseEngineHook,org.apache.linkis.engineconn.computation.executor.hook.HiveInitSQLHook
 
 wds.linkis.engineconn.maintain.enable=true
+
+#根据HIVE_ENGINE_TYPE中选择引擎的不同，控制scripts中cancel任务时调用的逻辑，目前枚举值为mr,tez
+wds.linkis.hive.engine.type=mr

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/conf/HiveEngineConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/conf/HiveEngineConfiguration.scala
@@ -25,4 +25,5 @@ object HiveEngineConfiguration {
   val ENABLE_FETCH_BASE64 = CommonVars[Boolean]("wds.linkis.hive.enable.fetch.base64",false).getValue
   val BASE64_SERDE_CLASS =  CommonVars[String]("wds.linkis.hive.base64.serde.class","org.apache.linkis.engineplugin.hive.serde.CustomerDelimitedJSONSerDe").getValue
   val HIVE_AUX_JARS_PATH = CommonVars[String]("hive.aux.jars.path", CommonVars[String]("HIVE_AUX_JARS_PATH", "").getValue).getValue
+  val HIVE_ENGINE_TYPE = CommonVars[String]("wds.linkis.hive.engine.type", "mr").getValue
 }

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
@@ -447,7 +447,7 @@ class HiveEngineConnExecutor(id: Int,
 
   override def killTask(taskID: String): Unit = {
     LOG.info(s"hive begins to kill job with id : ${taskID}")
-    //通过wds.linkis.hive.engine.type参数配置引擎来控制kill任务时的方式
+    //Configure the engine through the wds.linkis.hive.engine.type parameter to control the way the task is killed
     LOG.info(s"hive engine type :${HiveEngineConfiguration.HIVE_ENGINE_TYPE}")
     HiveEngineConfiguration.HIVE_ENGINE_TYPE match {
       case "mr" =>

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
@@ -52,9 +52,10 @@ import java.security.PrivilegedExceptionAction
 import java.util
 import java.util.concurrent.atomic.AtomicBoolean
 import org.apache.linkis.engineconn.executor.entity.ResourceFetchExecutor
-import org.apache.linkis.engineplugin.hive.conf.Counters
+import org.apache.linkis.engineplugin.hive.conf.{Counters, HiveEngineConfiguration}
 import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus
 import org.apache.commons.lang.StringUtils
+import org.apache.hadoop.hive.ql.exec.tez.TezJobExecHelper
 import org.apache.linkis.engineconn.computation.executor.utlis.ProgressUtils
 import org.apache.linkis.governance.common.utils.JobUtils
 
@@ -446,11 +447,18 @@ class HiveEngineConnExecutor(id: Int,
 
   override def killTask(taskID: String): Unit = {
     LOG.info(s"hive begins to kill job with id : ${taskID}")
-    HadoopJobExecHelper.killRunningJobs()
-    //Utils.tryQuietly(TezJobExecHelper.killRunningJobs())
-    Utils.tryQuietly(HiveInterruptUtils.interrupt())
-    if (null != thread) {
-      Utils.tryAndWarn(thread.interrupt())
+    //通过wds.linkis.hive.engine.type参数配置引擎来控制kill任务时的方式
+    LOG.info(s"hive engine type :${HiveEngineConfiguration.HIVE_ENGINE_TYPE}")
+    HiveEngineConfiguration.HIVE_ENGINE_TYPE match {
+      case "mr" =>
+        HadoopJobExecHelper.killRunningJobs()
+        Utils.tryQuietly(HiveInterruptUtils.interrupt())
+        if (null != thread) {
+          Utils.tryAndWarn(thread.interrupt())
+        }
+      case "tez" =>
+        Utils.tryQuietly(TezJobExecHelper.killRunningJobs())
+        driver.close()
     }
     clearCurrentProgress()
     singleSqlProgressMap.clear()


### PR DESCRIPTION
fix(linkis-engineplugin-hive): support cancel hive on tez task and engineconn is no longer busy

1.HiveEngineConfiguration中增加wds.linkis.hive.engine.type配置来控制cancel时的操作,目前支持mr和tez
2.HiveEngineConnExecutor中killtask时对于hive on tez进行了close driver的操作，确保engineconn不会卡在busy状态
3.properties里增加wds.linkis.hive.engine.type选项，默认值为mr
1.Add wds.linkis.hive.engine.type configuration to HiveEngineConfiguration to control the cancel operation, currently supports mr and tez
2.When killing task in HiveEngineConnExecutor, close driver is performed on hive on tez to ensure that engineconn will not be stuck in busy state
3.Add the wds.linkis.hive.engine.type option to the properties, the default value is mr

Closes https://github.com/apache/incubator-linkis/issues/2321