### PR TITLE
ES engine  code optimization and NoSuchMethodError bug fix

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-label-common/src/main/java/org/apache/linkis/manager/label/entity/engine/EngineType.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-label-common/src/main/java/org/apache/linkis/manager/label/entity/engine/EngineType.scala
@@ -27,7 +27,7 @@ object EngineType extends Enumeration with Logging {
 
   val SPARK = Value("spark")
 
-  val HIVE  = Value("hive")
+  val HIVE = Value("hive")
 
   val PYTHON = Value("python")
 
@@ -92,6 +92,9 @@ object EngineType extends Enumeration with Logging {
     case _ if APPCONN.toString.equals(str) => APPCONN
     case _ if SQOOP.toString.equalsIgnoreCase(str) => SQOOP
     case _ if DATAX.toString.equalsIgnoreCase(str) => DATAX
+    case _ if OPENLOOKENG.toString.equalsIgnoreCase(str) => OPENLOOKENG
+    case _ if TRINO.toString.equalsIgnoreCase(str) => TRINO
+    case _ if ELASTICSEARCH.toString.equalsIgnoreCase(str) => ELASTICSEARCH
     case _ => null
 
   }

--- a/linkis-engineconn-plugins/elasticsearch/src/main/scala/org/apache/linkis/engineplugin/elasticsearch/executer/client/EsClientFactory.scala
+++ b/linkis-engineconn-plugins/elasticsearch/src/main/scala/org/apache/linkis/engineplugin/elasticsearch/executer/client/EsClientFactory.scala
@@ -139,7 +139,7 @@ object EsClientFactory {
     clusterStr.split(",")
       .map(value => {
         val arr = value.split(":")
-        (arr(0), arr(1).toInt)
+        (arr(0).trim, arr(1).trim.toInt)
       })
   } else Array()
 


### PR DESCRIPTION
### What is the purpose of the change
1. code optimization：Remove white space at both ends of the string #2604 
2. NoSuchMethodError bug fix: add OPENLOOKENG,TRINO,ELASTICSEARCH case #2603 

### Brief change log
- modify org.apache.linkis.manager.label.entity.engine.EngineType.
- modify org.apache.linkis.engineplugin.elasticsearch.executer.client.EsClientFactory.