### PR TITLE
Performance optimization, remove the synchronization wait operation of mark cache

### DIFF
--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/org/apache/linkis/orchestrator/ecm/ComputationEngineConnManager.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/org/apache/linkis/orchestrator/ecm/ComputationEngineConnManager.scala
@@ -63,28 +63,7 @@ class ComputationEngineConnManager extends AbstractEngineConnManager with Loggin
 
   override def applyMark(markReq: MarkReq): Mark = {
     if (null == markReq) return null
-    val mark = MARK_CACHE_LOCKER.synchronized {
-      val markCache = getMarkCache().asScala.keys
-      val maybeMark = markCache.find(_.getMarkReq.equals(markReq))
-      maybeMark.orNull
-    }
-    if (null == mark) {
-      if (markReq.getLabels.containsKey(LabelKeyConstant.BIND_ENGINE_KEY)) {
-        val bindEngineLabel = MarkReq.getLabelBuilderFactory.createLabel[BindEngineLabel](
-          LabelKeyConstant.BIND_ENGINE_KEY,
-          markReq.getLabels.get(LabelKeyConstant.BIND_ENGINE_KEY)
-        )
-        if (!bindEngineLabel.getIsJobGroupHead) {
-          val msg =
-            s"Cannot find mark related to bindEngineLabel : ${bindEngineLabel.getStringValue}"
-          logger.error(msg)
-          throw new ECMPluginErrorException(ECMPluginConf.ECM_MARK_CACHE_ERROR_CODE, msg)
-        }
-      }
-      createMark(markReq)
-    } else {
-      mark
-    }
+    createMark(markReq)
   }
 
   override def createMark(markReq: MarkReq): Mark = {

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/org/apache/linkis/orchestrator/ecm/LoadBalanceLabelEngineConnManager.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/org/apache/linkis/orchestrator/ecm/LoadBalanceLabelEngineConnManager.scala
@@ -228,7 +228,7 @@ class LoadBalanceLabelEngineConnManager extends ComputationEngineConnManager wit
     }
   }
 
-  protected def getAllInstances(): Array[String] = MARK_CACHE_LOCKER.synchronized {
+  protected def getAllInstances(): Array[String] = {
     val instances = new ArrayBuffer[String]
     getMarkCache()
       .values()


### PR DESCRIPTION
### What is the purpose of the change

Performance optimization, remove the synchronization wait operation of mark cache
remove synchronization wait
### Related issues/PRs

Related issues: #3717


### Brief change log

- Remove synchronization wait


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
