### PR TITLE
[ISSUE-3873]Exception handling added key parameter information

### DIFF
--- a/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/exception/WorkspaceExceptionManager.java
+++ b/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/exception/WorkspaceExceptionManager.java
@@ -33,39 +33,43 @@ public class WorkspaceExceptionManager {
               "The user has obtained the filesystem for more than %d ms. Please contact the administrator.（用户获取filesystem的时间超过%d ms，请联系管理员）");
           put(
               "80003",
-              "User local root directory does not exist, please contact administrator to add（用户本地根目录不存在,请联系管理员添加)");
+              "User local root directory does not exist, please contact administrator to add. directory（用户本地根目录不存在,请联系管理员添加.本地目录为):%s");
           put("80004", "path:(路径：)%sIs empty!(为空！)");
-          put("80005", "The created folder name is duplicated!(创建的文件夹名重复!)");
-          put("80006", "The file name created is duplicated!(创建的文件名重复!)");
-          put("80007", "The renamed name is repeated!(重命名的名字重复!)");
+          put("80005", "The created folder name is duplicated!,folder name(创建的文件夹名重复!文件夹名):%s");
+          put("80006", "The file name created is duplicated!file name(创建的文件名重复!文件名):%s");
+          put("80007", "The renamed name is repeated!renamed name(重命名的名字重复!名字):%s");
           put("80008", "The deleted file or folder does not exist!(删除的文件or文件夹不存在!)");
           put(
               "80009",
               "This user does not have permission to delete this file or folder!(该用户无权删除此文件或文件夹！)");
           put(
               "80010",
-              "The user does not have permission to view the contents of the directory(该用户无权限查看该目录的内容)");
-          put("80011", "The downloaded file does not exist!(下载的文件不存在!)");
-          put("80012", "This user has no permission to read this file!");
-          put("80013", "file does not exist!(文件不存在！)");
+              "The user does not have permission to view the contents of the directory(该用户无权限查看该目录的内容)。user(用户):%s,directory(目录)：%s");
+          put("80011", "The downloaded file does not exist!file(下载的文件不存在!文件)：%s");
+          put("80012", "This user has no permission to read this file!(该用户无权读取该文件！)");
+          put("80013", "file does not exist!file(文件不存在！file):%s");
           put(
               "80014",
               "The user has no permission to modify the contents of this file and cannot save it!(该用户无权限对此文件内容进行修改，无法保存！)");
-          put("80015", "unsupported resultset output type");
+          put("80015", "unsupported resultset output type(不支持的结果集输出类型)");
           put("80016", "The file content is empty and cannot be imported!(文件内容为空，不能进行导入操作！)");
           put(
               "80017",
               "The header of the file has no qualifiers. Do not check the first behavior header or set no qualifier!(该文件的表头没有限定符，请勿勾选首行为表头或者设置无限定符！)");
           put("80018", "This user has no permission to read this log!(该用户无权限读取此日志！)");
-          put("80019", "scriptContent is empty,this is normal!");
-          put("80021", "上传失败");
-          put("80022", "更新失败");
-          put("80023", "下载失败");
-          put("80024", "非table类型的结果集不能下载为excel");
-          put("80028", "the path exist special char");
-          put("80029", "empty dir!");
-          put("80030", "Failed to create user path");
-          put("80031", "The user was not initialized(用户未初始化)");
+          put("80019", "scriptContent is empty,this is normal!(scriptContent 为空，这是正常的！)");
+          put("80021", "upload failed(上传失败)");
+          put("80022", "update failed(更新失败)");
+          put("80023", "download failed(下载失败)");
+          put(
+              "80024",
+              "Non-tabular result sets cannot be downloaded as excel(非table类型的结果集不能下载为excel)");
+          put(
+              "80028",
+              "the path exist special char,only support numbers, uppercase letters, underscores, Chinese(路径存在特殊字符,只支持数字,字母大小写,下划线,中文)");
+          put("80029", "empty dir!(空目录！)");
+          put("80030", "Failed to create user path,path(创建用户路径失败,路径为):%s");
+          put("80031", "The user  was not initialized(用户未初始化),user(用户为):%s");
         }
       };
 

--- a/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -141,7 +141,7 @@ public class FsRestfulApi {
     if (!fileSystem.exists(fsPath)) {
       if (!FsPath.WINDOWS && !UserGroupUtils.isUserExist(userName)) {
         LOGGER.warn("User {} not exist in linkis node.", userName);
-        throw WorkspaceExceptionManager.createException(80031);
+        throw WorkspaceExceptionManager.createException(80031, userName);
       }
       if (FILESYSTEM_PATH_AUTO_CREATE.getValue()) {
         try {
@@ -149,10 +149,10 @@ public class FsRestfulApi {
           return Message.ok().data(String.format("user%sRootPath", returnType), path);
         } catch (IOException e) {
           LOGGER.error(e.getMessage(), e);
-          throw WorkspaceExceptionManager.createException(80030);
+          throw WorkspaceExceptionManager.createException(80030, path);
         }
       }
-      throw WorkspaceExceptionManager.createException(80003);
+      throw WorkspaceExceptionManager.createException(80003, path);
     }
     return Message.ok().data(String.format("user%sRootPath", returnType), path);
   }
@@ -172,13 +172,13 @@ public class FsRestfulApi {
       throw WorkspaceExceptionManager.createException(80004, path);
     }
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     WorkspaceUtil.fileAndDirNameSpecialCharCheck(path);
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
     if (fileSystem.exists(fsPath)) {
-      throw WorkspaceExceptionManager.createException(80005);
+      throw WorkspaceExceptionManager.createException(80005, path);
     }
     fileSystem.mkdirs(fsPath);
     return Message.ok();
@@ -198,13 +198,13 @@ public class FsRestfulApi {
       throw WorkspaceExceptionManager.createException(80004, path);
     }
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     WorkspaceUtil.fileAndDirNameSpecialCharCheck(path);
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
     if (fileSystem.exists(fsPath)) {
-      throw WorkspaceExceptionManager.createException(80006);
+      throw WorkspaceExceptionManager.createException(80006, path);
     }
     fileSystem.createNewFile(fsPath);
     return Message.ok();
@@ -231,7 +231,7 @@ public class FsRestfulApi {
       PathValidator$.MODULE$.validate(newDest, userName);
     }
     if (!checkIsUsersDirectory(newDest, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, newDest);
+      throw WorkspaceExceptionManager.createException(80010, userName, newDest);
     }
     if (StringUtils.isEmpty(oldDest)) {
       throw WorkspaceExceptionManager.createException(80004, oldDest);
@@ -245,7 +245,7 @@ public class FsRestfulApi {
     FsPath fsPathNew = new FsPath(newDest);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPathOld);
     if (fileSystem.exists(fsPathNew)) {
-      throw WorkspaceExceptionManager.createException(80007);
+      throw WorkspaceExceptionManager.createException(80007, newDest);
     }
     fileSystem.renameTo(fsPathOld, fsPathNew);
     return Message.ok();
@@ -278,7 +278,7 @@ public class FsRestfulApi {
       PathValidator$.MODULE$.validate(newDir, userName);
     }
     if (!checkIsUsersDirectory(filePath, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, filePath);
+      throw WorkspaceExceptionManager.createException(80010, userName, filePath);
     }
     FsPath flieOldPath = new FsPath(filePath);
     String name =
@@ -288,7 +288,7 @@ public class FsRestfulApi {
     WorkspaceUtil.fileAndDirNameSpecialCharCheck(flieOldPath.getPath());
     WorkspaceUtil.fileAndDirNameSpecialCharCheck(flieNewPath.getPath());
     if (!fileSystem.exists(flieOldPath)) {
-      throw WorkspaceExceptionManager.createException(80013);
+      throw WorkspaceExceptionManager.createException(80013, filePath);
     }
     fileSystem.renameTo(flieOldPath, flieNewPath);
     return Message.ok();
@@ -312,7 +312,7 @@ public class FsRestfulApi {
     }
     String userName = ModuleUserUtils.getOperationUser(req, "upload " + path);
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
@@ -344,7 +344,7 @@ public class FsRestfulApi {
       throw WorkspaceExceptionManager.createException(80004, path);
     }
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
@@ -373,7 +373,7 @@ public class FsRestfulApi {
     }
     String userName = ModuleUserUtils.getOperationUser(req, "getDirFileTrees " + path);
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
@@ -385,7 +385,7 @@ public class FsRestfulApi {
     // if(!isInUserWorkspace(path,userName)) throw new WorkSpaceException("The user does not
     // have permission to view the contents of the directory");
     if (!fileSystem.canExecute(fsPath) || !fileSystem.canRead(fsPath)) {
-      throw WorkspaceExceptionManager.createException(80010);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     dirFileTree.setName(new File(path).getName());
     dirFileTree.setChildren(new ArrayList<>());
@@ -434,14 +434,14 @@ public class FsRestfulApi {
         charset = Consts.UTF_8.toString();
       }
       if (!checkIsUsersDirectory(path, userName)) {
-        throw WorkspaceExceptionManager.createException(80010, path);
+        throw WorkspaceExceptionManager.createException(80010, userName, path);
       }
       FsPath fsPath = new FsPath(path);
       // TODO: 2018/11/29 Judging the directory, the directory cannot be
       // downloaded(判断目录,目录不能下载)
       FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
       if (!fileSystem.exists(fsPath)) {
-        throw WorkspaceExceptionManager.createException(8011);
+        throw WorkspaceExceptionManager.createException(8011, path);
       }
       inputStream = fileSystem.read(fsPath);
       byte[] buffer = new byte[1024];
@@ -484,7 +484,7 @@ public class FsRestfulApi {
       throw WorkspaceExceptionManager.createException(80004, path);
     }
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
     return Message.ok().data("isExist", fileSystem.exists(fsPath));
@@ -566,7 +566,7 @@ public class FsRestfulApi {
     }
     String userName = ModuleUserUtils.getOperationUser(req, "openFile " + path);
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
@@ -618,7 +618,7 @@ public class FsRestfulApi {
       charset = Consts.UTF_8.toString();
     }
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     String scriptContent = (String) json.get("scriptContent");
     Object params = json.get("params");
@@ -627,7 +627,7 @@ public class FsRestfulApi {
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);
     if (!fileSystem.exists(fsPath)) {
-      throw WorkspaceExceptionManager.createException(80013);
+      throw WorkspaceExceptionManager.createException(80013, path);
     }
     if (!fileSystem.canWrite(fsPath)) {
       throw WorkspaceExceptionManager.createException(80014);
@@ -719,7 +719,7 @@ public class FsRestfulApi {
         throw WorkspaceExceptionManager.createException(80004, path);
       }
       if (!checkIsUsersDirectory(path, userName)) {
-        throw WorkspaceExceptionManager.createException(80010, path);
+        throw WorkspaceExceptionManager.createException(80010, userName, path);
       }
       response.addHeader(
           "Content-Disposition",
@@ -823,7 +823,7 @@ public class FsRestfulApi {
         throw WorkspaceExceptionManager.createException(80004, path);
       }
       if (!checkIsUsersDirectory(path, userName)) {
-        throw WorkspaceExceptionManager.createException(80010, path);
+        throw WorkspaceExceptionManager.createException(80010, userName, path);
       }
       // list目录下的文件
       FsPathListWithError fsPathListWithError = fileSystem.listPathWithError(fsPath);
@@ -915,7 +915,7 @@ public class FsRestfulApi {
     }
     String userName = ModuleUserUtils.getOperationUser(req, "formate " + path);
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     String suffix = path.substring(path.lastIndexOf("."));
     FsPath fsPath = new FsPath(path);
@@ -982,7 +982,7 @@ public class FsRestfulApi {
       userName = proxyUser;
     }
     if (!checkIsUsersDirectory(path, userName)) {
-      throw WorkspaceExceptionManager.createException(80010, path);
+      throw WorkspaceExceptionManager.createException(80010, userName, path);
     }
     FsPath fsPath = new FsPath(path);
     FileSystem fileSystem = fsService.getFileSystem(userName, fsPath);

--- a/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/util/WorkspaceUtil.java
+++ b/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/util/WorkspaceUtil.java
@@ -90,7 +90,7 @@ public class WorkspaceUtil {
     if (i != -1) {
       name = name.substring(0, i);
     }
-    // 只支持数字,字母大小写,下划线,中文
+    // Only support numbers, uppercase letters, underscores, Chinese(只支持数字,字母大小写,下划线,中文)
     String specialRegEx = "^[\\w\\u4e00-\\u9fa5]{1,200}$";
     Pattern specialPattern = Pattern.compile(specialRegEx);
     if (!specialPattern.matcher(name).find()) {


### PR DESCRIPTION
### What is the purpose of the change

**In the WorkspaceExceptionManager exception class, add relevant parameters according to the actual situation, and output the key information when the exception is output**

### Related issues/PRs

Related issues: #3873 
Related pr:#3874


### Brief change log

**path**:org.apache.linkis.filesystem.exception.WorkspaceExceptionManager

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



