### PR TITLE
add test case for factory launch extension

### DIFF
--- a/linkis-engineconn-plugins/spark/pom.xml
+++ b/linkis-engineconn-plugins/spark/pom.xml
@@ -295,6 +295,15 @@
                     <artifactId>protobuf-java</artifactId>
                     <groupId>com.google.protobuf</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-compiler</artifactId>
+                    <groupId>org.codehaus.janino</groupId>
+                </exclusion>
+
+                <exclusion>
+                    <artifactId>janino</artifactId>
+                    <groupId>org.codehaus.janino</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -332,9 +341,21 @@
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-compiler</artifactId>
+                    <groupId>org.codehaus.janino</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>janino</artifactId>
+                    <groupId>org.codehaus.janino</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <artifactId>hadoop-auth</artifactId>
+            <groupId>org.apache.hadoop</groupId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_${scala.binary.version}</artifactId>
@@ -349,9 +370,22 @@
                     <groupId>log4j</groupId>
                     <artifactId>apache-log4j-extras</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-compiler</artifactId>
+                    <groupId>org.codehaus.janino</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>janino</artifactId>
+                    <groupId>org.codehaus.janino</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <artifactId>janino</artifactId>
+            <groupId>org.codehaus.janino</groupId>
+            <version>3.0.9</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/extension/TestExecutionHooks.scala
+++ b/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/extension/TestExecutionHooks.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.engineplugin.spark.extension
+
+import org.apache.linkis.engineplugin.spark.cs.{CSSparkPostExecutionHook, CSSparkPreExecutionHook}
+import org.junit.jupiter.api.{Assertions, Test}
+
+class TestExecutionHooks {
+  @Test
+  def testPreHooks: Unit = {
+    val hookPre = new  CSSparkPreExecutionHook
+    SparkPreExecutionHook.register(hookPre)
+    Assertions.assertNotNull(SparkPreExecutionHook.getSparkPreExecutionHooks())
+  }
+  @Test
+  def testPostHooks: Unit = {
+    val hookPre = new  CSSparkPostExecutionHook
+    SparkPostExecutionHook.register(hookPre)
+    Assertions.assertNotNull(SparkPostExecutionHook.getSparkPostExecutionHooks())
+  }
+}

--- a/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/factory/TestSparkEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/factory/TestSparkEngineConnFactory.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.engineplugin.spark.factory
+
+import org.apache.spark.SparkConf
+import org.junit.jupiter.api.{Assertions, BeforeEach, Test}
+
+class TestSparkEngineConnFactory {
+  private var engineFactory: SparkEngineConnFactory = _
+  @BeforeEach
+  def before(): Unit = {
+    engineFactory = new SparkEngineConnFactory
+  }
+  @Test
+  def testCreateContext: Unit = {
+    val sparkConf: SparkConf = new SparkConf(true)
+    sparkConf.setAppName("test").setMaster("local[1]")
+    val outputDir = engineFactory.createOutputDir(sparkConf)
+    Assertions.assertNotNull(outputDir)
+    val sparkSession = engineFactory.createSparkSession(outputDir, sparkConf)
+    Assertions.assertNotNull(sparkSession)
+  }
+}

--- a/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/launch/TestSparkSubmitProcessEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/launch/TestSparkSubmitProcessEngineConnLaunchBuilder.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.engineplugin.spark.launch
+
+import org.apache.linkis.engineplugin.spark.launch.SparkSubmitProcessEngineConnLaunchBuilder.RelativePath
+import org.junit.jupiter.api.{Assertions, Test}
+
+
+class TestSparkSubmitProcessEngineConnLaunchBuilder {
+  @Test
+  def testCreateContext: Unit = {
+    val ddd = SparkSubmitProcessEngineConnLaunchBuilder.newBuilder()
+          .master("local[1]")
+          .deployMode("client")
+          .className("org.apache.linkis.engineplugin.spark.launch")
+      .driverClassPath("")
+      .archive(RelativePath(""))
+    Assertions.assertNotNull(ddd)
+  }
+}


### PR DESCRIPTION
This change added tests and can be verified as follows:  
- Added tests for Spark engine ExecutionHooks.
- Added tests for Spark engine SparkEngineConnFactory.
- Added tests for Spark engine SparkSubmitProcessEngineConnLaunchBuilder.
为Spark 引擎添加一些测试用例SparkSubmitProcessEngineConnLaunchBuilder SparkEngineConnFactory ExecutionHooks
