### PR TITLE
[Feature] Automatically create workspace for newly added users

### DIFF
--- a/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/conf/WorkSpaceConfiguration.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/conf/WorkSpaceConfiguration.java
@@ -55,6 +55,9 @@ public class WorkSpaceConfiguration {
     public static final CommonVars<Boolean> FILESYSTEM_PATH_CHECK_OWNER =
             CommonVars$.MODULE$.apply("wds.linkis.workspace.filesystem.owner.check", false);
 
+    public static final CommonVars<Boolean> FILESYSTEM_PATH_AUTO_CREATE =
+            CommonVars$.MODULE$.apply("wds.linkis.workspace.filesystem.auto.create", false);
+
     public static final ExecutorService executorService =
             new ThreadPoolExecutor(
                     FILESYSTEM_FS_THREAD_NUM.getValue(),

--- a/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/exception/WorkspaceExceptionManager.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/exception/WorkspaceExceptionManager.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public class WorkspaceExceptionManager {
 
-    private static Map<String, String> desc =
+    private static final Map<String, String> desc =
             new HashMap<String, String>(32) {
                 {
                     put(
@@ -66,6 +66,7 @@ public class WorkspaceExceptionManager {
                     put("80024", "非table类型的结果集不能下载为excel");
                     put("80028", "the path exist special char");
                     put("80029", "empty dir!");
+                    put("80030","Failed to create user path");
                 }
             };
 

--- a/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -104,8 +104,8 @@ public class FsRestfulApi {
         LOGGER.debug("workspacePath:" + workspacePath);
         LOGGER.debug("enginconnPath:" + enginconnPath);
         LOGGER.debug("adminUser:" + WorkSpaceConfiguration.FILESYSTEM_LOG_ADMIN.getValue());
-        return (requestPath.indexOf(workspacePath) > -1)
-                || (requestPath.indexOf(enginconnPath) > -1);
+        return (requestPath.contains(workspacePath))
+                || (requestPath.contains(enginconnPath));
     }
 
     @RequestMapping(path = "/getUserRootPath", method = RequestMethod.GET)
@@ -130,6 +130,15 @@ public class FsRestfulApi {
         FsPath fsPath = new FsPath(path);
         FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
         if (!fileSystem.exists(fsPath)) {
+            if (FILESYSTEM_PATH_AUTO_CREATE.getValue()) {
+                try {
+                    fileSystem.mkdirs(fsPath);
+                    return Message.ok().data(String.format("user%sRootPath", returnType), path);
+                } catch (IOException e) {
+                    LOGGER.error(e.getMessage(), e);
+                    throw WorkspaceExceptionManager.createException(80030);
+                }
+            }
             throw WorkspaceExceptionManager.createException(80003);
         }
         return Message.ok().data(String.format("user%sRootPath", returnType), path);


### PR DESCRIPTION
### What is the purpose of the change
Automatically create workspace for newly added users

### Brief change log
By adding wds.linkis.workspace.filesystem.auto.create.workspace=true, the current user's workspace and hdfs root dir can be created automatically

### Verifying this change


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no 
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: no

### Documentation
- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)