### PR TITLE
Fix MetadataQuery sql syntax error and LockManagerMapper method overload bug

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/StorageResultSetReader.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/StorageResultSetReader.scala
@@ -66,7 +66,7 @@ class StorageResultSetReader[K <: MetaData, V <: Record](resultSet: ResultSet[K,
     var rowLen = 0
     try rowLen = Dolphin.readInt(inputStream)
     catch {
-      case t: StorageWarnException => logger.info(s"Read finished(读取完毕)", t); return null
+      case _: StorageWarnException => logger.info(s"Read finished(读取完毕)"); return null
       case t: Throwable => throw t
     }
 
@@ -97,8 +97,8 @@ class StorageResultSetReader[K <: MetaData, V <: Record](resultSet: ResultSet[K,
     row
   }
 
-  def setFs(fs:Fs):Unit = this.fs = fs
-  def getFs:Fs = this.fs
+  def setFs(fs:Fs): Unit = this.fs = fs
+  def getFs: Fs = this.fs
 
   @scala.throws[IOException]
   override def getMetaData: MetaData = {
@@ -127,7 +127,7 @@ class StorageResultSetReader[K <: MetaData, V <: Record](resultSet: ResultSet[K,
 
   @scala.throws[IOException]
   override def hasNext: Boolean = {
-    if(metaData == null) getMetaData
+    if (metaData == null) getMetaData
     val line = readLine()
     if(line == null) return  false
     row = deserializer.createRecord(line)

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/selector/DefaultNodeSelector.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/selector/DefaultNodeSelector.scala
@@ -25,7 +25,7 @@ import org.apache.linkis.manager.common.entity.node.Node
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 
 @Service
@@ -33,8 +33,7 @@ class DefaultNodeSelector extends NodeSelector with Logging {
 
   @Autowired
   private var ruleList: util.List[NodeSelectRule] = _
-
-
+  
   /**
     * Select the most suitable node from a series of nodes through selection rules
     * 1. Rule processing logic, defaults to the last priority
@@ -43,14 +42,14 @@ class DefaultNodeSelector extends NodeSelector with Logging {
     * @return
     */
   override def choseNode(nodes: Array[Node]): Option[Node] = {
-    if (null == nodes || nodes.isEmpty){
+    if (null == nodes || nodes.isEmpty) {
       None
-    } else if (null == ruleList ) {
+    } else if (null == ruleList) {
       Some(nodes(0))
     } else {
       var resultNodes = nodes
       Utils.tryAndWarnMsg {
-        ruleList.foreach { rule =>
+        ruleList.asScala.foreach { rule =>
           resultNodes = rule.ruleFiltering(resultNodes)
         }
       }("Failed to execute select rule")
@@ -63,7 +62,7 @@ class DefaultNodeSelector extends NodeSelector with Logging {
   }
 
   override def getNodeSelectRules(): Array[NodeSelectRule] = {
-    if (null != ruleList) ruleList.toList.toArray
+    if (null != ruleList) ruleList.asScala.toArray
     else Array.empty[NodeSelectRule]
   }
 

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/selector/rule/AvailableNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/selector/rule/AvailableNodeSelectRule.scala
@@ -17,9 +17,9 @@
  
 package org.apache.linkis.manager.am.selector.rule
 
-import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.manager.common.entity.enumeration.{NodeHealthy, NodeStatus}
 import org.apache.linkis.manager.common.entity.node.{AMNode, Node}
+import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
@@ -28,7 +28,9 @@ import org.springframework.stereotype.Component
   */
 @Component
 @Order(2)
-class AvailableNodeSelectRule extends NodeSelectRule with Logging{
+class AvailableNodeSelectRule extends NodeSelectRule {
+
+  val logger: Logger = LoggerFactory.getLogger(classOf[AvailableNodeSelectRule])
 
   override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
     if (null != nodes) {
@@ -46,6 +48,4 @@ class AvailableNodeSelectRule extends NodeSelectRule with Logging{
       nodes
     }
   }
-
-
 }

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/selector/rule/ScoreNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/selector/rule/ScoreNodeSelectRule.scala
@@ -28,10 +28,8 @@ import org.springframework.stereotype.Component
 class ScoreNodeSelectRule extends NodeSelectRule with Logging {
 
   override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
-    if (null != nodes)
-      nodes.sortWith(sortByScore)
-    else
-      nodes
+    if (null != nodes) nodes.sortWith(sortByScore)
+    else nodes
   }
 
   /**

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
@@ -55,8 +55,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 import java.util
-import java.util.concurrent.{TimeUnit, TimeoutException}
-import scala.collection.JavaConversions._
+import java.util.concurrent.{TimeoutException, TimeUnit}
+
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 
 
@@ -117,8 +118,9 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
       return engineNode
     }
     val labels = resourceManagerPersistence.getLabelsByTicketId(serviceInstance.getInstance)
-    labels.foreach { label =>
-      LabelBuilderFactoryContext.getLabelBuilderFactory.createLabel[Label[_]](label.getLabelKey, label.getStringValue) match {
+    labels.asScala.foreach { label =>
+      LabelBuilderFactoryContext.getLabelBuilderFactory
+        .createLabel[Label[_]](label.getLabelKey, label.getStringValue) match {
         case engineInstanceLabel: EngineInstanceLabel =>
           val serviceInstance = ServiceInstance(engineInstanceLabel.getServiceName, engineInstanceLabel.getInstance)
           val engineNode = getEngineNodeManager.getEngineNode(serviceInstance)
@@ -151,13 +153,12 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
 
     //label chooser
     if (null != engineReuseLabelChoosers) {
-      engineReuseLabelChoosers.foreach { chooser =>
+      engineReuseLabelChoosers.asScala.foreach { chooser =>
         labelList = chooser.chooseLabels(labelList)
       }
     }
 
-
-    for (labelChecker <- labelCheckerList) {
+    for (labelChecker <- labelCheckerList.asScala) {
       if (!labelChecker.checkEngineLabel(labelList)) {
         throw new AMErrorException(AMConstant.EM_ERROR_CODE, "Need to specify engineType and userCreator label")
       }
@@ -167,8 +168,10 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
     val emInstanceLabel = labelBuilderFactory.createLabel(classOf[AliasServiceInstanceLabel])
     emInstanceLabel.setAlias(ENGINE_CONN_MANAGER_SPRING_NAME.getValue)
     emLabelList.add(emInstanceLabel)
-    //2. NodeLabelService getNodesByLabel  获取EMNodeList
-    val emScoreNodeList = getEMService().getEMNodes(emLabelList.filter(!_.isInstanceOf[EngineTypeLabel]))
+
+    // 2. NodeLabelService getNodesByLabel  获取EMNodeList
+    val emScoreNodeList =
+      getEMService().getEMNodes(emLabelList.asScala.filter(!_.isInstanceOf[EngineTypeLabel]).asJava)
 
     //3. 执行Select  比如负载过高，返回没有负载低的EM，每个规则如果返回为空就抛出异常
     val choseNode = if (null == emScoreNodeList || emScoreNodeList.isEmpty) null else {
@@ -176,7 +179,10 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
       nodeSelector.choseNode(emScoreNodeList.toArray)
     }
     if (null == choseNode || choseNode.isEmpty) {
-      throw new LinkisRetryException(AMConstant.EM_ERROR_CODE, s" The em of labels${engineCreateRequest.getLabels} not found")
+      throw new LinkisRetryException(
+        AMConstant.EM_ERROR_CODE,
+        s" The em of labels ${engineCreateRequest.getLabels} not found"
+      )
     }
     val emNode = choseNode.get.asInstanceOf[EMNode]
     //4. 请求资源
@@ -257,9 +263,9 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
     }
     val configProp = engineConnConfigurationService.getConsoleConfiguration(labelList)
     val props = engineCreateRequest.getProperties
-    if (null != configProp && configProp.nonEmpty) {
-      configProp.foreach(keyValue => {
-        if (! props.containsKey(keyValue._1)) {
+    if (null != configProp && configProp.asScala.nonEmpty) {
+      configProp.asScala.foreach(keyValue => {
+        if (!props.containsKey(keyValue._1)) {
           props.put(keyValue._1, keyValue._2)
         }
       })
@@ -278,9 +284,9 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
   }
 
   private def fromEMGetEngineLabels(emLabels: util.List[Label[_]]): util.List[Label[_]] = {
-    emLabels.filter { label =>
+    emLabels.asScala.filter { label =>
       label.isInstanceOf[EngineNodeLabel] && !label.isInstanceOf[EngineTypeLabel]
-    }
+    }.asJava
   }
 
   private def ensuresIdle(engineNode: EngineNode, resourceTicketId: String): Boolean = {

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/dao/LockManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/dao/LockManagerMapper.java
@@ -30,11 +30,8 @@ public interface LockManagerMapper {
                     + "values(#{jsonObject}, #{timeOut}, now(), now())")
     void lock(@Param("jsonObject") String jsonObject, @Param("timeOut") Long timeOut);
 
-    @Delete("delete  from linkis_cg_manager_lock where lock_object = #{jsonObject}")
-    void unlock(String jsonObject);
-
     @Delete("delete  from linkis_cg_manager_lock where id = #{id}")
-    void unlock(int id);
+    void unlock(Integer id);
 
     @Select("select * from  linkis_cg_manager_lock where lock_object = #{jsonObject}")
     List<PersistenceLock> getLockersByLockObject(String jsonObject);

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/hive/dao/impl/HiveMetaDao.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/hive/dao/impl/HiveMetaDao.xml
@@ -149,7 +149,7 @@
         select t2.TBL_NAME as NAME, t2.TBL_TYPE as TYPE, t2.CREATE_TIME as CREATE_TIME, t2.LAST_ACCESS_TIME as LAST_ACCESS_TIME, t2.OWNER as OWNER, t2.SD_ID as SD_ID
         from DB_PRIVS t1
             inner join TBLS t2 on t1.DB_ID = t2.DB_ID and t1.DB_PRIV in ('SELECT','ALL') and t2.TBL_NAME = #{tableName,jdbcType=VARCHAR}
-            inner join DBS t3 on t1.DB_ID = t3.DB_ID and and t3.NAME = #{dbName,jdbcType=VARCHAR}
+            inner join DBS t3 on t1.DB_ID = t3.DB_ID and t3.NAME = #{dbName,jdbcType=VARCHAR}
         where  (t1.PRINCIPAL_TYPE = 'USER' and t1.PRINCIPAL_NAME = #{userName,jdbcType=VARCHAR})
         <if test="roles != null and roles.size() > 0">
             OR (t1.PRINCIPAL_TYPE = 'ROLE' AND t1.PRINCIPAL_NAME IN


### PR DESCRIPTION
### What is the purpose of the change
1. MetadataQuery sql syntax error
2. LockManagerMapper method overload bug

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: no

### Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)