### PR TITLE
Rollback performance optimization changes from PR #2550

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/utils/StorageUtils.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/utils/StorageUtils.scala
@@ -187,7 +187,14 @@ object StorageUtils extends Logging{
   }
 
   def readBytes(inputStream: InputStream, bytes: Array[Byte], len: Int): Int = {
-    inputStream.read(bytes, 0 , len)
+    var count = 0
+    while (count < len) {
+      val value = inputStream.read()
+      if(value == -1 && inputStream.available() < 1) return count
+      bytes(count) = value.toByte
+      count += 1
+    }
+    count
   }
 
   def colToString(col: Any, nullValue: String = "NULL"): String = {


### PR DESCRIPTION
### What is the purpose of the change

PR #2550 There is a bug in Optimize the read efficiency of the result set, the number of rows will be lost, and you need to roll back the modification first

### Related issues/PRs

Related pr:#2550
