### PR TITLE
refactor: Update hive-exec and hive-jdbc dependency version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -328,7 +328,7 @@ See licenses-binary/ for text of these licenses.
     (Apache License, Version 2.0) Hive Llap Client (org.apache.hive:hive-llap-client:2.3.3 - http://hive.apache.org/hive-llap-client)
     (Apache License, Version 2.0) Hive Llap Common (org.apache.hive:hive-llap-common:2.3.3 - http://hive.apache.org/hive-llap-common)
     (Apache License, Version 2.0) Hive Llap Tez (org.apache.hive:hive-llap-tez:2.3.3 - http://hive.apache.org/hive-llap-tez)
-    (Apache License, Version 2.0) Hive Query Language (org.apache.hive:hive-exec:2.3.3 - http://hive.apache.org/hive-exec)
+    (Apache License, Version 2.0) Hive Query Language (org.apache.hive:hive-exec:2.3.9 - http://hive.apache.org/hive-exec)
     (Apache License, Version 2.0) Hive Storage API (org.apache.hive:hive-storage-api:2.4.0 - https://www.apache.org/hive-storage-api/)
     (Apache License, Version 2.0) Hive Vector-Code-Gen Utilities (org.apache.hive:hive-vector-code-gen:2.3.3 - http://hive.apache.org/hive-vector-code-gen)
     (Apache License, Version 2.0) HttpClient (commons-httpclient:commons-httpclient:3.1 - http://jakarta.apache.org/httpcomponents/httpclient-3.x/)

--- a/README.md
+++ b/README.md
@@ -39,23 +39,23 @@ Since the first release of Linkis in 2019, it has accumulated more than **700** 
 
 # Supported Engine Types
 
-| **Engine Name** | **Suppor Component Version<br/>(Default Dependent Version)** | **Linkis Version Requirements** | **Included in Release Package<br/> By Default** | **Description** |
-|:---- |:---- |:---- |:---- |:---- |
-|Spark|Apache 2.0.0~2.4.7, <br/>CDH >= 5.4.0, <br/>(default Apache Spark 2.4.3)|\>=1.0.3|Yes|Spark EngineConn, supports SQL , Scala, Pyspark and R code|
-|Hive|Apache >= 1.0.0, <br/>CDH >= 5.4.0, <br/>(default Apache Hive 2.3.3)|\>=1.0.3|Yes |Hive EngineConn, supports HiveQL code|
-|Python|Python >= 2.6, <br/>(default Python2*)|\>=1.0.3|Yes |Python EngineConn, supports python code|
-|Shell|Bash >= 2.0|\>=1.0.3|Yes|Shell EngineConn, supports Bash shell code|
-|JDBC|MySQL >= 5.0, Hive >=1.2.1, <br/>(default Hive-jdbc 2.3.4)|\>=1.0.3|No|JDBC EngineConn, already supports MySQL and HiveQL, can be extended quickly Support other engines with JDBC Driver package, such as Oracle|
-|Flink |Flink >= 1.12.2, <br/>(default Apache Flink 1.12.2)|\>=1.0.3|No |Flink EngineConn, supports FlinkSQL code, also supports starting a new Yarn in the form of Flink Jar Application |
-|Pipeline|-|\>=1.0.3|No|Pipeline EngineConn, supports file import and export|
-|openLooKeng|openLooKeng >= 1.5.0, <br/>(default openLookEng 1.5.0)|\>=1.1.1|No|openLooKeng EngineConn, supports querying data virtualization engine with Sql openLooKeng|
-|Sqoop| Sqoop >= 1.4.6, <br/>(default Apache Sqoop 1.4.6)|\>=1.1.2|No|Sqoop EngineConn, support data migration tool Sqoop engine|
-|Impala|Impala >= 3.2.0, CDH >=6.3.0|ongoing|-|Impala EngineConn, supports Impala SQL code|
-|Presto|Presto >= 0.180|ongoing|-|Presto EngineConn, supports Presto SQL code|
-|ElasticSearch|ElasticSearch >=6.0|ongoing|-|ElasticSearch EngineConn, supports SQL and DSL code|
-|MLSQL| MLSQL >=1.1.0|ongoing|-|MLSQL EngineConn, supports MLSQL code.|
-|Hadoop|Apache >=2.6.0, <br/>CDH >=5.4.0|ongoing|-|Hadoop EngineConn, supports Hadoop MR/YARN application|
-|TiSpark|1.1|ongoing|-|TiSpark EngineConn, supports querying TiDB with SparkSQL|
+| **Engine Name** | **Suppor Component Version<br/>(Default Dependent Version)**             | **Linkis Version Requirements** | **Included in Release Package<br/> By Default** | **Description** |
+|:---- |:-------------------------------------------------------------------------|:---- |:---- |:---- |
+|Spark| Apache 2.0.0~2.4.7, <br/>CDH >= 5.4.0, <br/>(default Apache Spark 2.4.3) |\>=1.0.3|Yes|Spark EngineConn, supports SQL , Scala, Pyspark and R code|
+|Hive| Apache >= 1.0.0, <br/>CDH >= 5.4.0, <br/>(default Apache Hive 2.3.3)     |\>=1.0.3|Yes |Hive EngineConn, supports HiveQL code|
+|Python| Python >= 2.6, <br/>(default Python2*)                                   |\>=1.0.3|Yes |Python EngineConn, supports python code|
+|Shell| Bash >= 2.0                                                              |\>=1.0.3|Yes|Shell EngineConn, supports Bash shell code|
+|JDBC| MySQL >= 5.0, Hive >=1.2.1, <br/>(default Hive-jdbc 2.3.9)               |\>=1.0.3|No|JDBC EngineConn, already supports MySQL and HiveQL, can be extended quickly Support other engines with JDBC Driver package, such as Oracle|
+|Flink | Flink >= 1.12.2, <br/>(default Apache Flink 1.12.2)                      |\>=1.0.3|No |Flink EngineConn, supports FlinkSQL code, also supports starting a new Yarn in the form of Flink Jar Application |
+|Pipeline| -                                                                        |\>=1.0.3|No|Pipeline EngineConn, supports file import and export|
+|openLooKeng| openLooKeng >= 1.5.0, <br/>(default openLookEng 1.5.0)                   |\>=1.1.1|No|openLooKeng EngineConn, supports querying data virtualization engine with Sql openLooKeng|
+|Sqoop| Sqoop >= 1.4.6, <br/>(default Apache Sqoop 1.4.6)                        |\>=1.1.2|No|Sqoop EngineConn, support data migration tool Sqoop engine|
+|Impala| Impala >= 3.2.0, CDH >=6.3.0                                             |ongoing|-|Impala EngineConn, supports Impala SQL code|
+|Presto| Presto >= 0.180                                                          |ongoing|-|Presto EngineConn, supports Presto SQL code|
+|ElasticSearch| ElasticSearch >=6.0                                                      |ongoing|-|ElasticSearch EngineConn, supports SQL and DSL code|
+|MLSQL| MLSQL >=1.1.0                                                            |ongoing|-|MLSQL EngineConn, supports MLSQL code.|
+|Hadoop| Apache >=2.6.0, <br/>CDH >=5.4.0                                         |ongoing|-|Hadoop EngineConn, supports Hadoop MR/YARN application|
+|TiSpark| 1.1                                                                      |ongoing|-|TiSpark EngineConn, supports querying TiDB with SparkSQL|
 
 
 # Ecosystem

--- a/README_CN.md
+++ b/README_CN.md
@@ -32,23 +32,23 @@ Linkis 自2019年开源发布以来，已累计积累了700多家试验企业和
 
 # 支持的引擎类型
 
-| **引擎名** | **支持底层组件版本<br/>(默认依赖版本)** | **Linkis 版本要求** | **是否默认包含在发布包中** | **说明** |
-|:---- |:---- |:---- |:---- |:---- |
-|Spark|Apache 2.0.0~2.4.7, <br/>CDH >= 5.4.0, <br/>（默认Apache Spark 2.4.3）|\>=1.0.3|是|Spark EngineConn， 支持SQL, Scala, Pyspark 和R 代码|
-|Hive|Apache >= 1.0.0, <br/>CDH >= 5.4.0, <br/>（默认Apache Hive 2.3.3）|\>=1.0.3|是|Hive EngineConn， 支持HiveQL 代码|
-|Python|Python >= 2.6, <br/>（默认Python2*）|\>=1.0.3|是|Python EngineConn， 支持python 代码|
-|Shell|Bash >= 2.0|\>=1.0.3|是|Shell EngineConn， 支持Bash shell 代码|
-|JDBC|MySQL >= 5.0, Hive >=1.2.1, <br/>(默认Hive-jdbc 2.3.4)|\>=1.0.3|否|JDBC EngineConn， 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle|
-|Flink |Flink >= 1.12.2, <br/>(默认Apache Flink 1.12.2)|\>=1.0.3|否|Flink EngineConn， 支持FlinkSQL 代码，也支持以Flink Jar 形式启动一个新的Yarn 应用程序|
-|Pipeline|-|\>=1.0.3|否|Pipeline EngineConn， 支持文件的导入和导出|
-|openLooKeng|openLooKeng >= 1.5.0, <br/>(默认openLookEng 1.5.0)|\>=1.1.1|否|openLooKeng EngineConn， 支持用Sql查询数据虚拟化引擎openLooKeng|
-|Sqoop| Sqoop >= 1.4.6, <br/>(默认Apache Sqoop 1.4.6)|\>=1.1.2|否|Sqoop EngineConn， 支持 数据迁移工具 Sqoop 引擎|
-|Impala|Impala >= 3.2.0, CDH >=6.3.0|ongoing|-|Impala EngineConn，支持Impala SQL 代码|
-|Presto|Presto >= 0.180|ongoing|-|Presto EngineConn， 支持Presto SQL 代码|
-|ElasticSearch|ElasticSearch >=6.0|ongoing|-|ElasticSearch EngineConn， 支持SQL 和DSL 代码|
-|MLSQL| MLSQL >=1.1.0|ongoing|-|MLSQL EngineConn， 支持MLSQL 代码.|
-|Hadoop|Apache >=2.6.0, <br/>CDH >=5.4.0|ongoing|-|Hadoop EngineConn， 支持Hadoop MR/YARN application|
-|TiSpark|1.1|ongoing|-|TiSpark EngineConn， 支持用SparkSQL 查询TiDB|
+| **引擎名** | **支持底层组件版本<br/>(默认依赖版本)**                                          | **Linkis 版本要求** | **是否默认包含在发布包中** | **说明** |
+|:---- |:-------------------------------------------------------------------|:---- |:---- |:---- |
+|Spark| Apache 2.0.0~2.4.7, <br/>CDH >= 5.4.0, <br/>（默认Apache Spark 2.4.3） |\>=1.0.3|是|Spark EngineConn， 支持SQL, Scala, Pyspark 和R 代码|
+|Hive| Apache >= 1.0.0, <br/>CDH >= 5.4.0, <br/>（默认Apache Hive 2.3.3）     |\>=1.0.3|是|Hive EngineConn， 支持HiveQL 代码|
+|Python| Python >= 2.6, <br/>（默认Python2*）                                   |\>=1.0.3|是|Python EngineConn， 支持python 代码|
+|Shell| Bash >= 2.0                                                        |\>=1.0.3|是|Shell EngineConn， 支持Bash shell 代码|
+|JDBC| MySQL >= 5.0, Hive >=1.2.1, <br/>(默认Hive-jdbc 2.3.9)               |\>=1.0.3|否|JDBC EngineConn， 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle|
+|Flink | Flink >= 1.12.2, <br/>(默认Apache Flink 1.12.2)                      |\>=1.0.3|否|Flink EngineConn， 支持FlinkSQL 代码，也支持以Flink Jar 形式启动一个新的Yarn 应用程序|
+|Pipeline| -                                                                  |\>=1.0.3|否|Pipeline EngineConn， 支持文件的导入和导出|
+|openLooKeng| openLooKeng >= 1.5.0, <br/>(默认openLookEng 1.5.0)                   |\>=1.1.1|否|openLooKeng EngineConn， 支持用Sql查询数据虚拟化引擎openLooKeng|
+|Sqoop| Sqoop >= 1.4.6, <br/>(默认Apache Sqoop 1.4.6)                        |\>=1.1.2|否|Sqoop EngineConn， 支持 数据迁移工具 Sqoop 引擎|
+|Impala| Impala >= 3.2.0, CDH >=6.3.0                                       |ongoing|-|Impala EngineConn，支持Impala SQL 代码|
+|Presto| Presto >= 0.180                                                    |ongoing|-|Presto EngineConn， 支持Presto SQL 代码|
+|ElasticSearch| ElasticSearch >=6.0                                                |ongoing|-|ElasticSearch EngineConn， 支持SQL 和DSL 代码|
+|MLSQL| MLSQL >=1.1.0                                                      |ongoing|-|MLSQL EngineConn， 支持MLSQL 代码.|
+|Hadoop| Apache >=2.6.0, <br/>CDH >=5.4.0                                   |ongoing|-|Hadoop EngineConn， 支持Hadoop MR/YARN application|
+|TiSpark| 1.1                                                                |ongoing|-|TiSpark EngineConn， 支持用SparkSQL 查询TiDB|
 
 # 生态组件
 

--- a/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/flink/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>linkis-engineconn-plugin-flink</artifactId>
     <properties>
         <flink.version>1.12.2</flink.version>
-        <hive.version>2.3.3</hive.version>
+        <hive.version>2.3.9</hive.version>
     </properties>
 
     <dependencies>

--- a/linkis-engineconn-plugins/engineconn-plugins/hive/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>linkis-engineplugin-hive</artifactId>
 
     <properties>
-        <hive.version>2.3.3</hive.version>
+        <hive.version>2.3.9</hive.version>
     </properties>
 
     <dependencies>

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
-            <version>2.3.4</version>
+            <version>2.3.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.hive</groupId>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/hive/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-manager/service/hive/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hive.version>2.3.3</hive.version>
+        <hive.version>2.3.9</hive.version>
         <hadoop.version>2.7.2</hadoop.version>
         <datanucleus-api-jdo.version>4.2.4</datanucleus-api-jdo.version>
     </properties>


### PR DESCRIPTION
### What is the purpose of the change

Update hive-exec and hive-jdbc dependency version to 2.3.9. Related issue: #1364

### Brief change log

Update hive-exec and hive-jdbc dependency version to 2.3.9.

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  
(or)  
This change is already covered by existing tests, such as (please describe tests).  
(or)  
This change added tests and can be verified as follows:  
(example:)  
- Added tests for submit and execute all kinds of jobs to go through and verify the lifecycles of different EngineConns.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)