### PR TITLE
Fixed the problem that the task state could not be flipped normally when thread unsafe SimpleDateFormat was used as a global variable

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/rm/restful/RMMonitorRest.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/rm/restful/RMMonitorRest.scala
@@ -66,8 +66,12 @@ class RMMonitorRest extends Logging {
 
   implicit val formats = DefaultFormats + ResourceSerializer + NodeResourceSerializer
   val mapper = new ObjectMapper()
-  val dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy")
-  dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"))
+
+  private val dateFormatLocal = new ThreadLocal[SimpleDateFormat]() {
+    override protected def initialValue = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy")
+  }
+
+  dateFormatLocal.get().setTimeZone(TimeZone.getTimeZone("GMT"))
   val labelFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
   val combinedLabelBuilder = new CombinedLabelBuilder
   val gson = BDPJettyServerHelper.gson
@@ -144,7 +148,7 @@ class RMMonitorRest extends Logging {
           } else {
             engineInstance.put("status", node.getNodeStatus.toString)
           }
-          engineInstance.put("startTime", dateFormat.format(node.getStartTime))
+          engineInstance.put("startTime", dateFormatLocal.get().format(node.getStartTime))
           engineInstance.put("owner", node.getOwner)
           applicationList("engineInstances").asInstanceOf[mutable.ArrayBuffer[Any]].append(engineInstance)
         }

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/imexport/CsvRelation.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/imexport/CsvRelation.scala
@@ -56,10 +56,11 @@ class CsvRelation(@transient private val source: Map[String, Any]) extends Seria
   val quote = LoadData.getMapValue[String](source, "quote", "\"")
   val escape = LoadData.getMapValue[String](source, "escape", "\\")
   val escapeQuotes = LoadData.getMapValue[Boolean](source, "escapeQuotes", false)
-  val dateFormat: SimpleDateFormat = new SimpleDateFormat(LoadData.getMapValue[String](source, "dateFormat", "yyyy-MM-dd"), Locale.US)
-  val timestampFormat: SimpleDateFormat = new SimpleDateFormat(LoadData.getMapValue[String](source, "timestampFormat", "yyyy-mm-dd hh:mm:ss"), Locale.US)
 
-
+  private val timestampFormatLocal = new ThreadLocal[SimpleDateFormat]() {
+    override protected def initialValue = new SimpleDateFormat(LoadData.getMapValue[String](source, "timestampFormat", "yyyy-mm-dd hh:mm:ss"), Locale.US)
+  }
+  
   def transfer(sc: SparkContext, path: String, encoding: String): RDD[String] = {
     sc.hadoopFile(path, classOf[TextInputFormat], classOf[LongWritable], classOf[Text], 1)
       .map(p => new String(p._2.getBytes, 0, p._2.getLength, encoding))
@@ -136,7 +137,7 @@ class CsvRelation(@transient private val source: Map[String, Any]) extends Seria
       case _: BooleanType => value.toBoolean
       case dt: DecimalType => val dataum = new BigDecimal(value.replaceAll(",", ""))
         Decimal(dataum, dt.precision, dt.scale)
-      case _: TimestampType => new Timestamp(Try(timestampFormat.parse(value).getTime).getOrElse(stringToTime(value).getTime * 1000L))
+      case _: TimestampType => new Timestamp(Try(timestampFormatLocal.get().parse(value).getTime).getOrElse(stringToTime(value).getTime * 1000L))
       case _: DateType => new Date(Try(dateFormatP.parse(value).getTime).getOrElse(stringToTime(value).getTime))
       case _: StringType => value.replaceAll("\n|\t", " ")
       case t => throw new RuntimeException(s"Unsupported cast from $value to $t")

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/util/QueryUtils.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/util/QueryUtils.scala
@@ -50,7 +50,9 @@ object QueryUtils extends Logging {
   private val NAME_REGEX = "^[a-zA-Z\\d_\\.]+$"
   private val nameRegexPattern = Pattern.compile(NAME_REGEX)
 
-  private val dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+  private val dateFormatLocal = new ThreadLocal[SimpleDateFormat]() {
+    override protected def initialValue = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+  }
 
   def storeExecutionCode(jobRequest: JobRequest): Unit = {
       storeExecutionCode(jobRequest.getExecuteUser, jobRequest.getExecutionCode, path => jobRequest.setExecutionCode(path))
@@ -139,7 +141,7 @@ object QueryUtils extends Logging {
   }
 
   def dateToString(date: Date): String = {
-    dateFormat.format(date)
+    dateFormatLocal.get().format(date)
   }
 
   def checkNameValid(param: String): Boolean = {


### PR DESCRIPTION
Fixed the problem that the task state could not be flipped normally when thread unsafe SimpleDateFormat was used as a global variable

For example:
1、when a large number of tasks are submitted, the UpdateTimeMills property of the JobHistory class is incorrect because the SimpleDateFormat thread is not safe. As a result, the linkis_ps_job_history_group_history table cannot update its status properly

2、Problems can be reproduced during task stress testing