### PR TITLE
test case for python engine

### DIFF
--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/conf/PythonEngineConfiguration.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/conf/PythonEngineConfiguration.scala
@@ -23,11 +23,18 @@ import org.apache.linkis.common.conf.{CommonVars, TimeType}
 object PythonEngineConfiguration {
 
   val PYTHON_CONSOLE_OUTPUT_LINE_LIMIT = CommonVars("wds.linkis.python.line.limit", 10)
-  val PY4J_HOME = CommonVars("wds.linkis.python.py4j.home", this.getClass.getResource("/conf").getPath)
+  val PY4J_HOME = CommonVars("wds.linkis.python.py4j.home", getPy4jHome)
   val PYTHON_VERSION = CommonVars("pythonVersion", "python3")
 
   val PYTHON_PATH:CommonVars[String] = CommonVars[String]("python.path", "", "Specify Python's extra path, which only accepts shared storage paths（指定Python额外的path，该路径只接受共享存储的路径）.")
 
   val PYTHON_LANGUAGE_REPL_INIT_TIME = CommonVars[TimeType]("wds.linkis.engine.python.language-repl.init.time", new TimeType("30s"))
 
+  private def getPy4jHome(): String = {
+    val confDir = "/conf"
+    if (null !=  this.getClass.getResource(confDir)) {
+      this.getClass.getResource(confDir).getPath
+    }
+    this.getClass.getResource("/").getPath
+  }
 }

--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
@@ -24,6 +24,7 @@ import org.apache.linkis.engineconn.launch.EngineConnServer
 import org.apache.linkis.governance.common.paser.PythonCodeParser
 import org.apache.linkis.manager.common.entity.resource.{CommonNodeResource, LoadInstanceResource, NodeResource}
 import org.apache.linkis.manager.engineplugin.common.conf.EngineConnPluginConf
+import org.apache.linkis.manager.engineplugin.python.conf.PythonEngineConfiguration
 import org.apache.linkis.manager.label.entity.Label
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.rpc.Sender
@@ -45,8 +46,14 @@ class PythonEngineConnExecutor(id: Int, pythonSession: PythonSession, outputPrin
     super.init
   }
 
-  private val pythonDefaultVersion: String = EngineConnServer.getEngineCreationContext.getOptions.getOrDefault("python.version", "python")
+  private val pythonDefaultVersion: String = getPyVersion
 
+  private def getPyVersion(): String = {
+    if (null != EngineConnServer.getEngineCreationContext.getOptions) {
+      EngineConnServer.getEngineCreationContext.getOptions.getOrDefault("python.version", "python")
+    }
+    PythonEngineConfiguration.PYTHON_VERSION.getValue
+  }
   override def executeLine(engineExecutionContext: EngineExecutionContext, code: String): ExecuteResponse = {
     val pythonVersion = engineExecutionContext.getProperties.getOrDefault("python.version", pythonDefaultVersion).toString.toLowerCase()
     logger.info(s" EngineExecutionContext user python.version = > ${pythonVersion}")

--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonSession.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonSession.scala
@@ -58,8 +58,15 @@ class PythonSession extends Logging {
   private var code: String = _
   private var pid: Option[String] = None
 
-  private val pythonDefaultVersion: String = EngineConnServer.getEngineCreationContext.getOptions.getOrDefault("python.version", "python")
+  private val pythonDefaultVersion: String = getPyVersion
 
+
+  private def getPyVersion(): String = {
+    if (null != EngineConnServer.getEngineCreationContext.getOptions) {
+      EngineConnServer.getEngineCreationContext.getOptions.getOrDefault("python.version", "python")
+    }
+    PythonEngineConfiguration.PYTHON_VERSION.getValue
+  }
 
   def init(): Unit = {
 

--- a/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/TestPythonEngineConnPlugin.scala
+++ b/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/TestPythonEngineConnPlugin.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.manager.engineplugin.python
+
+import org.junit.jupiter.api.{Assertions, Test}
+
+class TestPythonEngineConnPlugin {
+  @Test
+  def testGetEngineResourceFactory: Unit = {
+    val pythonEngineConnPlugin = new PythonEngineConnPlugin
+    Assertions.assertNotNull(pythonEngineConnPlugin.getEngineConnFactory)
+  }
+}

--- a/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/conf/TestPythonEngineConfiguration.scala
+++ b/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/conf/TestPythonEngineConfiguration.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.manager.engineplugin.python.conf
+
+import org.apache.linkis.common.conf.TimeType
+import org.junit.jupiter.api.{Assertions, Test}
+
+class TestPythonEngineConfiguration {
+  @Test
+  def testConfig: Unit = {
+    Assertions.assertEquals(10, PythonEngineConfiguration.PYTHON_CONSOLE_OUTPUT_LINE_LIMIT.getValue)
+    Assertions.assertEquals("python3", PythonEngineConfiguration.PYTHON_VERSION.getValue)
+    Assertions.assertEquals(new TimeType("30s").toString, PythonEngineConfiguration.PYTHON_LANGUAGE_REPL_INIT_TIME.getValue.toString)
+    Assertions.assertEquals(this.getClass.getResource("/").getPath, PythonEngineConfiguration.PY4J_HOME.getValue)
+    Assertions.assertEquals("", PythonEngineConfiguration.PYTHON_PATH.getValue)
+  }
+}

--- a/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/exception/TestNoSupportEngineException.scala
+++ b/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/exception/TestNoSupportEngineException.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.manager.engineplugin.python.exception
+
+import org.junit.jupiter.api.{Assertions, Test}
+
+class TestNoSupportEngineException {
+  @Test
+  def testNoSupportEngineException: Unit = {
+    val errorMsg = "NoSupportEngine"
+    val exception = new NoSupportEngineException(50010, errorMsg)
+    Assertions.assertEquals(50010, exception.getErrCode)
+    Assertions.assertEquals(errorMsg, exception.getDesc)
+  }
+
+  @Test
+  def testPythonSessionStartFailedException: Unit = {
+    val errorMsg = "PythonSessionStartFailed"
+    val exception = PythonSessionStartFailedExeception(errorMsg)
+    Assertions.assertEquals(errorMsg, exception.getDesc)
+  }
+
+  @Test
+  def testPythonSessionNullException: Unit = {
+    val errorMsg = "PythonSessionNull"
+    val exception = new PythonSessionNullException(50011, errorMsg)
+    Assertions.assertEquals(50011, exception.getErrCode)
+    Assertions.assertEquals(errorMsg, exception.getDesc)
+  }
+
+
+    @Test
+  def testPythonEngineException: Unit = {
+    val errorMsg = "PythonEngine"
+    val exception = new PythonEngineException(50012, errorMsg)
+    Assertions.assertEquals(50012, exception.getErrCode)
+    Assertions.assertEquals(errorMsg, exception.getDesc)
+  }
+
+  @Test
+  def testQueryFailedException: Unit = {
+    val errorMsg = "QueryFailed"
+    val exception = new QueryFailedException(60001, errorMsg)
+    Assertions.assertEquals(60001, exception.getErrCode)
+    Assertions.assertEquals(errorMsg, exception.getDesc)
+  }
+
+    @Test
+    def testPythonExecuteError: Unit = {
+      val errorMsg = "PythonExecuteError"
+      val exception = new PythonExecuteError(60006, errorMsg)
+      Assertions.assertEquals(60006, exception.getErrCode)
+      Assertions.assertEquals(errorMsg, exception.getDesc)
+    }
+    @Test
+    def testSessionStartFailedException: Unit = {
+      val errorMsg = "SessionStartFailed"
+      val exception = new SessionStartFailedException(60002, errorMsg)
+      Assertions.assertEquals(60002, exception.getErrCode)
+      Assertions.assertEquals(errorMsg, exception.getDesc)
+    }
+    @Test
+    def testExecuteException: Unit = {
+      val errorMsg = "ExecuteException"
+      val exception = new ExecuteException(60003, errorMsg)
+      Assertions.assertEquals(60003, exception.getErrCode)
+      Assertions.assertEquals(errorMsg, exception.getDesc)
+    }
+    @Test
+    def testEngineException: Unit = {
+      val errorMsg = "EngineException"
+      val exception = new EngineException(60004, errorMsg)
+      Assertions.assertEquals(60004, exception.getErrCode)
+      Assertions.assertEquals(errorMsg, exception.getDesc)
+    }
+}

--- a/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/factory/TestPythonEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/factory/TestPythonEngineConnFactory.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.manager.engineplugin.python.factory
+
+import org.apache.linkis.engineconn.common.creation.{DefaultEngineCreationContext, EngineCreationContext}
+import org.junit.jupiter.api.{Assertions, Test}
+
+class TestPythonEngineConnFactory {
+    @Test
+    def testCreateExecutor: Unit = {
+      val engineConnFactory: PythonEngineConnFactory = new PythonEngineConnFactory
+      val engineCreationContext: EngineCreationContext = new DefaultEngineCreationContext
+      val jMap = new java.util.HashMap[String, String]()
+      jMap.put("python.version", "python3")
+      engineCreationContext.setOptions(jMap)
+      val engineConn = engineConnFactory.createEngineConn(engineCreationContext)
+      val executor = engineConnFactory.newExecutor(1, engineCreationContext, engineConn)
+      Assertions.assertNotNull(executor)
+    }
+}

--- a/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/utils/TestKind.scala
+++ b/linkis-engineconn-plugins/python/src/test/scala/org/apache/linkis/manager/engineplugin/python/utils/TestKind.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.linkis.manager.engineplugin.python.utils
+
+import org.junit.jupiter.api.{Assertions, Test}
+
+class TestKind {
+  @Test
+  def testNeedToRestart: Unit = {
+    Assertions.assertTrue(Kind.needToRestart("@restart cmd"))
+    Assertions.assertFalse(Kind.needToRestart("cmd"))
+  }
+  @Test
+  def testGetKind: Unit = {
+    Assertions.assertEquals("scala", Kind.getKind("%scala"))
+  }
+  @Test
+  def testGetRealCode: Unit = {
+    val code = "%sql \n " +
+                "show tables";
+    Assertions.assertEquals("show tables", Kind.getRealCode(code))
+    Assertions.assertEquals("cmd", Kind.getRealCode("@restart cmd"))
+  }
+
+}


### PR DESCRIPTION
add test case for python engine
python 引擎的部分测试用例，为了修改PythonEngineConfiguration 可测试性，修改 PY4J_HOME 实现，改为从方法getPy4jHome获得。修改PythonEngineConnExecutor、PythonSession 的 pythonDefaultVersion获取方式。
test case for conf exception factory utils
In order to improve the testability of the class  PythonEngineConfiguration PythonEngineConnExecutor PythonEngineConnExecutor I modified  PY4J_HOME and pythonDefaultVersion.