### PR TITLE
[ISSUE-2970]exclude netty-3.6.2.Final.jar dependencies

### DIFF
--- a/linkis-commons/linkis-storage/pom.xml
+++ b/linkis-commons/linkis-storage/pom.xml
@@ -43,6 +43,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/linkis-engineconn-plugins/jdbc/pom.xml
+++ b/linkis-engineconn-plugins/jdbc/pom.xml
@@ -50,6 +50,12 @@
       <artifactId>linkis-storage</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -121,6 +127,10 @@
         <exclusion>
           <groupId>org.mortbay.jetty</groupId>
           <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
 
       </exclusions>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hive/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hive/pom.xml
@@ -87,6 +87,10 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-yarn-common</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hive/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hive/pom.xml
@@ -88,8 +88,8 @@
           <artifactId>hadoop-yarn-common</artifactId>
         </exclusion>
         <exclusion>
-          <artifactId>netty</artifactId>
           <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
exclude netty-3.6.2.Final.jar dependencies
Related issue #2970 