### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 2.7.2

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/kafka/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/kafka/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 2.7.0
- [CVE-2021-38153](https://www.oscs1024.com/hd/CVE-2021-38153)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 2.7.0 to 2.7.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS