### PR TITLE
[ISSUE 2389] Fixed the bug in the linkis-ps-metadataquery module

### DIFF
--- a/linkis-dist/bin/checkEnv.sh
+++ b/linkis-dist/bin/checkEnv.sh
@@ -139,7 +139,7 @@ check_service_port
 SERVER_PORT=$DATASOURCE_MANAGER_PORT
 check_service_port
 
-SERVER_PORT=$METADATA_MANAGER_PORT
+SERVER_PORT=$METADATA_QUERY_PORT
 check_service_port
 
 if [ "$portIsOccupy" = true ];then

--- a/linkis-dist/package/sbin/graceful-upgrade.sh
+++ b/linkis-dist/package/sbin/graceful-upgrade.sh
@@ -60,8 +60,8 @@ function getPort(){
     "ps-data-source-manager")
       export SERVER_PORT=$DATASOURCE_MANAGER_PORT
       ;;
-    "ps-metadatamanager")
-      export SERVER_PORT=$METADATA_MANAGER_PORT
+    "ps-metadataquery")
+      export SERVER_PORT=$METADATA_QUERY_PORT
       ;;
   esac
 }

--- a/linkis-dist/src/main/assembly/distribution.xml
+++ b/linkis-dist/src/main/assembly/distribution.xml
@@ -6,9 +6,9 @@
   ~ The ASF licenses this file to You under the Apache License, Version 2.0
   ~ (the "License"); you may not use this file except in compliance with
   ~ the License.  You may obtain a copy of the License at
-  ~ 
+  ~
   ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~ 
+  ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -290,13 +290,13 @@
                 <include>*.jar</include>
             </includes>
         </fileSet>
-        <!-- metadata manager -->
+        <!-- metadata query -->
         <fileSet>
             <directory>
-                ../linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/server/target/out/lib/
+                ../linkis-public-enhancements/linkis-datasource/linkis-metadata-query/server/target/out/lib/
             </directory>
             <outputDirectory>
-                linkis-package/lib/linkis-public-enhancements/linkis-ps-metadatamanager
+                linkis-package/lib/linkis-public-enhancements/linkis-ps-metadataquery
             </outputDirectory>
             <includes>
                 <include>**/*</include>


### PR DESCRIPTION

Fixed the bug in the linkis-ps-metadataquery module that was missing after packaging
Related issues: #2389
