### PR TITLE
[Feature] [1.2.0] When linkis-gateway is debugged locally, knife4j-related class dependencies conflict.

### DIFF
--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/pom.xml
@@ -58,6 +58,18 @@
                     <artifactId>jackson-databind</artifactId>
                     <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>com.github.xiaoymin</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>io.springfox</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>io.swagger</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://github.com/apache/incubator-linkis/issues/2454