### PR TITLE
Update dead link checker

### DIFF
--- a/.github/workflows/dlc.json
+++ b/.github/workflows/dlc.json
@@ -1,4 +1,12 @@
 {
+  "ignorePatterns": [ 
+    { 
+      "pattern": "^http://localhost" 
+    },
+    {
+      "pattern": "^http://127.0.0.1" 
+    }
+  ],
   "timeout": "10s",
   "retryOn429": true,
   "retryCount": 10,


### PR DESCRIPTION
Some links need to be skipped, such as `http://127.0.0.1`