### PR TITLE
Support scala multi-version of spark

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
@@ -34,6 +34,7 @@ object SparkConfiguration extends Logging {
   val SPARK_LOOP_INIT_TIME = CommonVars[TimeType]("wds.linkis.engine.spark.spark-loop.init.time", new TimeType("120s"))
   val SPARK_LANGUAGE_REPL_INIT_TIME = CommonVars[TimeType]("wds.linkis.engine.spark.language-repl.init.time", new TimeType("30s"))
   val SPARK_REPL_CLASSDIR = CommonVars[String]("spark.repl.classdir", "", "默认master")
+  val SPARK_SCALA_VERSION = CommonVars("linkis.spark.scala.version", "2.11")
 
 
   val PROXY_USER = CommonVars[String]("spark.proxy.user", "${UM}")


### PR DESCRIPTION
### What is the purpose of the change
This change makes spark_plugin compatible with scala 2.12 and allows users to choose the scala version through configuration.

### Brief change log
- Add the configuration of spark_scala_version in the linkis-engineconn-plugins\engineconn-plugins\spark\src\main\scala\org\apache\linkis\engineplugin\spark\config\SparkConfiguration;
- The val in0 is defined by spark_scala_version.

### Verifying this change
This change is already covered by existing tests.  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)
