### PR TITLE
fix the way of getting pythonversion

### DIFF
--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/conf/PythonEngineConfiguration.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/conf/PythonEngineConfiguration.scala
@@ -24,7 +24,7 @@ object PythonEngineConfiguration {
   val PYTHON_CONSOLE_OUTPUT_LINE_LIMIT = CommonVars("wds.linkis.python.line.limit", 10)
 
   val PY4J_HOME =
-    CommonVars("wds.linkis.python.py4j.home", this.getClass.getResource("/conf").getPath)
+    CommonVars("wds.linkis.python.py4j.home", getPy4jHome)
 
   val PYTHON_VERSION = CommonVars("pythonVersion", "python3")
 
@@ -36,5 +36,14 @@ object PythonEngineConfiguration {
 
   val PYTHON_LANGUAGE_REPL_INIT_TIME =
     CommonVars[TimeType]("wds.linkis.engine.python.language-repl.init.time", new TimeType("30s"))
+
+  private def getPy4jHome(): String = {
+    val confDir = "/conf"
+    if (null != this.getClass.getResource(confDir)) {
+      this.getClass.getResource(confDir).getPath
+    } else {
+      this.getClass.getResource("/").getPath
+    }
+  }
 
 }

--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
@@ -31,6 +31,7 @@ import org.apache.linkis.manager.common.entity.resource.{
   NodeResource
 }
 import org.apache.linkis.manager.engineplugin.common.conf.EngineConnPluginConf
+import org.apache.linkis.manager.engineplugin.python.conf.PythonEngineConfiguration
 import org.apache.linkis.manager.label.entity.Label
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.rpc.Sender
@@ -54,8 +55,16 @@ class PythonEngineConnExecutor(id: Int, pythonSession: PythonSession, outputPrin
     super.init
   }
 
-  private val pythonDefaultVersion: String =
-    EngineConnServer.getEngineCreationContext.getOptions.getOrDefault("python.version", "python")
+  private val pythonDefaultVersion: String = getPyVersion
+
+  private def getPyVersion(): String = {
+    if (null != EngineConnServer.getEngineCreationContext.getOptions) {
+      EngineConnServer.getEngineCreationContext.getOptions
+        .getOrDefault("python.version", "python")
+    } else {
+      PythonEngineConfiguration.PYTHON_VERSION.getValue
+    }
+  }
 
   override def executeLine(
       engineExecutionContext: EngineExecutionContext,

--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonSession.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonSession.scala
@@ -62,8 +62,16 @@ class PythonSession extends Logging {
   private var code: String = _
   private var pid: Option[String] = None
 
-  private val pythonDefaultVersion: String =
-    EngineConnServer.getEngineCreationContext.getOptions.getOrDefault("python.version", "python")
+  private val pythonDefaultVersion: String = getPyVersion
+
+  private def getPyVersion(): String = {
+    if (null != EngineConnServer.getEngineCreationContext.getOptions) {
+      EngineConnServer.getEngineCreationContext.getOptions
+        .getOrDefault("python.version", "python")
+    } else {
+      PythonEngineConfiguration.PYTHON_VERSION.getValue
+    }
+  }
 
   def init(): Unit = {}
 


### PR DESCRIPTION
python 为了修改PythonEngineConfiguration 可测试性，修改 PY4J_HOME 实现，改为从方法getPy4jHome获得。修改PythonEngineConnExecutor、PythonSession 的 pythonDefaultVersion获取方式。