### PR TITLE
Dispose of sqoop engine startup failure due to dependency library conflict

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/sqoop/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/sqoop/pom.xml
@@ -211,8 +211,14 @@
             <artifactId>linkis-common</artifactId>
             <version>${linkis.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
+      
         <dependency>
             <groupId>org.apache.linkis</groupId>
             <artifactId>linkis-bml-engine-hook</artifactId>


### PR DESCRIPTION
Dispose of sqoop engine startup failure due to dependency library conflict: log4j-slf4j library conflict causes sqoop engine startup failure, you need to exclude log4j-slf4j-impl library in the imported dependency library linkis-common.
