### PR TITLE
Fix writer the file is emptied by calling flush after calling the close

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/StorageResultSetWriter.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/StorageResultSetWriter.scala
@@ -59,6 +59,14 @@ class StorageResultSetWriter[K <: MetaData, V <: Record](
 
   private var proxyUser: String = StorageUtils.getJvmUser
 
+  private var fileCreated = false
+
+  private var closed = false
+
+  private val WRITER_LOCK_CREATE = new Object()
+
+  private val WRITER_LOCK_CLOSE = new Object()
+
   def getMetaData: MetaData = rMetaData
 
   def setProxyUser(proxyUser: String): Unit = {
@@ -74,16 +82,29 @@ class StorageResultSetWriter[K <: MetaData, V <: Record](
   }
 
   def createNewFile: Unit = {
-    if (storePath != null && outputStream == null) {
-      fs = FSFactory.getFsByProxyUser(storePath, proxyUser)
-      fs.init(null)
-      FileSystemUtils.createNewFile(storePath, proxyUser, true)
-      outputStream = fs.write(storePath, true)
-      logger.info(s"Succeed to create a new file:$storePath")
+    if (!fileCreated) {
+      WRITER_LOCK_CREATE.synchronized {
+        if (!fileCreated) {
+          if (storePath != null && outputStream == null) {
+            fs = FSFactory.getFsByProxyUser(storePath, proxyUser)
+            fs.init(null)
+            FileSystemUtils.createNewFile(storePath, proxyUser, true)
+            outputStream = fs.write(storePath, true)
+            logger.info(s"Succeed to create a new file:$storePath")
+            fileCreated = true
+          }
+        }
+      }
+    } else if (null != storePath && null == outputStream) {
+      logger.warn("outputStream had been set null, but createNewFile() was called again.")
     }
   }
 
   def writeLine(bytes: Array[Byte], cache: Boolean = false): Unit = {
+    if (closed) {
+      logger.warn("the writer had been closed, but writeLine() was still called.")
+      return
+    }
     if (bytes.length > LinkisStorageConf.ROW_BYTE_MAX_LEN) {
       throw new IOException(
         s"A single row of data cannot exceed ${LinkisStorageConf.ROW_BYTE_MAX_LEN_STR}"
@@ -153,6 +174,18 @@ class StorageResultSetWriter[K <: MetaData, V <: Record](
   }
 
   override def close(): Unit = {
+    if (closed) {
+      logger.warn("the writer had been closed, but close() was still called.")
+      return
+    } else {
+      WRITER_LOCK_CLOSE.synchronized {
+        if (!closed) {
+          closed = true
+        } else {
+          return
+        }
+      }
+    }
     Utils.tryFinally(if (outputStream != null) flush()) {
       closeFs
       if (outputStream != null) {
@@ -177,6 +210,11 @@ class StorageResultSetWriter[K <: MetaData, V <: Record](
             outputStream.flush()
         }
       }(s"Error encounters when flush result set ")
+    }
+    if (closed) {
+      if (logger.isDebugEnabled()) {
+        logger.debug("the writer had been closed, but flush() was still called.")
+      }
     }
   }
 


### PR DESCRIPTION
### What is the purpose of the change

After calling the close method, calling other methods should return directly and record the error log

### Related issues/PRs

Related issues: #3709

### Brief change log

- add writer's close check


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
