### PR TITLE
[ISSUE-2442][linkis-basedata-manager] engine config template manage

### DIFF
--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/CgManagerLabelMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/CgManagerLabelMapper.java
@@ -1,8 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.dao;
 
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.linkis.basedatamanager.server.domain.CgManagerLabel;
 
-public interface CgManagerLabelMapper extends BaseMapper<CgManagerLabel> {
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 
-}
+public interface CgManagerLabelMapper extends BaseMapper<CgManagerLabel> {}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/CgManagerLabelMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/CgManagerLabelMapper.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,10 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.dao;
 
 import org.apache.linkis.basedatamanager.server.domain.CgManagerLabel;
 
+import java.util.List;
+
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 
-public interface CgManagerLabelMapper extends BaseMapper<CgManagerLabel> {}
+public interface CgManagerLabelMapper extends BaseMapper<CgManagerLabel> {
+  /**
+   * query a engine label list
+   *
+   * @return List
+   */
+  List<CgManagerLabel> getEngineList();
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/CgManagerLabelMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/CgManagerLabelMapper.java
@@ -1,0 +1,8 @@
+package org.apache.linkis.basedatamanager.server.dao;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.linkis.basedatamanager.server.domain.CgManagerLabel;
+
+public interface CgManagerLabelMapper extends BaseMapper<CgManagerLabel> {
+
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigKeyMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigKeyMapper.java
@@ -1,0 +1,8 @@
+package org.apache.linkis.basedatamanager.server.dao;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
+
+public interface ConfigurationConfigKeyMapper extends BaseMapper<ConfigurationConfigKey> {
+
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigKeyMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigKeyMapper.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,10 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.dao;
 
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
 
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 
-public interface ConfigurationConfigKeyMapper extends BaseMapper<ConfigurationConfigKey> {}
+public interface ConfigurationConfigKeyMapper extends BaseMapper<ConfigurationConfigKey> {
+  /**
+   * query config key list by engine label id
+   *
+   * @param engineLabelId engine label id
+   * @return List
+   */
+  List<ConfigurationConfigKey> getTemplateListByLabelId(
+      @Param("engineLabelId") String engineLabelId);
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigKeyMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigKeyMapper.java
@@ -1,8 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.dao;
 
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
 
-public interface ConfigurationConfigKeyMapper extends BaseMapper<ConfigurationConfigKey> {
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 
-}
+public interface ConfigurationConfigKeyMapper extends BaseMapper<ConfigurationConfigKey> {}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigValueMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigValueMapper.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.dao;
 
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigValue;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigValueMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigValueMapper.java
@@ -1,0 +1,12 @@
+package org.apache.linkis.basedatamanager.server.dao;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigValue;
+
+public interface ConfigurationConfigValueMapper extends BaseMapper<ConfigurationConfigValue> {
+
+    int updateByKeyId(@Param("configValue") ConfigurationConfigValue configValue);
+
+    int deleteByKeyId(@Param("keyId") Long keyId);
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigValueMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationConfigValueMapper.java
@@ -1,12 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.dao;
 
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import org.apache.ibatis.annotations.Param;
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigValue;
+
+import org.apache.ibatis.annotations.Param;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 
 public interface ConfigurationConfigValueMapper extends BaseMapper<ConfigurationConfigValue> {
 
-    int updateByKeyId(@Param("configValue") ConfigurationConfigValue configValue);
+  int updateByKeyId(@Param("configValue") ConfigurationConfigValue configValue);
 
-    int deleteByKeyId(@Param("keyId") Long keyId);
+  int deleteByKeyId(@Param("keyId") Long keyId);
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationKeyEngineRelationMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationKeyEngineRelationMapper.java
@@ -1,10 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.dao;
 
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import org.apache.ibatis.annotations.Param;
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationKeyEngineRelation;
 
-public interface ConfigurationKeyEngineRelationMapper extends BaseMapper<ConfigurationKeyEngineRelation> {
+import org.apache.ibatis.annotations.Param;
 
-    int deleteByKeyId(@Param("keyId") Long keyId);
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+public interface ConfigurationKeyEngineRelationMapper
+    extends BaseMapper<ConfigurationKeyEngineRelation> {
+
+  int deleteByKeyId(@Param("keyId") Long keyId);
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationKeyEngineRelationMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationKeyEngineRelationMapper.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.dao;
 
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationKeyEngineRelation;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationKeyEngineRelationMapper.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/ConfigurationKeyEngineRelationMapper.java
@@ -1,0 +1,10 @@
+package org.apache.linkis.basedatamanager.server.dao;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationKeyEngineRelation;
+
+public interface ConfigurationKeyEngineRelationMapper extends BaseMapper<ConfigurationKeyEngineRelation> {
+
+    int deleteByKeyId(@Param("keyId") Long keyId);
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/CgManagerLabelMapper.xml
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/CgManagerLabelMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.linkis.basedatamanager.server.dao.CgManagerLabelMapper">
+
+</mapper>

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/CgManagerLabelMapper.xml
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/CgManagerLabelMapper.xml
@@ -17,5 +17,10 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.apache.linkis.basedatamanager.server.dao.CgManagerLabelMapper">
-
+    <!-- query a engine label list -->
+    <select id="getEngineList" resultType="org.apache.linkis.basedatamanager.server.domain.CgManagerLabel">
+        select a.id, a.label_key, a.label_value, a.label_feature
+        from linkis_cg_manager_label a
+        where a.label_value like '*_*,%';
+    </select>
 </mapper>

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationConfigKeyMapper.xml
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationConfigKeyMapper.xml
@@ -17,5 +17,25 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.apache.linkis.basedatamanager.server.dao.ConfigurationConfigKeyMapper">
-
+    <!-- query config key list by engine label id -->
+    <select id="getTemplateListByLabelId"
+            resultType="org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey"
+            parameterType="java.lang.String">
+        select k.id,
+               k.`key`,
+               k.description,
+               k.`name`,
+               k.default_value,
+               k.validate_type,
+               k.validate_range,
+               k.engine_conn_type,
+               k.is_hidden   hidden,
+               k.is_advanced advanced,
+               k.`level`,
+               k.treeName
+        from linkis_ps_configuration_config_key k
+                 inner join linkis_ps_configuration_key_engine_relation r
+                            on k.id = r.config_key_id
+        where r.engine_type_label_id = #{engineLabelId};
+    </select>
 </mapper>

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationConfigKeyMapper.xml
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationConfigKeyMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.linkis.basedatamanager.server.dao.ConfigurationConfigKeyMapper">
+
+</mapper>

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationConfigValueMapper.xml
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationConfigValueMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.linkis.basedatamanager.server.dao.ConfigurationConfigValueMapper">
+
+    <update id="updateByKeyId"
+            parameterType="org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigValue">
+        update linkis_ps_configuration_config_value
+        set config_value = #{configValue.configValue}
+        where config_key_id = #{configValue.configKeyId}
+    </update>
+    <delete id="deleteByKeyId" parameterType="java.lang.Long">
+        delete
+        from linkis_ps_configuration_config_value
+        where config_key_id = #{keyId}
+    </delete>
+</mapper>

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationKeyEngineRelationMapper.xml
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/dao/mapper/ConfigurationKeyEngineRelationMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.linkis.basedatamanager.server.dao.ConfigurationKeyEngineRelationMapper">
+
+    <delete id="deleteByKeyId" parameterType="java.lang.Long">
+        delete
+        from linkis_ps_configuration_key_engine_relation
+        where config_key_id = #{keyId}
+    </delete>
+</mapper>

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/CgManagerLabel.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/CgManagerLabel.java
@@ -1,0 +1,96 @@
+package org.apache.linkis.basedatamanager.server.domain;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@TableName("linkis_cg_manager_label")
+public class CgManagerLabel implements Serializable {
+
+    @TableId(value = "id", type = IdType.AUTO)
+    private Integer id;
+
+    private String labelKey;
+
+    private String labelValue;
+
+    private String labelFeature;
+
+    private Integer labelValueSize;
+
+    private LocalDateTime updateTime;
+
+    private LocalDateTime createTime;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getLabelKey() {
+        return labelKey;
+    }
+
+    public void setLabelKey(String labelKey) {
+        this.labelKey = labelKey;
+    }
+
+    public String getLabelValue() {
+        return labelValue;
+    }
+
+    public void setLabelValue(String labelValue) {
+        this.labelValue = labelValue;
+    }
+
+    public String getLabelFeature() {
+        return labelFeature;
+    }
+
+    public void setLabelFeature(String labelFeature) {
+        this.labelFeature = labelFeature;
+    }
+
+    public Integer getLabelValueSize() {
+        return labelValueSize;
+    }
+
+    public void setLabelValueSize(Integer labelValueSize) {
+        this.labelValueSize = labelValueSize;
+    }
+
+    public LocalDateTime getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(LocalDateTime updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public LocalDateTime getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(LocalDateTime createTime) {
+        this.createTime = createTime;
+    }
+
+    @Override
+    public String toString() {
+        return "LinkisCgManagerLabel{" +
+                "id=" + id +
+                ", labelKey=" + labelKey +
+                ", labelValue=" + labelValue +
+                ", labelFeature=" + labelFeature +
+                ", labelValueSize=" + labelValueSize +
+                ", updateTime=" + updateTime +
+                ", createTime=" + createTime +
+                "}";
+    }
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/CgManagerLabel.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/CgManagerLabel.java
@@ -1,96 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.domain;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
 
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 
-import java.io.Serializable;
-import java.time.LocalDateTime;
-
 @TableName("linkis_cg_manager_label")
 public class CgManagerLabel implements Serializable {
 
-    @TableId(value = "id", type = IdType.AUTO)
-    private Integer id;
+  @TableId(value = "id", type = IdType.AUTO)
+  private Integer id;
 
-    private String labelKey;
+  private String labelKey;
 
-    private String labelValue;
+  private String labelValue;
 
-    private String labelFeature;
+  private String labelFeature;
 
-    private Integer labelValueSize;
+  private Integer labelValueSize;
 
-    private LocalDateTime updateTime;
+  private LocalDateTime updateTime;
 
-    private LocalDateTime createTime;
+  private LocalDateTime createTime;
 
-    public Integer getId() {
-        return id;
-    }
+  public Integer getId() {
+    return id;
+  }
 
-    public void setId(Integer id) {
-        this.id = id;
-    }
+  public void setId(Integer id) {
+    this.id = id;
+  }
 
-    public String getLabelKey() {
-        return labelKey;
-    }
+  public String getLabelKey() {
+    return labelKey;
+  }
 
-    public void setLabelKey(String labelKey) {
-        this.labelKey = labelKey;
-    }
+  public void setLabelKey(String labelKey) {
+    this.labelKey = labelKey;
+  }
 
-    public String getLabelValue() {
-        return labelValue;
-    }
+  public String getLabelValue() {
+    return labelValue;
+  }
 
-    public void setLabelValue(String labelValue) {
-        this.labelValue = labelValue;
-    }
+  public void setLabelValue(String labelValue) {
+    this.labelValue = labelValue;
+  }
 
-    public String getLabelFeature() {
-        return labelFeature;
-    }
+  public String getLabelFeature() {
+    return labelFeature;
+  }
 
-    public void setLabelFeature(String labelFeature) {
-        this.labelFeature = labelFeature;
-    }
+  public void setLabelFeature(String labelFeature) {
+    this.labelFeature = labelFeature;
+  }
 
-    public Integer getLabelValueSize() {
-        return labelValueSize;
-    }
+  public Integer getLabelValueSize() {
+    return labelValueSize;
+  }
 
-    public void setLabelValueSize(Integer labelValueSize) {
-        this.labelValueSize = labelValueSize;
-    }
+  public void setLabelValueSize(Integer labelValueSize) {
+    this.labelValueSize = labelValueSize;
+  }
 
-    public LocalDateTime getUpdateTime() {
-        return updateTime;
-    }
+  public LocalDateTime getUpdateTime() {
+    return updateTime;
+  }
 
-    public void setUpdateTime(LocalDateTime updateTime) {
-        this.updateTime = updateTime;
-    }
+  public void setUpdateTime(LocalDateTime updateTime) {
+    this.updateTime = updateTime;
+  }
 
-    public LocalDateTime getCreateTime() {
-        return createTime;
-    }
+  public LocalDateTime getCreateTime() {
+    return createTime;
+  }
 
-    public void setCreateTime(LocalDateTime createTime) {
-        this.createTime = createTime;
-    }
+  public void setCreateTime(LocalDateTime createTime) {
+    this.createTime = createTime;
+  }
 
-    @Override
-    public String toString() {
-        return "LinkisCgManagerLabel{" +
-                "id=" + id +
-                ", labelKey=" + labelKey +
-                ", labelValue=" + labelValue +
-                ", labelFeature=" + labelFeature +
-                ", labelValueSize=" + labelValueSize +
-                ", updateTime=" + updateTime +
-                ", createTime=" + createTime +
-                "}";
-    }
+  @Override
+  public String toString() {
+    return "LinkisCgManagerLabel{"
+        + "id="
+        + id
+        + ", labelKey="
+        + labelKey
+        + ", labelValue="
+        + labelValue
+        + ", labelFeature="
+        + labelFeature
+        + ", labelValueSize="
+        + labelValueSize
+        + ", updateTime="
+        + updateTime
+        + ", createTime="
+        + createTime
+        + "}";
+  }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/CgManagerLabel.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/CgManagerLabel.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.domain;
 
 import java.io.Serializable;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigKey.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigKey.java
@@ -1,138 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.domain;
+
+import java.io.Serializable;
 
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 
-import java.io.Serializable;
-
 @TableName("linkis_ps_configuration_config_key")
 public class ConfigurationConfigKey implements Serializable {
 
-    @TableId(value = "id", type = IdType.AUTO)
-    private Long id;
+  @TableId(value = "id", type = IdType.AUTO)
+  private Long id;
 
-    @TableField("`key`")
-    private String key;
+  @TableField("`key`")
+  private String key;
 
-    private String description;
+  private String description;
 
-    private String name;
+  private String name;
 
-    private String defaultValue;
+  private String defaultValue;
 
-    private String validateType;
+  private String validateType;
 
-    private String validateRange;
+  private String validateRange;
 
-    private String engineConnType;
+  private String engineConnType;
 
-    @TableField("is_hidden")
-    private Integer hidden;
+  @TableField("is_hidden")
+  private Integer hidden;
 
-    @TableField("is_advanced")
-    private Integer advanced;
+  @TableField("is_advanced")
+  private Integer advanced;
 
-    @TableField("`level`")
-    private Integer level;
+  @TableField("`level`")
+  private Integer level;
 
-    @TableField("treeName")
-    private String treeName;
+  @TableField("treeName")
+  private String treeName;
 
-    public Long getId() {
-        return id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+  public void setId(Long id) {
+    this.id = id;
+  }
 
-    public String getKey() {
-        return key;
-    }
+  public String getKey() {
+    return key;
+  }
 
-    public void setKey(String key) {
-        this.key = key;
-    }
+  public void setKey(String key) {
+    this.key = key;
+  }
 
-    public String getDescription() {
-        return description;
-    }
+  public String getDescription() {
+    return description;
+  }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public String getDefaultValue() {
-        return defaultValue;
-    }
+  public String getDefaultValue() {
+    return defaultValue;
+  }
 
-    public void setDefaultValue(String defaultValue) {
-        this.defaultValue = defaultValue;
-    }
+  public void setDefaultValue(String defaultValue) {
+    this.defaultValue = defaultValue;
+  }
 
-    public String getValidateType() {
-        return validateType;
-    }
+  public String getValidateType() {
+    return validateType;
+  }
 
-    public void setValidateType(String validateType) {
-        this.validateType = validateType;
-    }
+  public void setValidateType(String validateType) {
+    this.validateType = validateType;
+  }
 
-    public String getValidateRange() {
-        return validateRange;
-    }
+  public String getValidateRange() {
+    return validateRange;
+  }
 
-    public void setValidateRange(String validateRange) {
-        this.validateRange = validateRange;
-    }
+  public void setValidateRange(String validateRange) {
+    this.validateRange = validateRange;
+  }
 
-    public String getEngineConnType() {
-        return engineConnType;
-    }
+  public String getEngineConnType() {
+    return engineConnType;
+  }
 
-    public void setEngineConnType(String engineConnType) {
-        this.engineConnType = engineConnType;
-    }
+  public void setEngineConnType(String engineConnType) {
+    this.engineConnType = engineConnType;
+  }
 
-    public Integer getHidden() {
-        return hidden;
-    }
+  public Integer getHidden() {
+    return hidden;
+  }
 
-    public void setHidden(Integer hidden) {
-        this.hidden = hidden;
-    }
+  public void setHidden(Integer hidden) {
+    this.hidden = hidden;
+  }
 
-    public Integer getAdvanced() {
-        return advanced;
-    }
+  public Integer getAdvanced() {
+    return advanced;
+  }
 
-    public void setAdvanced(Integer advanced) {
-        this.advanced = advanced;
-    }
+  public void setAdvanced(Integer advanced) {
+    this.advanced = advanced;
+  }
 
-    public Integer getLevel() {
-        return level;
-    }
+  public Integer getLevel() {
+    return level;
+  }
 
-    public void setLevel(Integer level) {
-        this.level = level;
-    }
+  public void setLevel(Integer level) {
+    this.level = level;
+  }
 
-    public String getTreeName() {
-        return treeName;
-    }
+  public String getTreeName() {
+    return treeName;
+  }
 
-    public void setTreeName(String treeName) {
-        this.treeName = treeName;
-    }
+  public void setTreeName(String treeName) {
+    this.treeName = treeName;
+  }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigKey.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigKey.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.domain;
 
 import java.io.Serializable;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigKey.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigKey.java
@@ -1,0 +1,138 @@
+package org.apache.linkis.basedatamanager.server.domain;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serializable;
+
+@TableName("linkis_ps_configuration_config_key")
+public class ConfigurationConfigKey implements Serializable {
+
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    @TableField("`key`")
+    private String key;
+
+    private String description;
+
+    private String name;
+
+    private String defaultValue;
+
+    private String validateType;
+
+    private String validateRange;
+
+    private String engineConnType;
+
+    @TableField("is_hidden")
+    private Integer hidden;
+
+    @TableField("is_advanced")
+    private Integer advanced;
+
+    @TableField("`level`")
+    private Integer level;
+
+    @TableField("treeName")
+    private String treeName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getValidateType() {
+        return validateType;
+    }
+
+    public void setValidateType(String validateType) {
+        this.validateType = validateType;
+    }
+
+    public String getValidateRange() {
+        return validateRange;
+    }
+
+    public void setValidateRange(String validateRange) {
+        this.validateRange = validateRange;
+    }
+
+    public String getEngineConnType() {
+        return engineConnType;
+    }
+
+    public void setEngineConnType(String engineConnType) {
+        this.engineConnType = engineConnType;
+    }
+
+    public Integer getHidden() {
+        return hidden;
+    }
+
+    public void setHidden(Integer hidden) {
+        this.hidden = hidden;
+    }
+
+    public Integer getAdvanced() {
+        return advanced;
+    }
+
+    public void setAdvanced(Integer advanced) {
+        this.advanced = advanced;
+    }
+
+    public Integer getLevel() {
+        return level;
+    }
+
+    public void setLevel(Integer level) {
+        this.level = level;
+    }
+
+    public String getTreeName() {
+        return treeName;
+    }
+
+    public void setTreeName(String treeName) {
+        this.treeName = treeName;
+    }
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigValue.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigValue.java
@@ -1,75 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.domain;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
 
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 
-import java.io.Serializable;
-import java.time.LocalDateTime;
-
 @TableName("linkis_ps_configuration_config_value")
 public class ConfigurationConfigValue implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    @TableId(value = "id", type = IdType.AUTO)
-    private Long id;
+  @TableId(value = "id", type = IdType.AUTO)
+  private Long id;
 
-    private Long configKeyId;
+  private Long configKeyId;
 
-    private String configValue;
+  private String configValue;
 
-    private Integer configLabelId;
+  private Integer configLabelId;
 
-    private LocalDateTime updateTime;
+  private LocalDateTime updateTime;
 
-    private LocalDateTime createTime;
+  private LocalDateTime createTime;
 
-    public Long getId() {
-        return id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+  public void setId(Long id) {
+    this.id = id;
+  }
 
-    public Long getConfigKeyId() {
-        return configKeyId;
-    }
+  public Long getConfigKeyId() {
+    return configKeyId;
+  }
 
-    public void setConfigKeyId(Long configKeyId) {
-        this.configKeyId = configKeyId;
-    }
+  public void setConfigKeyId(Long configKeyId) {
+    this.configKeyId = configKeyId;
+  }
 
-    public String getConfigValue() {
-        return configValue;
-    }
+  public String getConfigValue() {
+    return configValue;
+  }
 
-    public void setConfigValue(String configValue) {
-        this.configValue = configValue;
-    }
+  public void setConfigValue(String configValue) {
+    this.configValue = configValue;
+  }
 
-    public Integer getConfigLabelId() {
-        return configLabelId;
-    }
+  public Integer getConfigLabelId() {
+    return configLabelId;
+  }
 
-    public void setConfigLabelId(Integer configLabelId) {
-        this.configLabelId = configLabelId;
-    }
+  public void setConfigLabelId(Integer configLabelId) {
+    this.configLabelId = configLabelId;
+  }
 
-    public LocalDateTime getUpdateTime() {
-        return updateTime;
-    }
+  public LocalDateTime getUpdateTime() {
+    return updateTime;
+  }
 
-    public void setUpdateTime(LocalDateTime updateTime) {
-        this.updateTime = updateTime;
-    }
+  public void setUpdateTime(LocalDateTime updateTime) {
+    this.updateTime = updateTime;
+  }
 
-    public LocalDateTime getCreateTime() {
-        return createTime;
-    }
+  public LocalDateTime getCreateTime() {
+    return createTime;
+  }
 
-    public void setCreateTime(LocalDateTime createTime) {
-        this.createTime = createTime;
-    }
+  public void setCreateTime(LocalDateTime createTime) {
+    this.createTime = createTime;
+  }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigValue.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigValue.java
@@ -1,0 +1,75 @@
+package org.apache.linkis.basedatamanager.server.domain;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@TableName("linkis_ps_configuration_config_value")
+public class ConfigurationConfigValue implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    private Long configKeyId;
+
+    private String configValue;
+
+    private Integer configLabelId;
+
+    private LocalDateTime updateTime;
+
+    private LocalDateTime createTime;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getConfigKeyId() {
+        return configKeyId;
+    }
+
+    public void setConfigKeyId(Long configKeyId) {
+        this.configKeyId = configKeyId;
+    }
+
+    public String getConfigValue() {
+        return configValue;
+    }
+
+    public void setConfigValue(String configValue) {
+        this.configValue = configValue;
+    }
+
+    public Integer getConfigLabelId() {
+        return configLabelId;
+    }
+
+    public void setConfigLabelId(Integer configLabelId) {
+        this.configLabelId = configLabelId;
+    }
+
+    public LocalDateTime getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(LocalDateTime updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public LocalDateTime getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(LocalDateTime createTime) {
+        this.createTime = createTime;
+    }
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigValue.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationConfigValue.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.domain;
 
 import java.io.Serializable;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationKeyEngineRelation.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationKeyEngineRelation.java
@@ -1,0 +1,44 @@
+package org.apache.linkis.basedatamanager.server.domain;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serializable;
+
+@TableName("linkis_ps_configuration_key_engine_relation")
+public class ConfigurationKeyEngineRelation implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    private Long configKeyId;
+
+    private Long engineTypeLabelId;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getConfigKeyId() {
+        return configKeyId;
+    }
+
+    public void setConfigKeyId(Long configKeyId) {
+        this.configKeyId = configKeyId;
+    }
+
+    public Long getEngineTypeLabelId() {
+        return engineTypeLabelId;
+    }
+
+    public void setEngineTypeLabelId(Long engineTypeLabelId) {
+        this.engineTypeLabelId = engineTypeLabelId;
+    }
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationKeyEngineRelation.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationKeyEngineRelation.java
@@ -1,44 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.domain;
+
+import java.io.Serializable;
 
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 
-import java.io.Serializable;
-
 @TableName("linkis_ps_configuration_key_engine_relation")
 public class ConfigurationKeyEngineRelation implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    @TableId(value = "id", type = IdType.AUTO)
-    private Long id;
+  @TableId(value = "id", type = IdType.AUTO)
+  private Long id;
 
-    private Long configKeyId;
+  private Long configKeyId;
 
-    private Long engineTypeLabelId;
+  private Long engineTypeLabelId;
 
-    public Long getId() {
-        return id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+  public void setId(Long id) {
+    this.id = id;
+  }
 
-    public Long getConfigKeyId() {
-        return configKeyId;
-    }
+  public Long getConfigKeyId() {
+    return configKeyId;
+  }
 
-    public void setConfigKeyId(Long configKeyId) {
-        this.configKeyId = configKeyId;
-    }
+  public void setConfigKeyId(Long configKeyId) {
+    this.configKeyId = configKeyId;
+  }
 
-    public Long getEngineTypeLabelId() {
-        return engineTypeLabelId;
-    }
+  public Long getEngineTypeLabelId() {
+    return engineTypeLabelId;
+  }
 
-    public void setEngineTypeLabelId(Long engineTypeLabelId) {
-        this.engineTypeLabelId = engineTypeLabelId;
-    }
+  public void setEngineTypeLabelId(Long engineTypeLabelId) {
+    this.engineTypeLabelId = engineTypeLabelId;
+  }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationKeyEngineRelation.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/domain/ConfigurationKeyEngineRelation.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.domain;
 
 import java.io.Serializable;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
@@ -1,157 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.request;
+
+import java.io.Serializable;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-import java.io.Serializable;
-
-/**
- * A query request for the save a configuration template
- */
-@ApiModel(value = "configuration template save request", description = "configuration template save request")
+/** A query request for the save a configuration template */
+@ApiModel(
+    value = "configuration template save request",
+    description = "configuration template save request")
 public class ConfigurationTemplateSaveRequest implements Serializable {
-    private static final long serialVersionUID = -5910138059732157333L;
+  private static final long serialVersionUID = -5910138059732157333L;
 
-    @ApiModelProperty(value = "key id.")
-    private Long id;
+  @ApiModelProperty(value = "key id.")
+  private Long id;
 
-    @ApiModelProperty(value = "category name. eg: openlookeng-1.5.0")
-    private String categoryName;
+  @ApiModelProperty(value = "category name. eg: openlookeng-1.5.0")
+  private String categoryName;
 
-    @ApiModelProperty(value = "key. eg: linkis.openlookeng.url")
-    private String key;
+  @ApiModelProperty(value = "key. eg: linkis.openlookeng.url")
+  private String key;
 
-    @ApiModelProperty(value = "description. eg: 例如:http://127.0.0.1:8080")
-    private String description;
+  @ApiModelProperty(value = "description. eg: 例如:http://127.0.0.1:8080")
+  private String description;
 
-    @ApiModelProperty(value = "name. eg: 连接地址")
-    private String name;
+  @ApiModelProperty(value = "name. eg: 连接地址")
+  private String name;
 
-    @ApiModelProperty(value = "default value. eg: http://127.0.0.1:8080")
-    private String defaultValue;
+  @ApiModelProperty(value = "default value. eg: http://127.0.0.1:8080")
+  private String defaultValue;
 
-    @ApiModelProperty(value = "validate type. eg: Regex")
-    private String validateType;
+  @ApiModelProperty(value = "validate type. eg: Regex")
+  private String validateType;
 
-    @ApiModelProperty(value = "validate range. eg: ^\\\\s*http://([^:]+)(:\\\\d+)(/[^\\\\?]+)?(\\\\?\\\\S*)?$")
-    private String validateRange;
+  @ApiModelProperty(
+      value = "validate range. eg: ^\\\\s*http://([^:]+)(:\\\\d+)(/[^\\\\?]+)?(\\\\?\\\\S*)?$")
+  private String validateRange;
 
-    @ApiModelProperty(value = "engine conn type. eg: openlookeng")
-    private String engineConnType;
+  @ApiModelProperty(value = "engine conn type. eg: openlookeng")
+  private String engineConnType;
 
-    @ApiModelProperty(value = "is hidden. eg: 0-否，1-是")
-    private Integer hidden;
+  @ApiModelProperty(value = "is hidden. eg: 0-否，1-是")
+  private Integer hidden;
 
-    @ApiModelProperty(value = "is advanced. eg: 0-否，1-是")
-    private Integer advanced;
+  @ApiModelProperty(value = "is advanced. eg: 0-否，1-是")
+  private Integer advanced;
 
-    @ApiModelProperty(value = "level. eg: 1-一级，2-二级")
-    private Integer level;
+  @ApiModelProperty(value = "level. eg: 1-一级，2-二级")
+  private Integer level;
 
-    @ApiModelProperty(value = "tree name. eg: 数据源配置")
-    private String treeName;
+  @ApiModelProperty(value = "tree name. eg: 数据源配置")
+  private String treeName;
 
-    public Long getId() {
-        return id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+  public void setId(Long id) {
+    this.id = id;
+  }
 
-    public String getCategoryName() {
-        return categoryName;
-    }
+  public String getCategoryName() {
+    return categoryName;
+  }
 
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
-    }
+  public void setCategoryName(String categoryName) {
+    this.categoryName = categoryName;
+  }
 
-    public String getKey() {
-        return key;
-    }
+  public String getKey() {
+    return key;
+  }
 
-    public void setKey(String key) {
-        this.key = key;
-    }
+  public void setKey(String key) {
+    this.key = key;
+  }
 
-    public String getDescription() {
-        return description;
-    }
+  public String getDescription() {
+    return description;
+  }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public String getDefaultValue() {
-        return defaultValue;
-    }
+  public String getDefaultValue() {
+    return defaultValue;
+  }
 
-    public void setDefaultValue(String defaultValue) {
-        this.defaultValue = defaultValue;
-    }
+  public void setDefaultValue(String defaultValue) {
+    this.defaultValue = defaultValue;
+  }
 
-    public String getValidateType() {
-        return validateType;
-    }
+  public String getValidateType() {
+    return validateType;
+  }
 
-    public void setValidateType(String validateType) {
-        this.validateType = validateType;
-    }
+  public void setValidateType(String validateType) {
+    this.validateType = validateType;
+  }
 
-    public String getValidateRange() {
-        return validateRange;
-    }
+  public String getValidateRange() {
+    return validateRange;
+  }
 
-    public void setValidateRange(String validateRange) {
-        this.validateRange = validateRange;
-    }
+  public void setValidateRange(String validateRange) {
+    this.validateRange = validateRange;
+  }
 
-    public String getEngineConnType() {
-        return engineConnType;
-    }
+  public String getEngineConnType() {
+    return engineConnType;
+  }
 
-    public void setEngineConnType(String engineConnType) {
-        this.engineConnType = engineConnType;
-    }
+  public void setEngineConnType(String engineConnType) {
+    this.engineConnType = engineConnType;
+  }
 
-    public Integer getHidden() {
-        return hidden;
-    }
+  public Integer getHidden() {
+    return hidden;
+  }
 
-    public void setHidden(Integer hidden) {
-        this.hidden = hidden;
-    }
+  public void setHidden(Integer hidden) {
+    this.hidden = hidden;
+  }
 
-    public Integer getAdvanced() {
-        return advanced;
-    }
+  public Integer getAdvanced() {
+    return advanced;
+  }
 
-    public void setAdvanced(Integer advanced) {
-        this.advanced = advanced;
-    }
+  public void setAdvanced(Integer advanced) {
+    this.advanced = advanced;
+  }
 
-    public Integer getLevel() {
-        return level;
-    }
+  public Integer getLevel() {
+    return level;
+  }
 
-    public void setLevel(Integer level) {
-        this.level = level;
-    }
+  public void setLevel(Integer level) {
+    this.level = level;
+  }
 
-    public String getTreeName() {
-        return treeName;
-    }
+  public String getTreeName() {
+    return treeName;
+  }
 
-    public void setTreeName(String treeName) {
-        this.treeName = treeName;
-    }
+  public void setTreeName(String treeName) {
+    this.treeName = treeName;
+  }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
@@ -1,0 +1,157 @@
+package org.apache.linkis.basedatamanager.server.request;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.io.Serializable;
+
+/**
+ * A query request for the save a configuration template
+ */
+@ApiModel(value = "configuration template save request", description = "configuration template save request")
+public class ConfigurationTemplateSaveRequest implements Serializable {
+    private static final long serialVersionUID = -5910138059732157333L;
+
+    @ApiModelProperty(value = "key id.")
+    private Long id;
+
+    @ApiModelProperty(value = "category name. eg: openlookeng-1.5.0")
+    private String categoryName;
+
+    @ApiModelProperty(value = "key. eg: linkis.openlookeng.url")
+    private String key;
+
+    @ApiModelProperty(value = "description. eg: 例如:http://127.0.0.1:8080")
+    private String description;
+
+    @ApiModelProperty(value = "name. eg: 连接地址")
+    private String name;
+
+    @ApiModelProperty(value = "default value. eg: http://127.0.0.1:8080")
+    private String defaultValue;
+
+    @ApiModelProperty(value = "validate type. eg: Regex")
+    private String validateType;
+
+    @ApiModelProperty(value = "validate range. eg: ^\\\\s*http://([^:]+)(:\\\\d+)(/[^\\\\?]+)?(\\\\?\\\\S*)?$")
+    private String validateRange;
+
+    @ApiModelProperty(value = "engine conn type. eg: openlookeng")
+    private String engineConnType;
+
+    @ApiModelProperty(value = "is hidden. eg: 0-否，1-是")
+    private Integer hidden;
+
+    @ApiModelProperty(value = "is advanced. eg: 0-否，1-是")
+    private Integer advanced;
+
+    @ApiModelProperty(value = "level. eg: 1-一级，2-二级")
+    private Integer level;
+
+    @ApiModelProperty(value = "tree name. eg: 数据源配置")
+    private String treeName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getValidateType() {
+        return validateType;
+    }
+
+    public void setValidateType(String validateType) {
+        this.validateType = validateType;
+    }
+
+    public String getValidateRange() {
+        return validateRange;
+    }
+
+    public void setValidateRange(String validateRange) {
+        this.validateRange = validateRange;
+    }
+
+    public String getEngineConnType() {
+        return engineConnType;
+    }
+
+    public void setEngineConnType(String engineConnType) {
+        this.engineConnType = engineConnType;
+    }
+
+    public Integer getHidden() {
+        return hidden;
+    }
+
+    public void setHidden(Integer hidden) {
+        this.hidden = hidden;
+    }
+
+    public Integer getAdvanced() {
+        return advanced;
+    }
+
+    public void setAdvanced(Integer advanced) {
+        this.advanced = advanced;
+    }
+
+    public Integer getLevel() {
+        return level;
+    }
+
+    public void setLevel(Integer level) {
+        this.level = level;
+    }
+
+    public String getTreeName() {
+        return treeName;
+    }
+
+    public void setTreeName(String treeName) {
+        this.treeName = treeName;
+    }
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
@@ -32,8 +32,8 @@ public class ConfigurationTemplateSaveRequest implements Serializable {
   @ApiModelProperty(value = "key id.")
   private Long id;
 
-  @ApiModelProperty(value = "category name. eg: openlookeng-1.5.0")
-  private String categoryName;
+  @ApiModelProperty(value = "engineLabelId.")
+  private String engineLabelId;
 
   @ApiModelProperty(value = "key. eg: linkis.openlookeng.url")
   private String key;
@@ -77,12 +77,12 @@ public class ConfigurationTemplateSaveRequest implements Serializable {
     this.id = id;
   }
 
-  public String getCategoryName() {
-    return categoryName;
+  public String getEngineLabelId() {
+    return engineLabelId;
   }
 
-  public void setCategoryName(String categoryName) {
-    this.categoryName = categoryName;
+  public void setEngineLabelId(String engineLabelId) {
+    this.engineLabelId = engineLabelId;
   }
 
   public String getKey() {

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/request/ConfigurationTemplateSaveRequest.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.request;
 
 import java.io.Serializable;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/response/EngineLabelResponse.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/response/EngineLabelResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.basedatamanager.server.response;
+
+import java.io.Serializable;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+/** A response of engine label list query */
+@ApiModel(value = "engine list response", description = "A response of engine label list query")
+public class EngineLabelResponse implements Serializable {
+  private static final long serialVersionUID = 8326446645908746848L;
+
+  @ApiModelProperty(value = "label id.")
+  private Integer labelId;
+
+  @ApiModelProperty(value = "engine name. eg: spark-2.4.3")
+  private String engineName;
+
+  public EngineLabelResponse(Integer labelId, String engineName) {
+    this.labelId = labelId;
+    this.engineName = engineName;
+  }
+
+  public Integer getLabelId() {
+    return labelId;
+  }
+
+  public void setLabelId(Integer labelId) {
+    this.labelId = labelId;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(String engineName) {
+    this.engineName = engineName;
+  }
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.restful;
 
 import io.swagger.annotations.ApiImplicitParam;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
@@ -29,7 +29,7 @@ public class ConfigurationTemplateRestfulApi {
     @ApiOperation(value = "save", notes = "save a configuration template", httpMethod = "POST")
     @RequestMapping(path = "/save", method = RequestMethod.POST)
     public Message add(@RequestBody ConfigurationTemplateSaveRequest request) {
-        if (Objects.isNull(request) || StringUtils.isEmpty(request.getCategoryName()) || StringUtils.isEmpty(request.getKey()) ||
+        if (Objects.isNull(request) || StringUtils.isEmpty(request.getEngineLabelId()) || StringUtils.isEmpty(request.getKey()) ||
                 StringUtils.isEmpty(request.getEngineConnType()) || StringUtils.isEmpty(request.getName()) ||
                 StringUtils.isEmpty(request.getTreeName())) {
             throw new InvalidParameterException("please check your parameter.");

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
@@ -14,70 +14,88 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.restful;
 
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
 import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
 import org.apache.linkis.basedatamanager.server.response.EngineLabelResponse;
 import org.apache.linkis.basedatamanager.server.service.ConfigurationTemplateService;
 import org.apache.linkis.server.Message;
+import org.apache.linkis.server.utils.ModuleUserUtils;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * This module is designed to manage configuration parameter templates
- */
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+
+/** This module is designed to manage configuration parameter templates */
 @RestController
 @RequestMapping(path = "/basedata-manager/configuration-template")
 public class ConfigurationTemplateRestfulApi {
 
-    @Autowired
-    ConfigurationTemplateService configurationTemplateService;
+  @Autowired ConfigurationTemplateService configurationTemplateService;
 
-    @ApiOperation(value = "save", notes = "save a configuration template", httpMethod = "POST")
-    @RequestMapping(path = "/save", method = RequestMethod.POST)
-    public Message add(@RequestBody ConfigurationTemplateSaveRequest request) {
-        if (Objects.isNull(request) || StringUtils.isEmpty(request.getEngineLabelId()) || StringUtils.isEmpty(request.getKey()) ||
-                StringUtils.isEmpty(request.getEngineConnType()) || StringUtils.isEmpty(request.getName()) ||
-                StringUtils.isEmpty(request.getTreeName())) {
-            throw new InvalidParameterException("please check your parameter.");
-        }
-        Boolean flag = configurationTemplateService.saveConfigurationTemplate(request);
-        return Message.ok("").data("success: ", flag);
+  @ApiOperation(value = "save", notes = "save a configuration template", httpMethod = "POST")
+  @RequestMapping(path = "/save", method = RequestMethod.POST)
+  public Message add(
+      HttpServletRequest httpRequest, @RequestBody ConfigurationTemplateSaveRequest request) {
+    ModuleUserUtils.getOperationUser(httpRequest, "save a configuration template");
+    if (Objects.isNull(request)
+        || StringUtils.isEmpty(request.getEngineLabelId())
+        || StringUtils.isEmpty(request.getKey())
+        || StringUtils.isEmpty(request.getEngineConnType())
+        || StringUtils.isEmpty(request.getName())
+        || StringUtils.isEmpty(request.getTreeName())) {
+      throw new InvalidParameterException("please check your parameter.");
     }
+    Boolean flag = configurationTemplateService.saveConfigurationTemplate(request);
+    return Message.ok("").data("success: ", flag);
+  }
 
-    @ApiImplicitParams({
-            @ApiImplicitParam(paramType = "path", dataType = "long", name = "keyId", value = "")
-    })
-    @ApiOperation(value = "delete", notes = "delete a configuration template", httpMethod = "DELETE")
-    @RequestMapping(path = "/{keyId}", method = RequestMethod.DELETE)
-    public Message delete(@PathVariable("keyId") Long keyId) {
-        Boolean flag = configurationTemplateService.deleteConfigurationTemplate(keyId);
-        return Message.ok("").data("success: ", flag);
-    }
+  @ApiImplicitParams({
+    @ApiImplicitParam(paramType = "path", dataType = "long", name = "keyId", value = "")
+  })
+  @ApiOperation(value = "delete", notes = "delete a configuration template", httpMethod = "DELETE")
+  @RequestMapping(path = "/{keyId}", method = RequestMethod.DELETE)
+  public Message delete(HttpServletRequest httpRequest, @PathVariable("keyId") Long keyId) {
+    ModuleUserUtils.getOperationUser(
+        httpRequest, "delete a configuration template, keyId: " + keyId);
+    Boolean flag = configurationTemplateService.deleteConfigurationTemplate(keyId);
+    return Message.ok("").data("success: ", flag);
+  }
 
-    @ApiOperation(value = "engin-list", notes = "get all engine list", httpMethod = "GET")
-    @RequestMapping(path = "/engin-list", method = RequestMethod.GET)
-    public Message getEngineList() {
-        List<EngineLabelResponse> engineList = configurationTemplateService.getEngineList();
-        return Message.ok("").data("success: ", engineList);
-    }
+  @ApiOperation(value = "engin-list", notes = "get all engine list", httpMethod = "GET")
+  @RequestMapping(path = "/engin-list", method = RequestMethod.GET)
+  public Message getEngineList(HttpServletRequest httpRequest) {
+    ModuleUserUtils.getOperationUser(httpRequest, "get all engine list");
+    List<EngineLabelResponse> engineList = configurationTemplateService.getEngineList();
+    return Message.ok("").data("success: ", engineList);
+  }
 
-    @ApiOperation(value = "template-list-by-label", notes = "get template list by label", httpMethod = "GET")
-    @RequestMapping(path = "/template-list-by-label", method = RequestMethod.GET)
-    public Message getTemplateListByLabelId(@RequestParam String engineLabelId) {
-        if (StringUtils.isEmpty(engineLabelId)) {
-            throw new InvalidParameterException("please check your parameter.");
-        }
-        List<ConfigurationConfigKey> configKeyList = configurationTemplateService.getTemplateListByLabelId(engineLabelId);
-        return Message.ok("").data("success: ", configKeyList);
+  @ApiOperation(
+      value = "template-list-by-label",
+      notes = "get template list by label",
+      httpMethod = "GET")
+  @RequestMapping(path = "/template-list-by-label", method = RequestMethod.GET)
+  public Message getTemplateListByLabelId(
+      HttpServletRequest httpRequest, @RequestParam String engineLabelId) {
+    ModuleUserUtils.getOperationUser(
+        httpRequest, "get template list by label, engineLabelId: " + engineLabelId);
+    if (StringUtils.isEmpty(engineLabelId)) {
+      throw new InvalidParameterException("please check your parameter.");
     }
+    List<ConfigurationConfigKey> configKeyList =
+        configurationTemplateService.getTemplateListByLabelId(engineLabelId);
+    return Message.ok("").data("success: ", configKeyList);
+  }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
@@ -1,25 +1,11 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.apache.linkis.basedatamanager.server.restful;
 
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
 import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
+import org.apache.linkis.basedatamanager.server.response.EngineLabelResponse;
 import org.apache.linkis.basedatamanager.server.service.ConfigurationTemplateService;
 import org.apache.linkis.server.Message;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +13,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.InvalidParameterException;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -59,5 +46,22 @@ public class ConfigurationTemplateRestfulApi {
     public Message delete(@PathVariable("keyId") Long keyId) {
         Boolean flag = configurationTemplateService.deleteConfigurationTemplate(keyId);
         return Message.ok("").data("success: ", flag);
+    }
+
+    @ApiOperation(value = "engin-list", notes = "get all engine list", httpMethod = "GET")
+    @RequestMapping(path = "/engin-list", method = RequestMethod.GET)
+    public Message getEngineList() {
+        List<EngineLabelResponse> engineList = configurationTemplateService.getEngineList();
+        return Message.ok("").data("success: ", engineList);
+    }
+
+    @ApiOperation(value = "template-list-by-label", notes = "get template list by label", httpMethod = "GET")
+    @RequestMapping(path = "/template-list-by-label", method = RequestMethod.GET)
+    public Message getTemplateListByLabelId(@RequestParam String engineLabelId) {
+        if (StringUtils.isEmpty(engineLabelId)) {
+            throw new InvalidParameterException("please check your parameter.");
+        }
+        List<ConfigurationConfigKey> configKeyList = configurationTemplateService.getTemplateListByLabelId(engineLabelId);
+        return Message.ok("").data("success: ", configKeyList);
     }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.restful;
 
 import io.swagger.annotations.ApiImplicitParam;

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/restful/ConfigurationTemplateRestfulApi.java
@@ -1,0 +1,47 @@
+package org.apache.linkis.basedatamanager.server.restful;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
+import org.apache.linkis.basedatamanager.server.service.ConfigurationTemplateService;
+import org.apache.linkis.server.Message;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.InvalidParameterException;
+import java.util.Objects;
+
+/**
+ * This module is designed to manage configuration parameter templates
+ */
+@RestController
+@RequestMapping(path = "/basedata-manager/configuration-template")
+public class ConfigurationTemplateRestfulApi {
+
+    @Autowired
+    ConfigurationTemplateService configurationTemplateService;
+
+    @ApiOperation(value = "save", notes = "save a configuration template", httpMethod = "POST")
+    @RequestMapping(path = "/save", method = RequestMethod.POST)
+    public Message add(@RequestBody ConfigurationTemplateSaveRequest request) {
+        if (Objects.isNull(request) || StringUtils.isEmpty(request.getCategoryName()) || StringUtils.isEmpty(request.getKey()) ||
+                StringUtils.isEmpty(request.getEngineConnType()) || StringUtils.isEmpty(request.getName()) ||
+                StringUtils.isEmpty(request.getTreeName())) {
+            throw new InvalidParameterException("please check your parameter.");
+        }
+        Boolean flag = configurationTemplateService.saveConfigurationTemplate(request);
+        return Message.ok("").data("success: ", flag);
+    }
+
+    @ApiImplicitParams({
+            @ApiImplicitParam(paramType = "path", dataType = "long", name = "keyId", value = "")
+    })
+    @ApiOperation(value = "delete", notes = "delete a configuration template", httpMethod = "DELETE")
+    @RequestMapping(path = "/{keyId}", method = RequestMethod.DELETE)
+    public Message delete(@PathVariable("keyId") Long keyId) {
+        Boolean flag = configurationTemplateService.deleteConfigurationTemplate(keyId);
+        return Message.ok("").data("success: ", flag);
+    }
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/ConfigurationTemplateService.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/ConfigurationTemplateService.java
@@ -1,0 +1,25 @@
+package org.apache.linkis.basedatamanager.server.service;
+
+import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
+
+/**
+ * This module is designed to manage configuration parameter templates
+ */
+public interface ConfigurationTemplateService {
+
+    /**
+     * save a configuration template
+     *
+     * @param request ConfigurationTemplateSaveRequest
+     * @return Boolean
+     */
+    Boolean saveConfigurationTemplate(ConfigurationTemplateSaveRequest request);
+
+    /**
+     * delete a configuration template
+     *
+     * @param keyId Long
+     * @return Boolean
+     */
+    Boolean deleteConfigurationTemplate(Long keyId);
+}

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/ConfigurationTemplateService.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/ConfigurationTemplateService.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.service;
 
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
 import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
+import org.apache.linkis.basedatamanager.server.response.EngineLabelResponse;
+
+import java.util.List;
 
 /** This module is designed to manage configuration parameter templates */
 public interface ConfigurationTemplateService {
@@ -36,4 +41,19 @@ public interface ConfigurationTemplateService {
    * @return Boolean
    */
   Boolean deleteConfigurationTemplate(Long keyId);
+
+  /**
+   * query all engine list
+   *
+   * @return List
+   */
+  List<EngineLabelResponse> getEngineList();
+
+  /**
+   * query config key list by label id
+   *
+   * @param engineLabelId engine label id
+   * @return List
+   */
+  List<ConfigurationConfigKey> getTemplateListByLabelId(String engineLabelId);
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/ConfigurationTemplateService.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/ConfigurationTemplateService.java
@@ -1,25 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.service;
 
 import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
 
-/**
- * This module is designed to manage configuration parameter templates
- */
+/** This module is designed to manage configuration parameter templates */
 public interface ConfigurationTemplateService {
 
-    /**
-     * save a configuration template
-     *
-     * @param request ConfigurationTemplateSaveRequest
-     * @return Boolean
-     */
-    Boolean saveConfigurationTemplate(ConfigurationTemplateSaveRequest request);
+  /**
+   * save a configuration template
+   *
+   * @param request ConfigurationTemplateSaveRequest
+   * @return Boolean
+   */
+  Boolean saveConfigurationTemplate(ConfigurationTemplateSaveRequest request);
 
-    /**
-     * delete a configuration template
-     *
-     * @param keyId Long
-     * @return Boolean
-     */
-    Boolean deleteConfigurationTemplate(Long keyId);
+  /**
+   * delete a configuration template
+   *
+   * @param keyId Long
+   * @return Boolean
+   */
+  Boolean deleteConfigurationTemplate(Long keyId);
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
@@ -41,10 +41,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** This module is designed to manage configuration parameter templates */
 @Service
 public class ConfigurationTemplateServiceImpl implements ConfigurationTemplateService {
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigurationTemplateService.class);
   @Resource ConfigurationConfigKeyMapper configKeyMapper;
   @Resource ConfigurationKeyEngineRelationMapper relationMapper;
   @Resource CgManagerLabelMapper managerLabelMapper;
@@ -66,22 +69,28 @@ public class ConfigurationTemplateServiceImpl implements ConfigurationTemplateSe
 
     // update
     if (!StringUtils.isEmpty(keyId)) {
+      LOG.info("update configuration config key: [ keyId: " + keyId + " ]");
       int updateKey = configKeyMapper.updateById(configKey);
       configValue.setConfigKeyId(configKey.getId());
+      LOG.info("update configuration config value: [ keyId: " + keyId + " ]");
       int updateValue = configValueMapper.updateByKeyId(configValue);
       return updateKey > 0 && updateValue > 0;
     }
 
     // 1.insert into ps_configuration_config_key
     int insertKey = configKeyMapper.insert(configKey);
+    LOG.info("insert a configuration config key: [ keyId: " + configKey.getKey() + " ]");
     // 2.insert into ps_configuration_key_engine_relation
     ConfigurationKeyEngineRelation relation = new ConfigurationKeyEngineRelation();
     relation.setConfigKeyId(configKey.getId());
     relation.setEngineTypeLabelId(label.getId().longValue());
     int insertRelation = relationMapper.insert(relation);
+    LOG.info(
+        "insert a configuration key engine relation: [ relationId: " + relation.getId() + " ]");
     // 3.insert into ps_configuration_config_value
     configValue.setConfigKeyId(configKey.getId());
     int insertValue = configValueMapper.insert(configValue);
+    LOG.info("insert a configuration config value: [ valueId: " + configValue.getId() + " ]");
 
     return insertKey > 0 & insertRelation > 0 & insertValue > 0;
   }
@@ -91,12 +100,15 @@ public class ConfigurationTemplateServiceImpl implements ConfigurationTemplateSe
   public Boolean deleteConfigurationTemplate(Long keyId) {
     // 1.delete ps_configuration_config_value by keyId
     int deleteValue = configValueMapper.deleteByKeyId(keyId);
+    LOG.info("delete a configuration config value: [ keyId: " + keyId + " ]");
 
     // 2.delete ps_configuration_key_engine_relation by keyId
     int deleteRelation = relationMapper.deleteByKeyId(keyId);
+    LOG.info("delete a configuration key engine relation: [ keyId: " + keyId + " ]");
 
     // 3.delete ps_configuration_config_key by id
     int deleteKey = configKeyMapper.deleteById(keyId);
+    LOG.info("delete a configuration config key: [ keyId: " + keyId + " ]");
 
     return deleteValue > 0 & deleteRelation > 0 & deleteKey > 0;
   }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
@@ -1,6 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.linkis.basedatamanager.server.service.impl;
 
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.apache.linkis.basedatamanager.server.dao.CgManagerLabelMapper;
 import org.apache.linkis.basedatamanager.server.dao.ConfigurationConfigKeyMapper;
 import org.apache.linkis.basedatamanager.server.dao.ConfigurationConfigValueMapper;
@@ -11,86 +26,84 @@ import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigValue;
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationKeyEngineRelation;
 import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
 import org.apache.linkis.basedatamanager.server.service.ConfigurationTemplateService;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.Resource;
+
 import java.util.Objects;
 
-/**
- * This module is designed to manage configuration parameter templates
- */
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+
+/** This module is designed to manage configuration parameter templates */
 @Service
 public class ConfigurationTemplateServiceImpl implements ConfigurationTemplateService {
-    @Resource
-    ConfigurationConfigKeyMapper configKeyMapper;
-    @Resource
-    ConfigurationKeyEngineRelationMapper relationMapper;
-    @Resource
-    CgManagerLabelMapper managerLabelMapper;
-    @Resource
-    ConfigurationConfigValueMapper configValueMapper;
+  @Resource ConfigurationConfigKeyMapper configKeyMapper;
+  @Resource ConfigurationKeyEngineRelationMapper relationMapper;
+  @Resource CgManagerLabelMapper managerLabelMapper;
+  @Resource ConfigurationConfigValueMapper configValueMapper;
 
-    @Override
-    @Transactional(rollbackFor = Exception.class)
-    public Boolean saveConfigurationTemplate(ConfigurationTemplateSaveRequest request) {
-        // check label is exist
-        CgManagerLabel labelQuery = new CgManagerLabel();
-        labelQuery.setLabelKey("combined_userCreator_engineType");
-        labelQuery.setLabelValue("*-*," + request.getCategoryName());
-        CgManagerLabel label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
+  @Override
+  @Transactional(rollbackFor = Exception.class)
+  public Boolean saveConfigurationTemplate(ConfigurationTemplateSaveRequest request) {
+    // check label is exist
+    CgManagerLabel labelQuery = new CgManagerLabel();
+    labelQuery.setLabelKey("combined_userCreator_engineType");
+    labelQuery.setLabelValue("*-*," + request.getCategoryName());
+    CgManagerLabel label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
 
-        if (Objects.isNull(label)) {
-            labelQuery.setLabelFeature("OPTIONAL");
-            labelQuery.setLabelValueSize(2);
-            managerLabelMapper.insert(labelQuery);
-            label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
-        }
-
-        // build key&value
-        ConfigurationConfigKey configKey = new ConfigurationConfigKey();
-        BeanUtils.copyProperties(request, configKey);
-        Long keyId = request.getId();
-        ConfigurationConfigValue configValue = new ConfigurationConfigValue();
-        configValue.setConfigLabelId(label.getId());
-        configValue.setConfigValue(request.getDefaultValue());
-
-        // update
-        if (!StringUtils.isEmpty(keyId)) {
-            int updateKey = configKeyMapper.updateById(configKey);
-            configValue.setConfigKeyId(configKey.getId());
-            int updateValue = configValueMapper.updateByKeyId(configValue);
-            return updateKey > 0 && updateValue > 0;
-        }
-
-        // 1.insert into ps_configuration_config_key
-        int insertKey = configKeyMapper.insert(configKey);
-        // 2.insert into ps_configuration_key_engine_relation
-        ConfigurationKeyEngineRelation relation = new ConfigurationKeyEngineRelation();
-        relation.setConfigKeyId(configKey.getId());
-        relation.setEngineTypeLabelId(label.getId().longValue());
-        int insertRelation = relationMapper.insert(relation);
-        // 3.insert into ps_configuration_config_value
-        configValue.setConfigKeyId(configKey.getId());
-        int insertValue = configValueMapper.insert(configValue);
-
-        return insertKey > 0 & insertRelation > 0 & insertValue > 0;
+    if (Objects.isNull(label)) {
+      labelQuery.setLabelFeature("OPTIONAL");
+      labelQuery.setLabelValueSize(2);
+      managerLabelMapper.insert(labelQuery);
+      label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
     }
 
-    @Override
-    @Transactional(rollbackFor = Exception.class)
-    public Boolean deleteConfigurationTemplate(Long keyId) {
-        // 1.delete ps_configuration_config_value by keyId
-        int deleteValue = configValueMapper.deleteByKeyId(keyId);
+    // build key&value
+    ConfigurationConfigKey configKey = new ConfigurationConfigKey();
+    BeanUtils.copyProperties(request, configKey);
+    Long keyId = request.getId();
+    ConfigurationConfigValue configValue = new ConfigurationConfigValue();
+    configValue.setConfigLabelId(label.getId());
+    configValue.setConfigValue(request.getDefaultValue());
 
-        // 2.delete ps_configuration_key_engine_relation by keyId
-        int deleteRelation = relationMapper.deleteByKeyId(keyId);
-
-        // 3.delete ps_configuration_config_key by id
-        int deleteKey = configKeyMapper.deleteById(keyId);
-
-        return deleteValue > 0 & deleteRelation > 0 & deleteKey > 0;
+    // update
+    if (!StringUtils.isEmpty(keyId)) {
+      int updateKey = configKeyMapper.updateById(configKey);
+      configValue.setConfigKeyId(configKey.getId());
+      int updateValue = configValueMapper.updateByKeyId(configValue);
+      return updateKey > 0 && updateValue > 0;
     }
+
+    // 1.insert into ps_configuration_config_key
+    int insertKey = configKeyMapper.insert(configKey);
+    // 2.insert into ps_configuration_key_engine_relation
+    ConfigurationKeyEngineRelation relation = new ConfigurationKeyEngineRelation();
+    relation.setConfigKeyId(configKey.getId());
+    relation.setEngineTypeLabelId(label.getId().longValue());
+    int insertRelation = relationMapper.insert(relation);
+    // 3.insert into ps_configuration_config_value
+    configValue.setConfigKeyId(configKey.getId());
+    int insertValue = configValueMapper.insert(configValue);
+
+    return insertKey > 0 & insertRelation > 0 & insertValue > 0;
+  }
+
+  @Override
+  @Transactional(rollbackFor = Exception.class)
+  public Boolean deleteConfigurationTemplate(Long keyId) {
+    // 1.delete ps_configuration_config_value by keyId
+    int deleteValue = configValueMapper.deleteByKeyId(keyId);
+
+    // 2.delete ps_configuration_key_engine_relation by keyId
+    int deleteRelation = relationMapper.deleteByKeyId(keyId);
+
+    // 3.delete ps_configuration_config_key by id
+    int deleteKey = configKeyMapper.deleteById(keyId);
+
+    return deleteValue > 0 & deleteRelation > 0 & deleteKey > 0;
+  }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.linkis.basedatamanager.server.service.impl;
 
 import org.apache.linkis.basedatamanager.server.dao.CgManagerLabelMapper;
@@ -25,18 +26,23 @@ import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigValue;
 import org.apache.linkis.basedatamanager.server.domain.ConfigurationKeyEngineRelation;
 import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
+import org.apache.linkis.basedatamanager.server.response.EngineLabelResponse;
 import org.apache.linkis.basedatamanager.server.service.ConfigurationTemplateService;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.Resource;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.google.common.collect.Lists;
 
 /** This module is designed to manage configuration parameter templates */
 @Service
@@ -105,5 +111,28 @@ public class ConfigurationTemplateServiceImpl implements ConfigurationTemplateSe
     int deleteKey = configKeyMapper.deleteById(keyId);
 
     return deleteValue > 0 & deleteRelation > 0 & deleteKey > 0;
+  }
+
+  @Override
+  public List<EngineLabelResponse> getEngineList() {
+    List<CgManagerLabel> cgEngineList = managerLabelMapper.getEngineList();
+    if (CollectionUtils.isEmpty(cgEngineList)) {
+      return Lists.newArrayList();
+    }
+    return cgEngineList.stream()
+        .map(
+            e -> {
+              String labelValue = e.getLabelValue().split(",")[1];
+              if ("*-*".equals(labelValue)) {
+                labelValue = "全局设置";
+              }
+              return new EngineLabelResponse(e.getId(), labelValue);
+            })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<ConfigurationConfigKey> getTemplateListByLabelId(String engineLabelId) {
+    return configKeyMapper.getTemplateListByLabelId(engineLabelId);
   }
 }

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
@@ -38,10 +38,8 @@ import org.springframework.util.StringUtils;
 import javax.annotation.Resource;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.google.common.collect.Lists;
 
 /** This module is designed to manage configuration parameter templates */
@@ -55,18 +53,8 @@ public class ConfigurationTemplateServiceImpl implements ConfigurationTemplateSe
   @Override
   @Transactional(rollbackFor = Exception.class)
   public Boolean saveConfigurationTemplate(ConfigurationTemplateSaveRequest request) {
-    // check label is exist
-    CgManagerLabel labelQuery = new CgManagerLabel();
-    labelQuery.setLabelKey("combined_userCreator_engineType");
-    labelQuery.setLabelValue("*-*," + request.getCategoryName());
-    CgManagerLabel label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
-
-    if (Objects.isNull(label)) {
-      labelQuery.setLabelFeature("OPTIONAL");
-      labelQuery.setLabelValueSize(2);
-      managerLabelMapper.insert(labelQuery);
-      label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
-    }
+    // query engine label
+    CgManagerLabel label = managerLabelMapper.selectById(request.getEngineLabelId());
 
     // build key&value
     ConfigurationConfigKey configKey = new ConfigurationConfigKey();

--- a/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
+++ b/linkis-public-enhancements/linkis-basedata-manager/src/main/java/org/apache/linkis/basedatamanager/server/service/impl/ConfigurationTemplateServiceImpl.java
@@ -1,0 +1,96 @@
+package org.apache.linkis.basedatamanager.server.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import org.apache.linkis.basedatamanager.server.dao.CgManagerLabelMapper;
+import org.apache.linkis.basedatamanager.server.dao.ConfigurationConfigKeyMapper;
+import org.apache.linkis.basedatamanager.server.dao.ConfigurationConfigValueMapper;
+import org.apache.linkis.basedatamanager.server.dao.ConfigurationKeyEngineRelationMapper;
+import org.apache.linkis.basedatamanager.server.domain.CgManagerLabel;
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigKey;
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationConfigValue;
+import org.apache.linkis.basedatamanager.server.domain.ConfigurationKeyEngineRelation;
+import org.apache.linkis.basedatamanager.server.request.ConfigurationTemplateSaveRequest;
+import org.apache.linkis.basedatamanager.server.service.ConfigurationTemplateService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.Resource;
+import java.util.Objects;
+
+/**
+ * This module is designed to manage configuration parameter templates
+ */
+@Service
+public class ConfigurationTemplateServiceImpl implements ConfigurationTemplateService {
+    @Resource
+    ConfigurationConfigKeyMapper configKeyMapper;
+    @Resource
+    ConfigurationKeyEngineRelationMapper relationMapper;
+    @Resource
+    CgManagerLabelMapper managerLabelMapper;
+    @Resource
+    ConfigurationConfigValueMapper configValueMapper;
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Boolean saveConfigurationTemplate(ConfigurationTemplateSaveRequest request) {
+        // check label is exist
+        CgManagerLabel labelQuery = new CgManagerLabel();
+        labelQuery.setLabelKey("combined_userCreator_engineType");
+        labelQuery.setLabelValue("*-*," + request.getCategoryName());
+        CgManagerLabel label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
+
+        if (Objects.isNull(label)) {
+            labelQuery.setLabelFeature("OPTIONAL");
+            labelQuery.setLabelValueSize(2);
+            managerLabelMapper.insert(labelQuery);
+            label = managerLabelMapper.selectOne(new QueryWrapper<>(labelQuery));
+        }
+
+        // build key&value
+        ConfigurationConfigKey configKey = new ConfigurationConfigKey();
+        BeanUtils.copyProperties(request, configKey);
+        Long keyId = request.getId();
+        ConfigurationConfigValue configValue = new ConfigurationConfigValue();
+        configValue.setConfigLabelId(label.getId());
+        configValue.setConfigValue(request.getDefaultValue());
+
+        // update
+        if (!StringUtils.isEmpty(keyId)) {
+            int updateKey = configKeyMapper.updateById(configKey);
+            configValue.setConfigKeyId(configKey.getId());
+            int updateValue = configValueMapper.updateByKeyId(configValue);
+            return updateKey > 0 && updateValue > 0;
+        }
+
+        // 1.insert into ps_configuration_config_key
+        int insertKey = configKeyMapper.insert(configKey);
+        // 2.insert into ps_configuration_key_engine_relation
+        ConfigurationKeyEngineRelation relation = new ConfigurationKeyEngineRelation();
+        relation.setConfigKeyId(configKey.getId());
+        relation.setEngineTypeLabelId(label.getId().longValue());
+        int insertRelation = relationMapper.insert(relation);
+        // 3.insert into ps_configuration_config_value
+        configValue.setConfigKeyId(configKey.getId());
+        int insertValue = configValueMapper.insert(configValue);
+
+        return insertKey > 0 & insertRelation > 0 & insertValue > 0;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Boolean deleteConfigurationTemplate(Long keyId) {
+        // 1.delete ps_configuration_config_value by keyId
+        int deleteValue = configValueMapper.deleteByKeyId(keyId);
+
+        // 2.delete ps_configuration_key_engine_relation by keyId
+        int deleteRelation = relationMapper.deleteByKeyId(keyId);
+
+        // 3.delete ps_configuration_config_key by id
+        int deleteKey = configKeyMapper.deleteById(keyId);
+
+        return deleteValue > 0 & deleteRelation > 0 & deleteKey > 0;
+    }
+}

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
@@ -62,372 +62,372 @@ import static org.apache.linkis.configuration.errorcode.LinkisConfigurationError
 @RequestMapping(path = "/configuration")
 public class ConfigurationRestfulApi {
 
-    private static final Logger logger = LoggerFactory.getLogger(ConfigurationRestfulApi.class);
+  private static final Logger logger = LoggerFactory.getLogger(ConfigurationRestfulApi.class);
 
-    @Autowired private ConfigurationService configurationService;
+  @Autowired private ConfigurationService configurationService;
 
-    @Autowired private CategoryService categoryService;
+  @Autowired private CategoryService categoryService;
 
-    @Autowired private ConfigKeyService configKeyService;
+  @Autowired private ConfigKeyService configKeyService;
 
-    ObjectMapper mapper = new ObjectMapper();
+  ObjectMapper mapper = new ObjectMapper();
 
-    private static final String NULL = "null";
+  private static final String NULL = "null";
 
-    @ApiOperation(value = "addKeyForEngine", notes = "add key for engine", response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "engineType", dataType = "String"),
-            @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version"),
-            @ApiImplicitParam(name = "token, required = false", dataType = "String", value = "token"),
-            @ApiImplicitParam(name = "keyJson", required = false, dataType = "String", value = "key json")
-    })
-    @RequestMapping(path = "/addKeyForEngine", method = RequestMethod.GET)
-    public Message addKeyForEngine(
-            HttpServletRequest req,
-            @RequestParam(value = "engineType", required = false) String engineType,
-            @RequestParam(value = "version", required = false) String version,
-            @RequestParam(value = "token", required = false) String token,
-            @RequestParam(value = "keyJson", required = false) String keyJson)
-            throws ConfigurationException {
-        if (StringUtils.isBlank(engineType)
-                || StringUtils.isBlank(version)
-                || StringUtils.isBlank(token)) {
-            throw new ConfigurationException(PARAMS_CANNOT_BE_EMPTY.getErrorDesc());
-        }
-        // todo 检验token
-        if (!token.equals(ConfigurationConfiguration.COPYKEYTOKEN)) {
-            throw new ConfigurationException(TOKEN_IS_ERROR.getErrorDesc());
-        }
-        ConfigKey configKey = BDPJettyServerHelper.gson().fromJson(keyJson, ConfigKey.class);
-        configurationService.addKeyForEngine(engineType, version, configKey);
-        // TODO: 2019/12/30  configKey参数校验
-        return Message.ok();
+  @ApiOperation(value = "addKeyForEngine", notes = "add key for engine", response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "engineType", dataType = "String"),
+    @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version"),
+    @ApiImplicitParam(name = "token, required = false", dataType = "String", value = "token"),
+    @ApiImplicitParam(name = "keyJson", required = false, dataType = "String", value = "key json")
+  })
+  @RequestMapping(path = "/addKeyForEngine", method = RequestMethod.GET)
+  public Message addKeyForEngine(
+      HttpServletRequest req,
+      @RequestParam(value = "engineType", required = false) String engineType,
+      @RequestParam(value = "version", required = false) String version,
+      @RequestParam(value = "token", required = false) String token,
+      @RequestParam(value = "keyJson", required = false) String keyJson)
+      throws ConfigurationException {
+    if (StringUtils.isBlank(engineType)
+        || StringUtils.isBlank(version)
+        || StringUtils.isBlank(token)) {
+      throw new ConfigurationException(PARAMS_CANNOT_BE_EMPTY.getErrorDesc());
     }
-
-    @ApiOperation(
-            value = "getFullTreesByAppName",
-            notes = "get full trees by app name",
-            response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "engineType", dataType = "String"),
-            @ApiImplicitParam(name = "version", dataType = "String", value = "version"),
-            @ApiImplicitParam(name = "creator", dataType = "String", value = "creator")
-    })
-    @RequestMapping(path = "/getFullTreesByAppName", method = RequestMethod.GET)
-    public Message getFullTreesByAppName(
-            HttpServletRequest req,
-            @RequestParam(value = "engineType", required = false) String engineType,
-            @RequestParam(value = "version", required = false) String version,
-            @RequestParam(value = "creator", required = false) String creator)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(req, "getFullTreesByAppName");
-        if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
-            engineType = "*";
-            version = "*";
-            creator = "*";
-        }
-        List labelList =
-                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-                        username, creator, engineType, version);
-        ArrayList<ConfigTree> configTrees =
-                configurationService.getFullTreeByLabelList(labelList, true);
-        return Message.ok().data("fullTree", configTrees);
+    // todo 检验token
+    if (!token.equals(ConfigurationConfiguration.COPYKEYTOKEN)) {
+      throw new ConfigurationException(TOKEN_IS_ERROR.getErrorDesc());
     }
+    ConfigKey configKey = BDPJettyServerHelper.gson().fromJson(keyJson, ConfigKey.class);
+    configurationService.addKeyForEngine(engineType, version, configKey);
+    // TODO: 2019/12/30  configKey参数校验
+    return Message.ok();
+  }
 
-    @ApiOperation(value = "getCategory", notes = "get category", response = Message.class)
-    @RequestMapping(path = "/getCategory", method = RequestMethod.GET)
-    public Message getCategory(HttpServletRequest req) {
-        List<CategoryLabelVo> categoryLabelList = categoryService.getAllCategory();
-        return Message.ok().data("Category", categoryLabelList);
+  @ApiOperation(
+      value = "getFullTreesByAppName",
+      notes = "get full trees by app name",
+      response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "engineType", dataType = "String"),
+    @ApiImplicitParam(name = "version", dataType = "String", value = "version"),
+    @ApiImplicitParam(name = "creator", dataType = "String", value = "creator")
+  })
+  @RequestMapping(path = "/getFullTreesByAppName", method = RequestMethod.GET)
+  public Message getFullTreesByAppName(
+      HttpServletRequest req,
+      @RequestParam(value = "engineType", required = false) String engineType,
+      @RequestParam(value = "version", required = false) String version,
+      @RequestParam(value = "creator", required = false) String creator)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(req, "getFullTreesByAppName");
+    if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
+      engineType = "*";
+      version = "*";
+      creator = "*";
     }
+    List labelList =
+        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+            username, creator, engineType, version);
+    ArrayList<ConfigTree> configTrees =
+        configurationService.getFullTreeByLabelList(labelList, true);
+    return Message.ok().data("fullTree", configTrees);
+  }
 
-    @ApiOperation(
-            value = "createFirstCategory",
-            notes = "create first category",
-            response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "categoryName", required = true, dataType = "String"),
-            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-    })
-    @ApiOperationSupport(ignoreParameters = {"jsonNode"})
-    @RequestMapping(path = "/createFirstCategory", method = RequestMethod.POST)
-    public Message createFirstCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(request, "createFirstCategory");
-        checkAdmin(username);
-        String categoryName = jsonNode.get("categoryName").asText();
-        String description = jsonNode.get("description").asText();
-        if (StringUtils.isEmpty(categoryName) || categoryName.equals(NULL)) {
-            throw new ConfigurationException(IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
-        }
-        if (StringUtils.isEmpty(categoryName) || categoryName.contains("-")) {
-            throw new ConfigurationException(CANNOT_BE_INCLUDED.getErrorDesc());
-        }
-        categoryService.createFirstCategory(categoryName, description);
-        return Message.ok();
+  @ApiOperation(value = "getCategory", notes = "get category", response = Message.class)
+  @RequestMapping(path = "/getCategory", method = RequestMethod.GET)
+  public Message getCategory(HttpServletRequest req) {
+    List<CategoryLabelVo> categoryLabelList = categoryService.getAllCategory();
+    return Message.ok().data("Category", categoryLabelList);
+  }
+
+  @ApiOperation(
+      value = "createFirstCategory",
+      notes = "create first category",
+      response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "categoryName", required = true, dataType = "String"),
+    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+  })
+  @ApiOperationSupport(ignoreParameters = {"jsonNode"})
+  @RequestMapping(path = "/createFirstCategory", method = RequestMethod.POST)
+  public Message createFirstCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(request, "createFirstCategory");
+    checkAdmin(username);
+    String categoryName = jsonNode.get("categoryName").asText();
+    String description = jsonNode.get("description").asText();
+    if (StringUtils.isEmpty(categoryName) || categoryName.equals(NULL)) {
+      throw new ConfigurationException(IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
     }
-
-    @ApiOperation(value = "deleteCategory", notes = "delete category", response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "54")
-    })
-    @ApiOperationSupport(ignoreParameters = "jsonNode")
-    @RequestMapping(path = "/deleteCategory", method = RequestMethod.POST)
-    public Message deleteCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(request, "deleteCategory");
-        checkAdmin(username);
-        Integer categoryId = jsonNode.get("categoryId").asInt();
-        categoryService.deleteCategory(categoryId);
-        return Message.ok();
+    if (StringUtils.isEmpty(categoryName) || categoryName.contains("-")) {
+      throw new ConfigurationException(CANNOT_BE_INCLUDED.getErrorDesc());
     }
+    categoryService.createFirstCategory(categoryName, description);
+    return Message.ok();
+  }
 
-    @ApiOperation(
-            value = "createSecondCategory",
-            notes = "create second category",
-            response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "39"),
-            @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
-            @ApiImplicitParam(name = "version", required = true, dataType = "String", example = "1.2.0"),
-            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-    })
-    @ApiOperationSupport(ignoreParameters = {"jsonNode"})
-    @RequestMapping(path = "/createSecondCategory", method = RequestMethod.POST)
-    public Message createSecondCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(request, "createSecondCategory");
-        checkAdmin(username);
-        Integer categoryId = jsonNode.get("categoryId").asInt();
-        String engineType = jsonNode.get("engineType").asText();
-        String version = jsonNode.get("version").asText();
-        String description = jsonNode.get("description").asText();
-        if (categoryId <= 0) {
-            throw new ConfigurationException(CREATOR_IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
-        }
-        if (StringUtils.isEmpty(engineType) || engineType.toLowerCase().equals(NULL)) {
-            throw new ConfigurationException(ENGINE_TYPE_IS_NULL.getErrorDesc());
-        }
-        if (StringUtils.isEmpty(version) || version.toLowerCase().equals(NULL)) {
-            version = LabelUtils.COMMON_VALUE;
-        }
-        categoryService.createSecondCategory(categoryId, engineType, version, description);
-        return Message.ok();
+  @ApiOperation(value = "deleteCategory", notes = "delete category", response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "54")
+  })
+  @ApiOperationSupport(ignoreParameters = "jsonNode")
+  @RequestMapping(path = "/deleteCategory", method = RequestMethod.POST)
+  public Message deleteCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(request, "deleteCategory");
+    checkAdmin(username);
+    Integer categoryId = jsonNode.get("categoryId").asInt();
+    categoryService.deleteCategory(categoryId);
+    return Message.ok();
+  }
+
+  @ApiOperation(
+      value = "createSecondCategory",
+      notes = "create second category",
+      response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "39"),
+    @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
+    @ApiImplicitParam(name = "version", required = true, dataType = "String", example = "1.2.0"),
+    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+  })
+  @ApiOperationSupport(ignoreParameters = {"jsonNode"})
+  @RequestMapping(path = "/createSecondCategory", method = RequestMethod.POST)
+  public Message createSecondCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(request, "createSecondCategory");
+    checkAdmin(username);
+    Integer categoryId = jsonNode.get("categoryId").asInt();
+    String engineType = jsonNode.get("engineType").asText();
+    String version = jsonNode.get("version").asText();
+    String description = jsonNode.get("description").asText();
+    if (categoryId <= 0) {
+      throw new ConfigurationException(CREATOR_IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
     }
-
-    @ApiOperation(value = "saveFullTree", notes = "save full tree", response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "creator", required = true, dataType = "String", example = "xwzTest"),
-            @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
-            @ApiImplicitParam(name = "fullTree", required = true, dataType = "List", value = "full tree"),
-            @ApiImplicitParam(name = "name", required = true, dataType = "String", value = "name"),
-            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-            @ApiImplicitParam(name = "settings", required = true, dataType = "List", value = "settings")
-    })
-    @ApiOperationSupport(ignoreParameters = {"json"})
-    @RequestMapping(path = "/saveFullTree", method = RequestMethod.POST)
-    public Message saveFullTree(HttpServletRequest req, @RequestBody JsonNode json)
-            throws IOException, ConfigurationException {
-        List fullTrees = mapper.treeToValue(json.get("fullTree"), List.class);
-        String creator = JsonNodeUtil.getStringValue(json.get("creator"));
-        String engineType = JsonNodeUtil.getStringValue(json.get("engineType"));
-        if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
-            creator = "*";
-        }
-        String username = ModuleUserUtils.getOperationUser(req, "saveFullTree");
-        ArrayList<ConfigValue> createList = new ArrayList<>();
-        ArrayList<ConfigValue> updateList = new ArrayList<>();
-        for (Object o : fullTrees) {
-            String s = BDPJettyServerHelper.gson().toJson(o);
-            ConfigTree fullTree = BDPJettyServerHelper.gson().fromJson(s, ConfigTree.class);
-            List<ConfigKeyValue> settings = fullTree.getSettings();
-            Integer userLabelId =
-                    configurationService.checkAndCreateUserLabel(settings, username, creator);
-            for (ConfigKeyValue setting : settings) {
-                configurationService.updateUserValue(setting, userLabelId, createList, updateList);
-            }
-        }
-        String engine = null;
-        String version = null;
-        if (engineType != null) {
-            String[] tmpString = engineType.split("-");
-            if (tmpString.length != 2) {
-                throw new ConfigurationException(INCORRECT_FIXED_SUCH.getErrorDesc());
-            }
-            engine = tmpString[0];
-            version = tmpString[1];
-        }
-        configurationService.updateUserValue(createList, updateList);
-        configurationService.clearAMCacheConf(username, creator, engine, version);
-        Message message = Message.ok();
-        return message;
+    if (StringUtils.isEmpty(engineType) || engineType.toLowerCase().equals(NULL)) {
+      throw new ConfigurationException(ENGINE_TYPE_IS_NULL.getErrorDesc());
     }
-
-    @ApiOperation(
-            value = "listAllEngineType",
-            notes = "list all engine type",
-            response = Message.class)
-    @RequestMapping(path = "/engineType", method = RequestMethod.GET)
-    public Message listAllEngineType(HttpServletRequest request) {
-        String[] engineType = configurationService.listAllEngineType();
-        return Message.ok().data("engineType", engineType);
+    if (StringUtils.isEmpty(version) || version.toLowerCase().equals(NULL)) {
+      version = LabelUtils.COMMON_VALUE;
     }
+    categoryService.createSecondCategory(categoryId, engineType, version, description);
+    return Message.ok();
+  }
 
-    @ApiOperation(
-            value = "updateCategoryInfo",
-            notes = "update category info",
-            response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-            @ApiImplicitParam(name = "categoryId", required = true, dataType = "String")
-    })
-    @ApiOperationSupport(ignoreParameters = {"jsonNode"})
-    @RequestMapping(path = "/updateCategoryInfo", method = RequestMethod.POST)
-    public Message updateCategoryInfo(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(request, "updateCategoryInfo");
-        checkAdmin(username);
-        String description = null;
-        Integer categoryId = null;
-        try {
-            description = jsonNode.get("description").asText();
-            categoryId = jsonNode.get("categoryId").asInt();
-        } catch (Exception e) {
-            throw new ConfigurationException(INCOMPLETE_RECONFIRM.getErrorDesc());
-        }
-        if (description != null) {
-            categoryService.updateCategory(categoryId, description);
-        }
-        return Message.ok();
+  @ApiOperation(value = "saveFullTree", notes = "save full tree", response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "creator", required = true, dataType = "String", example = "xwzTest"),
+    @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
+    @ApiImplicitParam(name = "fullTree", required = true, dataType = "List", value = "full tree"),
+    @ApiImplicitParam(name = "name", required = true, dataType = "String", value = "name"),
+    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+    @ApiImplicitParam(name = "settings", required = true, dataType = "List", value = "settings")
+  })
+  @ApiOperationSupport(ignoreParameters = {"json"})
+  @RequestMapping(path = "/saveFullTree", method = RequestMethod.POST)
+  public Message saveFullTree(HttpServletRequest req, @RequestBody JsonNode json)
+      throws IOException, ConfigurationException {
+    List fullTrees = mapper.treeToValue(json.get("fullTree"), List.class);
+    String creator = JsonNodeUtil.getStringValue(json.get("creator"));
+    String engineType = JsonNodeUtil.getStringValue(json.get("engineType"));
+    if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
+      creator = "*";
     }
-
-    @ApiOperation(value = "rpcTest", notes = "rpc test", response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "creator", dataType = "String", value = "creator"),
-            @ApiImplicitParam(name = "engineType", dataType = "String"),
-            @ApiImplicitParam(name = "username", dataType = "String"),
-            @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
-    })
-    @RequestMapping(path = "/rpcTest", method = RequestMethod.GET)
-    public Message rpcTest(
-            @RequestParam(value = "username", required = false) String username,
-            @RequestParam(value = "creator", required = false) String creator,
-            @RequestParam(value = "engineType", required = false) String engineType,
-            @RequestParam(value = "version", required = false) String version) {
-        configurationService.queryGlobalConfig(username);
-        EngineTypeLabel engineTypeLabel = new EngineTypeLabel();
-        engineTypeLabel.setVersion(version);
-        engineTypeLabel.setEngineType(engineType);
-        configurationService.queryDefaultEngineConfig(engineTypeLabel);
-        UserCreatorLabel userCreatorLabel = new UserCreatorLabel();
-        userCreatorLabel.setCreator(creator);
-        userCreatorLabel.setUser(username);
-        configurationService.queryConfig(userCreatorLabel, engineTypeLabel, "wds.linkis.rm");
-        Message message = Message.ok();
-        return message;
+    String username = ModuleUserUtils.getOperationUser(req, "saveFullTree");
+    ArrayList<ConfigValue> createList = new ArrayList<>();
+    ArrayList<ConfigValue> updateList = new ArrayList<>();
+    for (Object o : fullTrees) {
+      String s = BDPJettyServerHelper.gson().toJson(o);
+      ConfigTree fullTree = BDPJettyServerHelper.gson().fromJson(s, ConfigTree.class);
+      List<ConfigKeyValue> settings = fullTree.getSettings();
+      Integer userLabelId =
+          configurationService.checkAndCreateUserLabel(settings, username, creator);
+      for (ConfigKeyValue setting : settings) {
+        configurationService.updateUserValue(setting, userLabelId, createList, updateList);
+      }
     }
-
-    private void checkAdmin(String userName) throws ConfigurationException {
-        if (!Configuration.isAdmin(userName)) {
-            throw new ConfigurationException(ONLY_ADMIN_CAN_MODIFY.getErrorDesc());
-        }
+    String engine = null;
+    String version = null;
+    if (engineType != null) {
+      String[] tmpString = engineType.split("-");
+      if (tmpString.length != 2) {
+        throw new ConfigurationException(INCORRECT_FIXED_SUCH.getErrorDesc());
+      }
+      engine = tmpString[0];
+      version = tmpString[1];
     }
+    configurationService.updateUserValue(createList, updateList);
+    configurationService.clearAMCacheConf(username, creator, engine, version);
+    Message message = Message.ok();
+    return message;
+  }
 
-    @ApiOperation(value = "getKeyValue", notes = "get key value", response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "creator", required = false, dataType = "String", value = "creator"),
-            @ApiImplicitParam(name = "engineType", dataType = "String"),
-            @ApiImplicitParam(name = "configKey", dataType = "String"),
-            @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
-    })
-    @RequestMapping(path = "/keyvalue", method = RequestMethod.GET)
-    public Message getKeyValue(
-            HttpServletRequest req,
-            @RequestParam(value = "engineType", required = false, defaultValue = "*") String engineType,
-            @RequestParam(value = "version", required = false, defaultValue = "*") String version,
-            @RequestParam(value = "creator", required = false, defaultValue = "*") String creator,
-            @RequestParam(value = "configKey") String configKey)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(req, "saveKey");
-        if (engineType.equals("*") && !version.equals("*")) {
-            return Message.error("When engineType is any engine, the version must also be any version");
-        }
-        List labelList =
-                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-                        username, creator, engineType, version);
+  @ApiOperation(
+      value = "listAllEngineType",
+      notes = "list all engine type",
+      response = Message.class)
+  @RequestMapping(path = "/engineType", method = RequestMethod.GET)
+  public Message listAllEngineType(HttpServletRequest request) {
+    String[] engineType = configurationService.listAllEngineType();
+    return Message.ok().data("engineType", engineType);
+  }
 
-        List<ConfigValue> configValues = configKeyService.getConfigValue(configKey, labelList);
-        Message message = Message.ok().data("configValues", configValues);
-        if (configValues.size() > 1) {
-            message.data(
-                    "warnMessage", "There are multiple values for the corresponding Key： " + configKey);
-        }
-        return message;
+  @ApiOperation(
+      value = "updateCategoryInfo",
+      notes = "update category info",
+      response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+    @ApiImplicitParam(name = "categoryId", required = true, dataType = "String")
+  })
+  @ApiOperationSupport(ignoreParameters = {"jsonNode"})
+  @RequestMapping(path = "/updateCategoryInfo", method = RequestMethod.POST)
+  public Message updateCategoryInfo(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(request, "updateCategoryInfo");
+    checkAdmin(username);
+    String description = null;
+    Integer categoryId = null;
+    try {
+      description = jsonNode.get("description").asText();
+      categoryId = jsonNode.get("categoryId").asInt();
+    } catch (Exception e) {
+      throw new ConfigurationException(INCOMPLETE_RECONFIRM.getErrorDesc());
     }
-
-    @ApiOperation(value = "saveKeyValue", notes = "save key value", response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
-            @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
-            @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
-            @ApiImplicitParam(name = "configKey", required = true, dataType = "String"),
-            @ApiImplicitParam(name = "configValue", required = true, dataType = "String")
-    })
-    @ApiOperationSupport(ignoreParameters = {"json"})
-    @RequestMapping(path = "/keyvalue", method = RequestMethod.POST)
-    public Message saveKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(req, "saveKey");
-        String engineType = (String) json.getOrDefault("engineType", "*");
-        String version = (String) json.getOrDefault("version", "*");
-        String creator = (String) json.getOrDefault("creator", "*");
-        String configKey = (String) json.get("configKey");
-        String value = (String) json.get("configValue");
-        if (engineType.equals("*") && !version.equals("*")) {
-            return Message.error("When engineType is any engine, the version must also be any version");
-        }
-        if (StringUtils.isBlank(configKey) || StringUtils.isBlank(value)) {
-            return Message.error("key or value cannot be empty");
-        }
-        List labelList =
-                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-                        username, creator, engineType, version);
-
-        ConfigKeyValue configKeyValue = new ConfigKeyValue();
-        configKeyValue.setKey(configKey);
-        configKeyValue.setConfigValue(value);
-
-        ConfigValue configValue = configKeyService.saveConfigValue(configKeyValue, labelList);
-        configurationService.clearAMCacheConf(username, creator, engineType, version);
-        return Message.ok().data("configValue", configValue);
+    if (description != null) {
+      categoryService.updateCategory(categoryId, description);
     }
+    return Message.ok();
+  }
 
-    @ApiOperation(value = "deleteKeyValue", notes = "delete key value", response = Message.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
-            @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
-            @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
-            @ApiImplicitParam(name = "configKey", required = true, dataType = "String")
-    })
-    @ApiOperationSupport(ignoreParameters = {"json"})
-    @RequestMapping(path = "/keyvalue", method = RequestMethod.DELETE)
-    public Message deleteKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
-            throws ConfigurationException {
-        String username = ModuleUserUtils.getOperationUser(req, "saveKey");
-        String engineType = (String) json.getOrDefault("engineType", "*");
-        String version = (String) json.getOrDefault("version", "*");
-        String creator = (String) json.getOrDefault("creator", "*");
-        String configKey = (String) json.get("configKey");
-        if (engineType.equals("*") && !version.equals("*")) {
-            return Message.error("When engineType is any engine, the version must also be any version");
-        }
-        if (StringUtils.isBlank(configKey)) {
-            return Message.error("key cannot be empty");
-        }
-        List labelList =
-                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-                        username, creator, engineType, version);
-        List<ConfigValue> configValues = configKeyService.deleteConfigValue(configKey, labelList);
-        return Message.ok().data("configValues", configValues);
+  @ApiOperation(value = "rpcTest", notes = "rpc test", response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "creator", dataType = "String", value = "creator"),
+    @ApiImplicitParam(name = "engineType", dataType = "String"),
+    @ApiImplicitParam(name = "username", dataType = "String"),
+    @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
+  })
+  @RequestMapping(path = "/rpcTest", method = RequestMethod.GET)
+  public Message rpcTest(
+      @RequestParam(value = "username", required = false) String username,
+      @RequestParam(value = "creator", required = false) String creator,
+      @RequestParam(value = "engineType", required = false) String engineType,
+      @RequestParam(value = "version", required = false) String version) {
+    configurationService.queryGlobalConfig(username);
+    EngineTypeLabel engineTypeLabel = new EngineTypeLabel();
+    engineTypeLabel.setVersion(version);
+    engineTypeLabel.setEngineType(engineType);
+    configurationService.queryDefaultEngineConfig(engineTypeLabel);
+    UserCreatorLabel userCreatorLabel = new UserCreatorLabel();
+    userCreatorLabel.setCreator(creator);
+    userCreatorLabel.setUser(username);
+    configurationService.queryConfig(userCreatorLabel, engineTypeLabel, "wds.linkis.rm");
+    Message message = Message.ok();
+    return message;
+  }
+
+  private void checkAdmin(String userName) throws ConfigurationException {
+    if (!Configuration.isAdmin(userName)) {
+      throw new ConfigurationException(ONLY_ADMIN_CAN_MODIFY.getErrorDesc());
     }
+  }
+
+  @ApiOperation(value = "getKeyValue", notes = "get key value", response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "creator", required = false, dataType = "String", value = "creator"),
+    @ApiImplicitParam(name = "engineType", dataType = "String"),
+    @ApiImplicitParam(name = "configKey", dataType = "String"),
+    @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
+  })
+  @RequestMapping(path = "/keyvalue", method = RequestMethod.GET)
+  public Message getKeyValue(
+      HttpServletRequest req,
+      @RequestParam(value = "engineType", required = false, defaultValue = "*") String engineType,
+      @RequestParam(value = "version", required = false, defaultValue = "*") String version,
+      @RequestParam(value = "creator", required = false, defaultValue = "*") String creator,
+      @RequestParam(value = "configKey") String configKey)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(req, "saveKey");
+    if (engineType.equals("*") && !version.equals("*")) {
+      return Message.error("When engineType is any engine, the version must also be any version");
+    }
+    List labelList =
+        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+            username, creator, engineType, version);
+
+    List<ConfigValue> configValues = configKeyService.getConfigValue(configKey, labelList);
+    Message message = Message.ok().data("configValues", configValues);
+    if (configValues.size() > 1) {
+      message.data(
+          "warnMessage", "There are multiple values for the corresponding Key： " + configKey);
+    }
+    return message;
+  }
+
+  @ApiOperation(value = "saveKeyValue", notes = "save key value", response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
+    @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
+    @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
+    @ApiImplicitParam(name = "configKey", required = true, dataType = "String"),
+    @ApiImplicitParam(name = "configValue", required = true, dataType = "String")
+  })
+  @ApiOperationSupport(ignoreParameters = {"json"})
+  @RequestMapping(path = "/keyvalue", method = RequestMethod.POST)
+  public Message saveKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(req, "saveKey");
+    String engineType = (String) json.getOrDefault("engineType", "*");
+    String version = (String) json.getOrDefault("version", "*");
+    String creator = (String) json.getOrDefault("creator", "*");
+    String configKey = (String) json.get("configKey");
+    String value = (String) json.get("configValue");
+    if (engineType.equals("*") && !version.equals("*")) {
+      return Message.error("When engineType is any engine, the version must also be any version");
+    }
+    if (StringUtils.isBlank(configKey) || StringUtils.isBlank(value)) {
+      return Message.error("key or value cannot be empty");
+    }
+    List labelList =
+        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+            username, creator, engineType, version);
+
+    ConfigKeyValue configKeyValue = new ConfigKeyValue();
+    configKeyValue.setKey(configKey);
+    configKeyValue.setConfigValue(value);
+
+    ConfigValue configValue = configKeyService.saveConfigValue(configKeyValue, labelList);
+    configurationService.clearAMCacheConf(username, creator, engineType, version);
+    return Message.ok().data("configValue", configValue);
+  }
+
+  @ApiOperation(value = "deleteKeyValue", notes = "delete key value", response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
+    @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
+    @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
+    @ApiImplicitParam(name = "configKey", required = true, dataType = "String")
+  })
+  @ApiOperationSupport(ignoreParameters = {"json"})
+  @RequestMapping(path = "/keyvalue", method = RequestMethod.DELETE)
+  public Message deleteKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
+      throws ConfigurationException {
+    String username = ModuleUserUtils.getOperationUser(req, "saveKey");
+    String engineType = (String) json.getOrDefault("engineType", "*");
+    String version = (String) json.getOrDefault("version", "*");
+    String creator = (String) json.getOrDefault("creator", "*");
+    String configKey = (String) json.get("configKey");
+    if (engineType.equals("*") && !version.equals("*")) {
+      return Message.error("When engineType is any engine, the version must also be any version");
+    }
+    if (StringUtils.isBlank(configKey)) {
+      return Message.error("key cannot be empty");
+    }
+    List labelList =
+        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+            username, creator, engineType, version);
+    List<ConfigValue> configValues = configKeyService.deleteConfigValue(configKey, labelList);
+    return Message.ok().data("configValues", configValues);
+  }
 }

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
@@ -62,372 +62,372 @@ import static org.apache.linkis.configuration.errorcode.LinkisConfigurationError
 @RequestMapping(path = "/configuration")
 public class ConfigurationRestfulApi {
 
-  private static final Logger logger = LoggerFactory.getLogger(ConfigurationRestfulApi.class);
+    private static final Logger logger = LoggerFactory.getLogger(ConfigurationRestfulApi.class);
 
-  @Autowired private ConfigurationService configurationService;
+    @Autowired private ConfigurationService configurationService;
 
-  @Autowired private CategoryService categoryService;
+    @Autowired private CategoryService categoryService;
 
-  @Autowired private ConfigKeyService configKeyService;
+    @Autowired private ConfigKeyService configKeyService;
 
-  ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new ObjectMapper();
 
-  private static final String NULL = "null";
+    private static final String NULL = "null";
 
-  @ApiOperation(value = "addKeyForEngine", notes = "add key for engine", response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "engineType", dataType = "String"),
-    @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version"),
-    @ApiImplicitParam(name = "token, required = false", dataType = "String", value = "token"),
-    @ApiImplicitParam(name = "keyJson", required = false, dataType = "String", value = "key json")
-  })
-  @RequestMapping(path = "/addKeyForEngine", method = RequestMethod.GET)
-  public Message addKeyForEngine(
-      HttpServletRequest req,
-      @RequestParam(value = "engineType", required = false) String engineType,
-      @RequestParam(value = "version", required = false) String version,
-      @RequestParam(value = "token", required = false) String token,
-      @RequestParam(value = "keyJson", required = false) String keyJson)
-      throws ConfigurationException {
-    if (StringUtils.isBlank(engineType)
-        || StringUtils.isBlank(version)
-        || StringUtils.isBlank(token)) {
-      throw new ConfigurationException(PARAMS_CANNOT_BE_EMPTY.getErrorDesc());
+    @ApiOperation(value = "addKeyForEngine", notes = "add key for engine", response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "engineType", dataType = "String"),
+            @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version"),
+            @ApiImplicitParam(name = "token, required = false", dataType = "String", value = "token"),
+            @ApiImplicitParam(name = "keyJson", required = false, dataType = "String", value = "key json")
+    })
+    @RequestMapping(path = "/addKeyForEngine", method = RequestMethod.GET)
+    public Message addKeyForEngine(
+            HttpServletRequest req,
+            @RequestParam(value = "engineType", required = false) String engineType,
+            @RequestParam(value = "version", required = false) String version,
+            @RequestParam(value = "token", required = false) String token,
+            @RequestParam(value = "keyJson", required = false) String keyJson)
+            throws ConfigurationException {
+        if (StringUtils.isBlank(engineType)
+                || StringUtils.isBlank(version)
+                || StringUtils.isBlank(token)) {
+            throw new ConfigurationException(PARAMS_CANNOT_BE_EMPTY.getErrorDesc());
+        }
+        // todo 检验token
+        if (!token.equals(ConfigurationConfiguration.COPYKEYTOKEN)) {
+            throw new ConfigurationException(TOKEN_IS_ERROR.getErrorDesc());
+        }
+        ConfigKey configKey = BDPJettyServerHelper.gson().fromJson(keyJson, ConfigKey.class);
+        configurationService.addKeyForEngine(engineType, version, configKey);
+        // TODO: 2019/12/30  configKey参数校验
+        return Message.ok();
     }
-    // todo 检验token
-    if (!token.equals(ConfigurationConfiguration.COPYKEYTOKEN)) {
-      throw new ConfigurationException(TOKEN_IS_ERROR.getErrorDesc());
-    }
-    ConfigKey configKey = BDPJettyServerHelper.gson().fromJson(keyJson, ConfigKey.class);
-    configurationService.addKeyForEngine(engineType, version, configKey);
-    // TODO: 2019/12/30  configKey参数校验
-    return Message.ok();
-  }
 
-  @ApiOperation(
-      value = "getFullTreesByAppName",
-      notes = "get full trees by app name",
-      response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "engineType", dataType = "String"),
-    @ApiImplicitParam(name = "version", dataType = "String", value = "version"),
-    @ApiImplicitParam(name = "creator", dataType = "String", value = "creator")
-  })
-  @RequestMapping(path = "/getFullTreesByAppName", method = RequestMethod.GET)
-  public Message getFullTreesByAppName(
-      HttpServletRequest req,
-      @RequestParam(value = "engineType", required = false) String engineType,
-      @RequestParam(value = "version", required = false) String version,
-      @RequestParam(value = "creator", required = false) String creator)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(req, "getFullTreesByAppName");
-    if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
-      engineType = "*";
-      version = "*";
-      creator = "*";
+    @ApiOperation(
+            value = "getFullTreesByAppName",
+            notes = "get full trees by app name",
+            response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "engineType", dataType = "String"),
+            @ApiImplicitParam(name = "version", dataType = "String", value = "version"),
+            @ApiImplicitParam(name = "creator", dataType = "String", value = "creator")
+    })
+    @RequestMapping(path = "/getFullTreesByAppName", method = RequestMethod.GET)
+    public Message getFullTreesByAppName(
+            HttpServletRequest req,
+            @RequestParam(value = "engineType", required = false) String engineType,
+            @RequestParam(value = "version", required = false) String version,
+            @RequestParam(value = "creator", required = false) String creator)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(req, "getFullTreesByAppName");
+        if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
+            engineType = "*";
+            version = "*";
+            creator = "*";
+        }
+        List labelList =
+                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+                        username, creator, engineType, version);
+        ArrayList<ConfigTree> configTrees =
+                configurationService.getFullTreeByLabelList(labelList, true);
+        return Message.ok().data("fullTree", configTrees);
     }
-    List labelList =
-        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-            username, creator, engineType, version);
-    ArrayList<ConfigTree> configTrees =
-        configurationService.getFullTreeByLabelList(labelList, true);
-    return Message.ok().data("fullTree", configTrees);
-  }
 
-  @ApiOperation(value = "getCategory", notes = "get category", response = Message.class)
-  @RequestMapping(path = "/getCategory", method = RequestMethod.GET)
-  public Message getCategory(HttpServletRequest req) {
-    List<CategoryLabelVo> categoryLabelList = categoryService.getAllCategory();
-    return Message.ok().data("Category", categoryLabelList);
-  }
+    @ApiOperation(value = "getCategory", notes = "get category", response = Message.class)
+    @RequestMapping(path = "/getCategory", method = RequestMethod.GET)
+    public Message getCategory(HttpServletRequest req) {
+        List<CategoryLabelVo> categoryLabelList = categoryService.getAllCategory();
+        return Message.ok().data("Category", categoryLabelList);
+    }
 
-  @ApiOperation(
-      value = "createFirstCategory",
-      notes = "create first category",
-      response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "categoryName", required = true, dataType = "String"),
-    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-  })
-  @ApiOperationSupport(ignoreParameters = {"jsonNode"})
-  @RequestMapping(path = "/createFirstCategory", method = RequestMethod.POST)
-  public Message createFirstCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(request, "createFirstCategory");
-    checkAdmin(username);
-    String categoryName = jsonNode.get("categoryName").asText();
-    String description = jsonNode.get("description").asText();
-    if (StringUtils.isEmpty(categoryName) || categoryName.equals(NULL)) {
-      throw new ConfigurationException(IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
+    @ApiOperation(
+            value = "createFirstCategory",
+            notes = "create first category",
+            response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "categoryName", required = true, dataType = "String"),
+            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+    })
+    @ApiOperationSupport(ignoreParameters = {"jsonNode"})
+    @RequestMapping(path = "/createFirstCategory", method = RequestMethod.POST)
+    public Message createFirstCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(request, "createFirstCategory");
+        checkAdmin(username);
+        String categoryName = jsonNode.get("categoryName").asText();
+        String description = jsonNode.get("description").asText();
+        if (StringUtils.isEmpty(categoryName) || categoryName.equals(NULL)) {
+            throw new ConfigurationException(IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
+        }
+        if (StringUtils.isEmpty(categoryName) || categoryName.contains("-")) {
+            throw new ConfigurationException(CANNOT_BE_INCLUDED.getErrorDesc());
+        }
+        categoryService.createFirstCategory(categoryName, description);
+        return Message.ok();
     }
-    if (StringUtils.isEmpty(categoryName) || categoryName.contains("-")) {
-      throw new ConfigurationException(CANNOT_BE_INCLUDED.getErrorDesc());
-    }
-    categoryService.createFirstCategory(categoryName, description);
-    return Message.ok();
-  }
 
-  @ApiOperation(value = "deleteCategory", notes = "delete category", response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "54")
-  })
-  @ApiOperationSupport(ignoreParameters = "jsonNode")
-  @RequestMapping(path = "/deleteCategory", method = RequestMethod.POST)
-  public Message deleteCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(request, "deleteCategory");
-    checkAdmin(username);
-    Integer categoryId = jsonNode.get("categoryId").asInt();
-    categoryService.deleteCategory(categoryId);
-    return Message.ok();
-  }
+    @ApiOperation(value = "deleteCategory", notes = "delete category", response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "54")
+    })
+    @ApiOperationSupport(ignoreParameters = "jsonNode")
+    @RequestMapping(path = "/deleteCategory", method = RequestMethod.POST)
+    public Message deleteCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(request, "deleteCategory");
+        checkAdmin(username);
+        Integer categoryId = jsonNode.get("categoryId").asInt();
+        categoryService.deleteCategory(categoryId);
+        return Message.ok();
+    }
 
-  @ApiOperation(
-      value = "createSecondCategory",
-      notes = "create second category",
-      response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "39"),
-    @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
-    @ApiImplicitParam(name = "version", required = true, dataType = "String", example = "1.2.0"),
-    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-  })
-  @ApiOperationSupport(ignoreParameters = {"jsonNode"})
-  @RequestMapping(path = "/createSecondCategory", method = RequestMethod.POST)
-  public Message createSecondCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(request, "createSecondCategory");
-    checkAdmin(username);
-    Integer categoryId = jsonNode.get("categoryId").asInt();
-    String engineType = jsonNode.get("engineType").asText();
-    String version = jsonNode.get("version").asText();
-    String description = jsonNode.get("description").asText();
-    if (categoryId <= 0) {
-      throw new ConfigurationException(CREATOR_IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
+    @ApiOperation(
+            value = "createSecondCategory",
+            notes = "create second category",
+            response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "categoryId", required = true, dataType = "String", example = "39"),
+            @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
+            @ApiImplicitParam(name = "version", required = true, dataType = "String", example = "1.2.0"),
+            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+    })
+    @ApiOperationSupport(ignoreParameters = {"jsonNode"})
+    @RequestMapping(path = "/createSecondCategory", method = RequestMethod.POST)
+    public Message createSecondCategory(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(request, "createSecondCategory");
+        checkAdmin(username);
+        Integer categoryId = jsonNode.get("categoryId").asInt();
+        String engineType = jsonNode.get("engineType").asText();
+        String version = jsonNode.get("version").asText();
+        String description = jsonNode.get("description").asText();
+        if (categoryId <= 0) {
+            throw new ConfigurationException(CREATOR_IS_NULL_CANNOT_BE_ADDED.getErrorDesc());
+        }
+        if (StringUtils.isEmpty(engineType) || engineType.toLowerCase().equals(NULL)) {
+            throw new ConfigurationException(ENGINE_TYPE_IS_NULL.getErrorDesc());
+        }
+        if (StringUtils.isEmpty(version) || version.toLowerCase().equals(NULL)) {
+            version = LabelUtils.COMMON_VALUE;
+        }
+        categoryService.createSecondCategory(categoryId, engineType, version, description);
+        return Message.ok();
     }
-    if (StringUtils.isEmpty(engineType) || engineType.toLowerCase().equals(NULL)) {
-      throw new ConfigurationException(ENGINE_TYPE_IS_NULL.getErrorDesc());
-    }
-    if (StringUtils.isEmpty(version) || version.toLowerCase().equals(NULL)) {
-      version = LabelUtils.COMMON_VALUE;
-    }
-    categoryService.createSecondCategory(categoryId, engineType, version, description);
-    return Message.ok();
-  }
 
-  @ApiOperation(value = "saveFullTree", notes = "save full tree", response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "creator", required = true, dataType = "String", example = "xwzTest"),
-    @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
-    @ApiImplicitParam(name = "fullTree", required = true, dataType = "List", value = "full tree"),
-    @ApiImplicitParam(name = "name", required = true, dataType = "String", value = "name"),
-    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-    @ApiImplicitParam(name = "settings", required = true, dataType = "List", value = "settings")
-  })
-  @ApiOperationSupport(ignoreParameters = {"json"})
-  @RequestMapping(path = "/saveFullTree", method = RequestMethod.POST)
-  public Message saveFullTree(HttpServletRequest req, @RequestBody JsonNode json)
-      throws IOException, ConfigurationException {
-    List fullTrees = mapper.treeToValue(json.get("fullTree"), List.class);
-    String creator = JsonNodeUtil.getStringValue(json.get("creator"));
-    String engineType = JsonNodeUtil.getStringValue(json.get("engineType"));
-    if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
-      creator = "*";
+    @ApiOperation(value = "saveFullTree", notes = "save full tree", response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "creator", required = true, dataType = "String", example = "xwzTest"),
+            @ApiImplicitParam(name = "engineType", required = true, dataType = "String", example = "hive"),
+            @ApiImplicitParam(name = "fullTree", required = true, dataType = "List", value = "full tree"),
+            @ApiImplicitParam(name = "name", required = true, dataType = "String", value = "name"),
+            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+            @ApiImplicitParam(name = "settings", required = true, dataType = "List", value = "settings")
+    })
+    @ApiOperationSupport(ignoreParameters = {"json"})
+    @RequestMapping(path = "/saveFullTree", method = RequestMethod.POST)
+    public Message saveFullTree(HttpServletRequest req, @RequestBody JsonNode json)
+            throws IOException, ConfigurationException {
+        List fullTrees = mapper.treeToValue(json.get("fullTree"), List.class);
+        String creator = JsonNodeUtil.getStringValue(json.get("creator"));
+        String engineType = JsonNodeUtil.getStringValue(json.get("engineType"));
+        if (creator != null && (creator.equals("通用设置") || creator.equals("全局设置"))) {
+            creator = "*";
+        }
+        String username = ModuleUserUtils.getOperationUser(req, "saveFullTree");
+        ArrayList<ConfigValue> createList = new ArrayList<>();
+        ArrayList<ConfigValue> updateList = new ArrayList<>();
+        for (Object o : fullTrees) {
+            String s = BDPJettyServerHelper.gson().toJson(o);
+            ConfigTree fullTree = BDPJettyServerHelper.gson().fromJson(s, ConfigTree.class);
+            List<ConfigKeyValue> settings = fullTree.getSettings();
+            Integer userLabelId =
+                    configurationService.checkAndCreateUserLabel(settings, username, creator);
+            for (ConfigKeyValue setting : settings) {
+                configurationService.updateUserValue(setting, userLabelId, createList, updateList);
+            }
+        }
+        String engine = null;
+        String version = null;
+        if (engineType != null) {
+            String[] tmpString = engineType.split("-");
+            if (tmpString.length != 2) {
+                throw new ConfigurationException(INCORRECT_FIXED_SUCH.getErrorDesc());
+            }
+            engine = tmpString[0];
+            version = tmpString[1];
+        }
+        configurationService.updateUserValue(createList, updateList);
+        configurationService.clearAMCacheConf(username, creator, engine, version);
+        Message message = Message.ok();
+        return message;
     }
-    String username = ModuleUserUtils.getOperationUser(req, "saveFullTree");
-    ArrayList<ConfigValue> createList = new ArrayList<>();
-    ArrayList<ConfigValue> updateList = new ArrayList<>();
-    for (Object o : fullTrees) {
-      String s = BDPJettyServerHelper.gson().toJson(o);
-      ConfigTree fullTree = BDPJettyServerHelper.gson().fromJson(s, ConfigTree.class);
-      List<ConfigKeyValue> settings = fullTree.getSettings();
-      Integer userLabelId =
-          configurationService.checkAndCreateUserLabel(settings, username, creator);
-      for (ConfigKeyValue setting : settings) {
-        configurationService.updateUserValue(setting, userLabelId, createList, updateList);
-      }
-    }
-    String engine = null;
-    String version = null;
-    if (engineType != null) {
-      String[] tmpString = engineType.split("-");
-      if (tmpString.length != 2) {
-        throw new ConfigurationException(INCORRECT_FIXED_SUCH.getErrorDesc());
-      }
-      engine = tmpString[0];
-      version = tmpString[1];
-    }
-    configurationService.updateUserValue(createList, updateList);
-    configurationService.clearAMCacheConf(username, creator, engine, version);
-    Message message = Message.ok();
-    return message;
-  }
 
-  @ApiOperation(
-      value = "listAllEngineType",
-      notes = "list all engine type",
-      response = Message.class)
-  @RequestMapping(path = "/engineType", method = RequestMethod.GET)
-  public Message listAllEngineType(HttpServletRequest request) {
-    String[] engineType = configurationService.listAllEngineType();
-    return Message.ok().data("engineType", engineType);
-  }
-
-  @ApiOperation(
-      value = "updateCategoryInfo",
-      notes = "update category info",
-      response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "description", required = true, dataType = "String"),
-    @ApiImplicitParam(name = "categoryId", required = true, dataType = "String")
-  })
-  @ApiOperationSupport(ignoreParameters = {"jsonNode"})
-  @RequestMapping(path = "/updateCategoryInfo", method = RequestMethod.POST)
-  public Message updateCategoryInfo(HttpServletRequest request, @RequestBody JsonNode jsonNode)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(request, "updateCategoryInfo");
-    checkAdmin(username);
-    String description = null;
-    Integer categoryId = null;
-    try {
-      description = jsonNode.get("description").asText();
-      categoryId = jsonNode.get("categoryId").asInt();
-    } catch (Exception e) {
-      throw new ConfigurationException(INCOMPLETE_RECONFIRM.getErrorDesc());
+    @ApiOperation(
+            value = "listAllEngineType",
+            notes = "list all engine type",
+            response = Message.class)
+    @RequestMapping(path = "/engineType", method = RequestMethod.GET)
+    public Message listAllEngineType(HttpServletRequest request) {
+        String[] engineType = configurationService.listAllEngineType();
+        return Message.ok().data("engineType", engineType);
     }
-    if (description != null) {
-      categoryService.updateCategory(categoryId, description);
-    }
-    return Message.ok();
-  }
 
-  @ApiOperation(value = "rpcTest", notes = "rpc test", response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "creator", dataType = "String", value = "creator"),
-    @ApiImplicitParam(name = "engineType", dataType = "String"),
-    @ApiImplicitParam(name = "username", dataType = "String"),
-    @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
-  })
-  @RequestMapping(path = "/rpcTest", method = RequestMethod.GET)
-  public Message rpcTest(
-      @RequestParam(value = "username", required = false) String username,
-      @RequestParam(value = "creator", required = false) String creator,
-      @RequestParam(value = "engineType", required = false) String engineType,
-      @RequestParam(value = "version", required = false) String version) {
-    configurationService.queryGlobalConfig(username);
-    EngineTypeLabel engineTypeLabel = new EngineTypeLabel();
-    engineTypeLabel.setVersion(version);
-    engineTypeLabel.setEngineType(engineType);
-    configurationService.queryDefaultEngineConfig(engineTypeLabel);
-    UserCreatorLabel userCreatorLabel = new UserCreatorLabel();
-    userCreatorLabel.setCreator(creator);
-    userCreatorLabel.setUser(username);
-    configurationService.queryConfig(userCreatorLabel, engineTypeLabel, "wds.linkis.rm");
-    Message message = Message.ok();
-    return message;
-  }
-
-  private void checkAdmin(String userName) throws ConfigurationException {
-    if (!Configuration.isAdmin(userName)) {
-      throw new ConfigurationException(ONLY_ADMIN_CAN_MODIFY.getErrorDesc());
+    @ApiOperation(
+            value = "updateCategoryInfo",
+            notes = "update category info",
+            response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "description", required = true, dataType = "String"),
+            @ApiImplicitParam(name = "categoryId", required = true, dataType = "String")
+    })
+    @ApiOperationSupport(ignoreParameters = {"jsonNode"})
+    @RequestMapping(path = "/updateCategoryInfo", method = RequestMethod.POST)
+    public Message updateCategoryInfo(HttpServletRequest request, @RequestBody JsonNode jsonNode)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(request, "updateCategoryInfo");
+        checkAdmin(username);
+        String description = null;
+        Integer categoryId = null;
+        try {
+            description = jsonNode.get("description").asText();
+            categoryId = jsonNode.get("categoryId").asInt();
+        } catch (Exception e) {
+            throw new ConfigurationException(INCOMPLETE_RECONFIRM.getErrorDesc());
+        }
+        if (description != null) {
+            categoryService.updateCategory(categoryId, description);
+        }
+        return Message.ok();
     }
-  }
 
-  @ApiOperation(value = "getKeyValue", notes = "get key value", response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "creator", required = false, dataType = "String", value = "creator"),
-    @ApiImplicitParam(name = "engineType", dataType = "String"),
-    @ApiImplicitParam(name = "configKey", dataType = "String"),
-    @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
-  })
-  @RequestMapping(path = "/keyvalue", method = RequestMethod.GET)
-  public Message getKeyValue(
-      HttpServletRequest req,
-      @RequestParam(value = "engineType", required = false, defaultValue = "*") String engineType,
-      @RequestParam(value = "version", required = false, defaultValue = "*") String version,
-      @RequestParam(value = "creator", required = false, defaultValue = "*") String creator,
-      @RequestParam(value = "configKey") String configKey)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(req, "saveKey");
-    if (engineType.equals("*") && !version.equals("*")) {
-      return Message.error("When engineType is any engine, the version must also be any version");
+    @ApiOperation(value = "rpcTest", notes = "rpc test", response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "creator", dataType = "String", value = "creator"),
+            @ApiImplicitParam(name = "engineType", dataType = "String"),
+            @ApiImplicitParam(name = "username", dataType = "String"),
+            @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
+    })
+    @RequestMapping(path = "/rpcTest", method = RequestMethod.GET)
+    public Message rpcTest(
+            @RequestParam(value = "username", required = false) String username,
+            @RequestParam(value = "creator", required = false) String creator,
+            @RequestParam(value = "engineType", required = false) String engineType,
+            @RequestParam(value = "version", required = false) String version) {
+        configurationService.queryGlobalConfig(username);
+        EngineTypeLabel engineTypeLabel = new EngineTypeLabel();
+        engineTypeLabel.setVersion(version);
+        engineTypeLabel.setEngineType(engineType);
+        configurationService.queryDefaultEngineConfig(engineTypeLabel);
+        UserCreatorLabel userCreatorLabel = new UserCreatorLabel();
+        userCreatorLabel.setCreator(creator);
+        userCreatorLabel.setUser(username);
+        configurationService.queryConfig(userCreatorLabel, engineTypeLabel, "wds.linkis.rm");
+        Message message = Message.ok();
+        return message;
     }
-    List labelList =
-        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-            username, creator, engineType, version);
 
-    List<ConfigValue> configValues = configKeyService.getConfigValue(configKey, labelList);
-    Message message = Message.ok().data("configValues", configValues);
-    if (configValues.size() > 1) {
-      message.data(
-          "warnMessage", "There are multiple values for the corresponding Key： " + configKey);
+    private void checkAdmin(String userName) throws ConfigurationException {
+        if (!Configuration.isAdmin(userName)) {
+            throw new ConfigurationException(ONLY_ADMIN_CAN_MODIFY.getErrorDesc());
+        }
     }
-    return message;
-  }
 
-  @ApiOperation(value = "saveKeyValue", notes = "save key value", response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
-    @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
-    @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
-    @ApiImplicitParam(name = "configKey", required = true, dataType = "String"),
-    @ApiImplicitParam(name = "configValue", required = true, dataType = "String")
-  })
-  @ApiOperationSupport(ignoreParameters = {"json"})
-  @RequestMapping(path = "/keyvalue", method = RequestMethod.POST)
-  public Message saveKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(req, "saveKey");
-    String engineType = (String) json.getOrDefault("engineType", "*");
-    String version = (String) json.getOrDefault("version", "*");
-    String creator = (String) json.getOrDefault("creator", "*");
-    String configKey = (String) json.get("configKey");
-    String value = (String) json.get("configValue");
-    if (engineType.equals("*") && !version.equals("*")) {
-      return Message.error("When engineType is any engine, the version must also be any version");
-    }
-    if (StringUtils.isBlank(configKey) || StringUtils.isBlank(value)) {
-      return Message.error("key or value cannot be empty");
-    }
-    List labelList =
-        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-            username, creator, engineType, version);
+    @ApiOperation(value = "getKeyValue", notes = "get key value", response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "creator", required = false, dataType = "String", value = "creator"),
+            @ApiImplicitParam(name = "engineType", dataType = "String"),
+            @ApiImplicitParam(name = "configKey", dataType = "String"),
+            @ApiImplicitParam(name = "version", required = false, dataType = "String", value = "version")
+    })
+    @RequestMapping(path = "/keyvalue", method = RequestMethod.GET)
+    public Message getKeyValue(
+            HttpServletRequest req,
+            @RequestParam(value = "engineType", required = false, defaultValue = "*") String engineType,
+            @RequestParam(value = "version", required = false, defaultValue = "*") String version,
+            @RequestParam(value = "creator", required = false, defaultValue = "*") String creator,
+            @RequestParam(value = "configKey") String configKey)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(req, "saveKey");
+        if (engineType.equals("*") && !version.equals("*")) {
+            return Message.error("When engineType is any engine, the version must also be any version");
+        }
+        List labelList =
+                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+                        username, creator, engineType, version);
 
-    ConfigKeyValue configKeyValue = new ConfigKeyValue();
-    configKeyValue.setKey(configKey);
-    configKeyValue.setConfigValue(value);
-
-    ConfigValue configValue = configKeyService.saveConfigValue(configKeyValue, labelList);
-    configurationService.clearAMCacheConf(username, creator, engineType, version);
-    return Message.ok().data("configValue", configValue);
-  }
-
-  @ApiOperation(value = "deleteKeyValue", notes = "delete key value", response = Message.class)
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
-    @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
-    @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
-    @ApiImplicitParam(name = "configKey", required = true, dataType = "String")
-  })
-  @ApiOperationSupport(ignoreParameters = {"json"})
-  @RequestMapping(path = "/keyvalue", method = RequestMethod.DELETE)
-  public Message deleteKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
-      throws ConfigurationException {
-    String username = ModuleUserUtils.getOperationUser(req, "saveKey");
-    String engineType = (String) json.getOrDefault("engineType", "*");
-    String version = (String) json.getOrDefault("version", "*");
-    String creator = (String) json.getOrDefault("creator", "*");
-    String configKey = (String) json.get("configKey");
-    if (engineType.equals("*") && !version.equals("*")) {
-      return Message.error("When engineType is any engine, the version must also be any version");
+        List<ConfigValue> configValues = configKeyService.getConfigValue(configKey, labelList);
+        Message message = Message.ok().data("configValues", configValues);
+        if (configValues.size() > 1) {
+            message.data(
+                    "warnMessage", "There are multiple values for the corresponding Key： " + configKey);
+        }
+        return message;
     }
-    if (StringUtils.isBlank(configKey)) {
-      return Message.error("key cannot be empty");
+
+    @ApiOperation(value = "saveKeyValue", notes = "save key value", response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
+            @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
+            @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
+            @ApiImplicitParam(name = "configKey", required = true, dataType = "String"),
+            @ApiImplicitParam(name = "configValue", required = true, dataType = "String")
+    })
+    @ApiOperationSupport(ignoreParameters = {"json"})
+    @RequestMapping(path = "/keyvalue", method = RequestMethod.POST)
+    public Message saveKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(req, "saveKey");
+        String engineType = (String) json.getOrDefault("engineType", "*");
+        String version = (String) json.getOrDefault("version", "*");
+        String creator = (String) json.getOrDefault("creator", "*");
+        String configKey = (String) json.get("configKey");
+        String value = (String) json.get("configValue");
+        if (engineType.equals("*") && !version.equals("*")) {
+            return Message.error("When engineType is any engine, the version must also be any version");
+        }
+        if (StringUtils.isBlank(configKey) || StringUtils.isBlank(value)) {
+            return Message.error("key or value cannot be empty");
+        }
+        List labelList =
+                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+                        username, creator, engineType, version);
+
+        ConfigKeyValue configKeyValue = new ConfigKeyValue();
+        configKeyValue.setKey(configKey);
+        configKeyValue.setConfigValue(value);
+
+        ConfigValue configValue = configKeyService.saveConfigValue(configKeyValue, labelList);
+        configurationService.clearAMCacheConf(username, creator, engineType, version);
+        return Message.ok().data("configValue", configValue);
     }
-    List labelList =
-        LabelEntityParser.generateUserCreatorEngineTypeLabelList(
-            username, creator, engineType, version);
-    List<ConfigValue> configValues = configKeyService.deleteConfigValue(configKey, labelList);
-    return Message.ok().data("configValues", configValues);
-  }
+
+    @ApiOperation(value = "deleteKeyValue", notes = "delete key value", response = Message.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "engineType", required = true, dataType = "String"),
+            @ApiImplicitParam(name = "version", required = true, dataType = "String", value = "version"),
+            @ApiImplicitParam(name = "creator", required = true, dataType = "String", value = "creator"),
+            @ApiImplicitParam(name = "configKey", required = true, dataType = "String")
+    })
+    @ApiOperationSupport(ignoreParameters = {"json"})
+    @RequestMapping(path = "/keyvalue", method = RequestMethod.DELETE)
+    public Message deleteKeyValue(HttpServletRequest req, @RequestBody Map<String, Object> json)
+            throws ConfigurationException {
+        String username = ModuleUserUtils.getOperationUser(req, "saveKey");
+        String engineType = (String) json.getOrDefault("engineType", "*");
+        String version = (String) json.getOrDefault("version", "*");
+        String creator = (String) json.getOrDefault("creator", "*");
+        String configKey = (String) json.get("configKey");
+        if (engineType.equals("*") && !version.equals("*")) {
+            return Message.error("When engineType is any engine, the version must also be any version");
+        }
+        if (StringUtils.isBlank(configKey)) {
+            return Message.error("key cannot be empty");
+        }
+        List labelList =
+                LabelEntityParser.generateUserCreatorEngineTypeLabelList(
+                        username, creator, engineType, version);
+        List<ConfigValue> configValues = configKeyService.deleteConfigValue(configKey, labelList);
+        return Message.ok().data("configValues", configValues);
+    }
 }

--- a/linkis-public-enhancements/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/CategoryService.scala
+++ b/linkis-public-enhancements/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/CategoryService.scala
@@ -237,6 +237,9 @@ class CategoryService extends Logging {
       )
       if (linkedEngineTypeLabelInDb != null) {
         associateConfigKey(linkedEngineTypeLabelInDb.getId, linkedEngineTypeLabel.getStringValue)
+      } else {
+        val engineLabel = LabelEntityParser.parseToConfigLabel(linkedEngineTypeLabel)
+        labelMapper.insertLabel(engineLabel)
       }
     }
   }

--- a/linkis-public-enhancements/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
+++ b/linkis-public-enhancements/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
@@ -17,6 +17,8 @@
 
 package org.apache.linkis.configuration.service
 
+import com.google.common.collect.Lists
+import org.apache.commons.lang3.StringUtils
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.configuration.conf.Configuration
 import org.apache.linkis.configuration.dao.{ConfigMapper, LabelMapper}
@@ -24,26 +26,19 @@ import org.apache.linkis.configuration.entity._
 import org.apache.linkis.configuration.exception.ConfigurationException
 import org.apache.linkis.configuration.util.{LabelEntityParser, LabelParameterParser}
 import org.apache.linkis.configuration.validate.ValidatorManager
-import org.apache.linkis.governance.common.protocol.conf.{
-  RemoveCacheConfRequest,
-  ResponseQueryConfig
-}
+import org.apache.linkis.governance.common.protocol.conf.{RemoveCacheConfRequest, ResponseQueryConfig}
 import org.apache.linkis.manager.label.builder.CombinedLabelBuilder
 import org.apache.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
-import org.apache.linkis.manager.label.entity.{CombinedLabel, CombinedLabelImpl, Label}
 import org.apache.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import org.apache.linkis.manager.label.entity.{CombinedLabel, CombinedLabelImpl, Label}
 import org.apache.linkis.manager.label.utils.{EngineTypeLabelCreator, LabelUtils}
 import org.apache.linkis.rpc.Sender
-
-import org.apache.commons.lang3.StringUtils
-
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.util.CollectionUtils
 
 import java.util
-
 import scala.collection.JavaConverters._
 
 @Service
@@ -382,6 +377,15 @@ class ConfigurationService extends Logging {
       useDefaultConfig: Boolean = true
   ): util.ArrayList[ConfigTree] = {
     val (configs, defaultEngineConfigs) = getConfigsByLabelList(labelList, useDefaultConfig)
+    buildTreeResult(configs, defaultEngineConfigs)
+  }
+
+  def getConfigurationTemplateByLabelList(
+                              labelList: java.util.List[Label[_]],
+                              useDefaultConfig: Boolean = true
+                            ): util.ArrayList[ConfigTree] = {
+    var (configs, defaultEngineConfigs) = getConfigsByLabelList(labelList, useDefaultConfig)
+    configs = Lists.newArrayList()
     buildTreeResult(configs, defaultEngineConfigs)
   }
 

--- a/linkis-public-enhancements/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
+++ b/linkis-public-enhancements/linkis-configuration/src/main/scala/org/apache/linkis/configuration/service/ConfigurationService.scala
@@ -17,8 +17,6 @@
 
 package org.apache.linkis.configuration.service
 
-import com.google.common.collect.Lists
-import org.apache.commons.lang3.StringUtils
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.configuration.conf.Configuration
 import org.apache.linkis.configuration.dao.{ConfigMapper, LabelMapper}
@@ -26,20 +24,29 @@ import org.apache.linkis.configuration.entity._
 import org.apache.linkis.configuration.exception.ConfigurationException
 import org.apache.linkis.configuration.util.{LabelEntityParser, LabelParameterParser}
 import org.apache.linkis.configuration.validate.ValidatorManager
-import org.apache.linkis.governance.common.protocol.conf.{RemoveCacheConfRequest, ResponseQueryConfig}
+import org.apache.linkis.governance.common.protocol.conf.{
+  RemoveCacheConfRequest,
+  ResponseQueryConfig
+}
 import org.apache.linkis.manager.label.builder.CombinedLabelBuilder
 import org.apache.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
-import org.apache.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
 import org.apache.linkis.manager.label.entity.{CombinedLabel, CombinedLabelImpl, Label}
+import org.apache.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
 import org.apache.linkis.manager.label.utils.{EngineTypeLabelCreator, LabelUtils}
 import org.apache.linkis.rpc.Sender
+
+import org.apache.commons.lang3.StringUtils
+
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.util.CollectionUtils
 
 import java.util
+
 import scala.collection.JavaConverters._
+
+import com.google.common.collect.Lists
 
 @Service
 class ConfigurationService extends Logging {
@@ -381,9 +388,9 @@ class ConfigurationService extends Logging {
   }
 
   def getConfigurationTemplateByLabelList(
-                              labelList: java.util.List[Label[_]],
-                              useDefaultConfig: Boolean = true
-                            ): util.ArrayList[ConfigTree] = {
+      labelList: java.util.List[Label[_]],
+      useDefaultConfig: Boolean = true
+  ): util.ArrayList[ConfigTree] = {
     var (configs, defaultEngineConfigs) = getConfigsByLabelList(labelList, useDefaultConfig)
     configs = Lists.newArrayList()
     buildTreeResult(configs, defaultEngineConfigs)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

At present, the new engine needs to manually enter sql to prepare the engine parameters. This submission is the basic data management module, and the related interfaces for the configuration management of the engine parameters are added:

1.Query all engine lists
/api/rest_j/v1/basedata-manager/engin-list
2.Add/modify configuration item template interface
/api/rest_j/v1/basedata-manager/configuration-template/save
3.Delete configuration item template interface
/api/rest_j/v1/basedata-manager/configuration-template/{keyId}
4.Query the list of configuration templates according to the engine tag
/api/rest_j/v1/basedata-manager/configuration-template/template-list-by-label

目前新增引擎需要手动录入sql进行引擎参数准备，该次提交是基础数据管理模块，新增引擎参数配置管理的相关接口：
1.查询所有引擎列表
/api/rest_j/v1/basedata-manager/engin-list
2.新增/修改配置项模板接口
/api/rest_j/v1/basedata-manager/configuration-template/save
3. 删除配置项模板接口
/api/rest_j/v1/basedata-manager/configuration-template/{keyId}
4.根据引擎标签查询配置模板列表
/api/rest_j/v1/basedata-manager/configuration-template/template-list-by-label