### PR TITLE
fix: bug#2307.Before removing dist and plugin /

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-application/src/main/assembly/distribution.xml
+++ b/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-application/src/main/assembly/distribution.xml
@@ -99,7 +99,7 @@
             <directory>
                 ${basedir}/src/main/resources/conf/
             </directory>
-            <outputDirectory>/conf</outputDirectory>
+            <outputDirectory>conf</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>
@@ -111,7 +111,7 @@
             <directory>
                 ${basedir}/src/main/resources/bin/
             </directory>
-            <outputDirectory>/bin</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/src/main/assembly/distribution.xml
@@ -197,7 +197,7 @@
             </includes>
             <fileMode>0777</fileMode>
             <directoryMode>0755</directoryMode>
-            <outputDirectory>./dist/v${flink.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${flink.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -210,7 +210,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>./plugin/${flink.version}</outputDirectory>
+            <outputDirectory>plugin/${flink.version}</outputDirectory>
         </fileSet>
 
     </fileSets>

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/assembly/distribution.xml
@@ -233,7 +233,7 @@
                 <include>*</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${hive.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${hive.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -246,7 +246,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${hive.version}</outputDirectory>
+            <outputDirectory>plugin/${hive.version}</outputDirectory>
         </fileSet>
 
     </fileSets>

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/assembly/distribution.xml
@@ -50,7 +50,7 @@
                 <include>log4j2.xml</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${io_file.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${io_file.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -63,7 +63,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${io_file.version}</outputDirectory>
+            <outputDirectory>plugin/${io_file.version}</outputDirectory>
         </fileSet>
 
     </fileSets>

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/assembly/distribution.xml
@@ -50,7 +50,7 @@
                 <include>log4j2.xml</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${jdbc.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${jdbc.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -63,7 +63,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${jdbc.version}</outputDirectory>
+            <outputDirectory>plugin/${jdbc.version}</outputDirectory>
         </fileSet>
 
     </fileSets>

--- a/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/openlookeng/src/main/assembly/distribution.xml
@@ -50,7 +50,7 @@
                 <include>log4j2.xml</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${openlookeng.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${openlookeng.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -63,7 +63,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${openlookeng.version}</outputDirectory>
+            <outputDirectory>plugin/${openlookeng.version}</outputDirectory>
         </fileSet>
 
     </fileSets>

--- a/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/pipeline/src/main/assembly/distribution.xml
@@ -51,7 +51,7 @@
                 <include>log4j2.xml</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${pipeline.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${pipeline.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -64,7 +64,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${pipeline.version}</outputDirectory>
+            <outputDirectory>plugin/${pipeline.version}</outputDirectory>
         </fileSet>
 
     </fileSets>

--- a/linkis-engineconn-plugins/engineconn-plugins/python/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/python/src/main/assembly/distribution.xml
@@ -53,7 +53,7 @@
                 <exclude>python</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${python.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${python.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -63,7 +63,7 @@
                 <include>*</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${python.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${python.version}/conf</outputDirectory>
         </fileSet>
 
         <fileSet>
@@ -75,7 +75,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${python.version}</outputDirectory>
+            <outputDirectory>plugin/${python.version}</outputDirectory>
         </fileSet>
     </fileSets>
 

--- a/linkis-engineconn-plugins/engineconn-plugins/shell/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/shell/src/main/assembly/distribution.xml
@@ -50,7 +50,7 @@
                 <include>*</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${shell.version}/bin</outputDirectory>
+            <outputDirectory>dist/v${shell.version}/bin</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -60,7 +60,7 @@
                 <include>*</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${shell.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${shell.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -73,7 +73,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${shell.version}</outputDirectory>
+            <outputDirectory>plugin/${shell.version}</outputDirectory>
         </fileSet>
     </fileSets>
 

--- a/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/assembly/distribution.xml
@@ -54,7 +54,7 @@
             </excludes>
             <fileMode>0777</fileMode>
             <directoryMode>0755</directoryMode>
-            <outputDirectory>/dist/v${spark.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${spark.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -67,7 +67,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${spark.version}</outputDirectory>
+            <outputDirectory>plugin/${spark.version}</outputDirectory>
         </fileSet>
 
     </fileSets>

--- a/linkis-engineconn-plugins/engineconn-plugins/sqoop/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/sqoop/src/main/assembly/distribution.xml
@@ -301,7 +301,7 @@
             </includes>
             <fileMode>0777</fileMode>
             <directoryMode>0755</directoryMode>
-            <outputDirectory>/dist/v${sqoop.version}/conf</outputDirectory>
+            <outputDirectory>dist/v${sqoop.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
@@ -314,7 +314,7 @@
                 <exclude>*doc.jar</exclude>
             </excludes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/plugin/${sqoop.version}</outputDirectory>
+            <outputDirectory>plugin/${sqoop.version}</outputDirectory>
         </fileSet>
 
     </fileSets>


### PR DESCRIPTION
### What is the purpose of the change
(For example: EngineConn-Core defines the the abstractions and interfaces of the EngineConn core functions.
The Engine Service in Linkis 0.x is refactored, EngineConn will handle the engine connection and session management.
Related issues: #590. )
#2307 

### Brief change log
linkis-engineconn-plugins ---> engineconn-plugins , dist and plugins in distribution.xml remove /
linkis-computation-governance ---> linkis-client ---> linkis-cli ---> linkis-cli-application conf and bin in distribution.xml remove /

### Verifying this change
Using a win10(or other win versions) computer.
Maven and JDK versions:
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-11T00:41:47+08:00)
Java version: 1.8.0_241, vendor: Oracle Corporation

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)