### PR TITLE
refactor(spark): get scala version from util.properties.versionNumber…

### DIFF
--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
@@ -34,8 +34,6 @@ object SparkConfiguration extends Logging {
   val SPARK_LOOP_INIT_TIME = CommonVars[TimeType]("wds.linkis.engine.spark.spark-loop.init.time", new TimeType("120s"))
   val SPARK_LANGUAGE_REPL_INIT_TIME = CommonVars[TimeType]("wds.linkis.engine.spark.language-repl.init.time", new TimeType("30s"))
   val SPARK_REPL_CLASSDIR = CommonVars[String]("spark.repl.classdir", "", "默认master")
-  val SPARK_SCALA_VERSION = CommonVars("linkis.spark.scala.version", "2.11")
-
 
   val PROXY_USER = CommonVars[String]("spark.proxy.user", "${UM}")
 


### PR DESCRIPTION
…String

### What is the purpose of the change
remove the config SPARK_SCALA_VERSION and get the scalaVersion from env

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: no

### Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)