### PR TITLE
Use lsof -i tcp:$server_ Port | fgrep listen detects whether the port is occupied

### DIFF
--- a/linkis-dist/bin/checkEnv.sh
+++ b/linkis-dist/bin/checkEnv.sh
@@ -75,7 +75,7 @@ function checkSpark(){
 
 portIsOccupy=false
 function check_service_port() {
-    pid=`lsof -i :$SERVER_PORT | grep -v "PID"`
+    pid=`lsof -i TCP:$SERVER_PORT | fgrep LISTEN`
     if [ "$pid" != "" ];then
       echo "$SERVER_PORT already used"
       portIsOccupy=true


### PR DESCRIPTION
fix: use the lsof i , TCP ports connected to other machines are detected

### What is the purpose of the change
https://github.com/apache/incubator-linkis/issues/2293

### Brief change log
- checkEnv.sh ,  lsof -i  update lsof -i TCP:$SERVER_PORT | fgrep LISTEN

### Verifying this change
- Start some existing ports and execute scripts, which will be detected
- Use telnet to connect to the port of other machines. If the local service does not start using this port, it will not be detected

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)