### PR TITLE
The resultMap return type is not added to some functions in InstanceLabelMapper

### DIFF
--- a/linkis-public-enhancements/linkis-instance-label/linkis-instance-label-server/src/main/java/org/apache/linkis/instance/label/dao/impl/InstanceLabelMapper.xml
+++ b/linkis-public-enhancements/linkis-instance-label/linkis-instance-label-server/src/main/java/org/apache/linkis/instance/label/dao/impl/InstanceLabelMapper.xml
@@ -39,13 +39,13 @@
         `label_key`, `label_value`, `label_feature`,
         `label_value_size`
     </sql>
-    <select id="selectForUpdate" parameterType="Integer">
+    <select id="selectForUpdate" parameterType="Integer" resultMap="insPersistenceLabelMap">
         <![CDATA[SELECT ]]>
         <include refid="label_search_columns" />
         <![CDATA[ FROM `linkis_ps_instance_label` WHERE `id` = #{labelId} FOR UPDATE;]]>
     </select>
 
-    <select id="searchForUpdate">
+    <select id="searchForUpdate" resultMap="insPersistenceLabelMap">
         <![CDATA[SELECT ]]>
         <include refid="label_search_columns"/>
         <![CDATA[ FROM `linkis_ps_instance_label` WHERE `label_key` = #{labelKey}


### PR DESCRIPTION
The resultMap return type is not added to some functions in InstanceLabelMapper
Related issues: https://github.com/apache/incubator-linkis/issues/3290