### PR TITLE
clear expired cookie when user login

### DIFF
--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/GatewaySSOUtils.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/GatewaySSOUtils.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.apache.linkis.gateway.security
 
 import org.apache.linkis.common.utils.{Logging, Utils}
@@ -31,18 +31,16 @@ object GatewaySSOUtils extends Logging {
   private def getCookies(gatewayContext: GatewayContext): Array[Cookie] = gatewayContext.getRequest.getCookies.flatMap(_._2).toArray
   private val DOMAIN_REGEX = "[a-zA-Z][a-zA-Z0-9\\.]+".r
   private val IP_REGEX = "([^:]+):.+".r
-
-  private val level = GatewayConfiguration.GATEWAY_DOMAIN_LEVEL.getValue
   private val cookieDomainSetupSwitch = GatewayConfiguration.GATEWAY_COOKIE_DOMAIN_SETUP_SWITCH.getValue
 
   /**
-    * "dss.com" -> "dss.com"
-    * "127.0.0.1" -> "127.0.0.1"
-    * "127.0.0.1:8080" -> "127.0.0.1"
-    * @param host the Host in HttpRequest Headers
-    * @return
-    */
-  def getCookieDomain(host: String): String = host match {
+   * "dss.com" -> "dss.com"
+   * "127.0.0.1" -> "127.0.0.1"
+   * "127.0.0.1:8080" -> "127.0.0.1"
+   * @param host the Host in HttpRequest Headers
+   * @return
+   */
+  def getCookieDomain(host: String, level: Int): String = host match {
     case DOMAIN_REGEX() =>
       val domains = host.split("\\.")
       val index = if (domains.length > level) level else if (domains.length == level) level -1 else domains.length
@@ -72,7 +70,7 @@ object GatewaySSOUtils extends Logging {
     SSOUtils.setLoginUser(c => {
       if (cookieDomainSetupSwitch) {
         val host = gatewayContext.getRequest.getHeaders.get("Host")
-        if(host != null && host.nonEmpty) c.setDomain(getCookieDomain(host.head))
+        if(host != null && host.nonEmpty) c.setDomain(getCookieDomain(host.head, GatewayConfiguration.GATEWAY_DOMAIN_LEVEL.getValue))
       }
       gatewayContext.getResponse.addCookie(c)
     }, proxyUser)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change
When the domain name of linkis gateway is switched, the logged in users will fail to authenticate most of the interfaces because they hold cookies of expired domain names.
Whenever the linkis login interface is called, the cookies in the linkis login state under all levels of domain names are cleared.


### Related issues/PRs

Related issues: #2695


### Checklist

- [✔] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [✔ ] I have explained the need for this PR and the problem it solves
- [✔ ] I have explained the changes or the new features added to this PR
- [✔ ] I have added tests corresponding to this change
- [✔] I have updated the documentation to reflect this change
- [✔ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [✔ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



