### PR TITLE
[ISSUE-2506] Upgrade 1.1.1 ddl,miss engine=innodb default charset=utf8 statement

### DIFF
--- a/linkis-dist/package/db/upgrade/1.1.1_schema/mysql/linkis_ddl.sql
+++ b/linkis-dist/package/db/upgrade/1.1.1_schema/mysql/linkis_ddl.sql
@@ -70,7 +70,7 @@ CREATE TABLE linkis_cg_rm_resource_action_record (
   `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `label_value_ticket_id` (`label_value`, `ticket_id`)
-)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
 -- Table structure for linkis_mg_gateway_auth_token


### PR DESCRIPTION
fix: upgrade 1.1.1 ddl,miss engine=innodb default charset=utf8 statement

### What is the purpose of the change
https://github.com/apache/incubator-linkis/issues/2506
upgrade --> 1.1.1_schema --> linkis_ddl.sql

### Brief change log
- add ENGINE=InnoDB DEFAULT CHARSET=utf8;

### Verifying this change
- Execute this upgrade script

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (docs)