### PR TITLE
feat: remove sun.misc.BASE64

### DIFF
--- a/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/DESUtil.java
+++ b/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/DESUtil.java
@@ -25,9 +25,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESKeySpec;
 
 import java.security.SecureRandom;
-
-import sun.misc.BASE64Decoder;
-import sun.misc.BASE64Encoder;
+import java.util.Base64;
 
 public class DESUtil {
     private static final String DES = "DES";
@@ -50,8 +48,7 @@ public class DESUtil {
             }
         }
         byte[] bt = encrypt(data.getBytes(), key.getBytes());
-        String strs = new BASE64Encoder().encode(bt);
-        return strs;
+        return Base64.getMimeEncoder().encodeToString(bt);
     }
 
     /**
@@ -73,8 +70,8 @@ public class DESUtil {
                 i++;
             }
         }
-        BASE64Decoder decoder = new BASE64Decoder();
-        byte[] buf = decoder.decodeBuffer(data);
+        Base64.Decoder decoder = Base64.getMimeDecoder();
+        byte[] buf = decoder.decode(data);
         byte[] bt = decrypt(buf, key.getBytes());
         return new String(bt);
     }

--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/ServerConfiguration.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/ServerConfiguration.scala
@@ -21,11 +21,9 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.linkis.common.conf.{CommonVars, Configuration, TimeType}
 import org.apache.linkis.common.utils.{DESUtil, Logging, Utils}
 import org.apache.linkis.server.exception.BDPInitServerException
-import sun.misc.BASE64Encoder
-
 import java.io.File
+import java.util.Base64
 import java.lang
-
 
 object ServerConfiguration extends Logging{
   val BDP_SERVER_EXCLUDE_PACKAGES = CommonVars("wds.linkis.server.component.exclude.packages", "")
@@ -38,7 +36,7 @@ object ServerConfiguration extends Logging{
     throw new BDPInitServerException(10010, "DataWorkCloud service must set the version, please add property [[wds.linkis.server.version]] to properties file.")
   }
 
-  val cryptKey = new BASE64Encoder().encode(CommonVars("wds.linkis.crypt.key", "bdp-for-server").getValue.getBytes)
+  val cryptKey = Base64.getMimeEncoder.encodeToString(CommonVars("wds.linkis.crypt.key", "bdp-for-server").getValue.getBytes)
 
   private val ticketHeader = CommonVars("wds.linkis.ticket.header", "bfs_").getValue
 

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/rm/external/yarn/YarnResourceRequester.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/rm/external/yarn/YarnResourceRequester.scala
@@ -32,10 +32,9 @@ import org.apache.linkis.manager.rm.utils.RequestKerberosUrlUtils
 import org.json4s.JValue
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods.parse
-import sun.misc.BASE64Encoder
-
 import java.util
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Base64
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
@@ -51,8 +50,7 @@ class YarnResourceRequester extends ExternalResourceRequester with Logging {
     val user = this.provider.getConfigMap.getOrDefault("user", "").asInstanceOf[String]
     val pwd = this.provider.getConfigMap.getOrDefault("pwd", "").asInstanceOf[String]
     val authKey = user + ":" + pwd
-    val base64Encoder = new BASE64Encoder()
-    base64Encoder.encode(authKey.getBytes)
+    Base64.getMimeEncoder.encodeToString(authKey.getBytes)
   }
 
   override def requestResourceInfo(identifier: ExternalResourceIdentifier, provider: ExternalResourceProvider): NodeResource = {

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveUtils.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveUtils.java
@@ -25,8 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-
-import sun.misc.BASE64Decoder;
+import java.util.Base64;
 
 public class HiveUtils {
 
@@ -45,10 +44,10 @@ public class HiveUtils {
     }
 
     public static String decode(String str) {
-        BASE64Decoder decoder = new BASE64Decoder();
+        Base64.Decoder decoder = Base64.getMimeDecoder();
         String res = str;
         try {
-            res = new String(decoder.decodeBuffer(str));
+            res = new String(decoder.decode(str));
         } catch (Throwable e) {
             logger.error(str + " decode failed", e);
         }

--- a/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/cache/utils/MD5Util.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/cache/utils/MD5Util.java
@@ -19,8 +19,7 @@ package org.apache.linkis.jobhistory.cache.utils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-
-import sun.misc.BASE64Encoder;
+import java.util.Base64;
 
 public class MD5Util {
 
@@ -41,9 +40,9 @@ public class MD5Util {
             // 创建加密对象
             MessageDigest md = MessageDigest.getInstance("md5");
             if (bit == SIXTY_FOUR) {
-                BASE64Encoder bw = new BASE64Encoder();
-                String bsB64 = bw.encode(md.digest(src.getBytes(StandardCharsets.UTF_8)));
-                md5 = bsB64;
+                md5 =
+                        Base64.getMimeEncoder()
+                                .encodeToString(md.digest(src.getBytes(StandardCharsets.UTF_8)));
             } else {
                 // 计算MD5函数
                 md.update(src.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
### What is the purpose of the change
remove use of sun.misc.BASE64Decoder and sun.misc.BASE64Encoder
Related issues: #1411. 

### Brief change log
(for example:)
- use  Base64.getMimeEncoder().encodeToString() replace BASE64Encoder().encode()
- use  Base64.getMimeDecoder().decodeBuffer() replace BASE64Decoder().decode()

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: no

### Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)