### PR TITLE
upgrade to commons-text 1.10.0 due to cve (#3927)

### DIFF
--- a/linkis-dist/release-docs/LICENSE
+++ b/linkis-dist/release-docs/LICENSE
@@ -268,7 +268,7 @@ See licenses/ for text of these licenses.
     (Apache License, Version 2.0) Apache Commons Lang (org.apache.commons:commons-lang3:3.3.2 - http://commons.apache.org/proper/commons-lang/)
     (Apache License, Version 2.0) Apache Commons Logging (commons-logging:commons-logging:1.2 - http://commons.apache.org/proper/commons-logging/)
     (Apache License, Version 2.0) Apache Commons Math (org.apache.commons:commons-math3:3.4.1 - http://commons.apache.org/proper/commons-math/)
-    (Apache License, Version 2.0) Apache Commons Text (org.apache.commons:commons-text:1.6 - http://commons.apache.org/proper/commons-text)
+    (Apache License, Version 2.0) Apache Commons Text (org.apache.commons:commons-text:1.10.0 - http://commons.apache.org/proper/commons-text)
     (Apache License, Version 2.0) Apache Directory API ASN.1 API (org.apache.directory.api:api-asn1-api:1.0.0-M20 - http://directory.apache.org/api-parent/api-asn1-parent/api-asn1-api/)
     (Apache License, Version 2.0) Apache Directory LDAP API Utilities (org.apache.directory.api:api-util:1.0.0-M20 - http://directory.apache.org/api-parent/api-util/)
     (Apache License, Version 2.0) Apache Extras™ for Apache log4j™. (log4j:apache-log4j-extras:1.2.17 - http://logging.apache.org/log4j/extras)

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
-    <commons-text.version>1.9</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-io.version>2.11.0</commons-io.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>

--- a/tool/dependencies/known-dependencies.txt
+++ b/tool/dependencies/known-dependencies.txt
@@ -75,7 +75,7 @@ commons-math-2.2.jar
 commons-math3-3.6.1.jar
 commons-net-3.1.jar
 commons-pool-1.6.jar
-commons-text-1.9.jar
+commons-text-1.10.0.jar
 concurrent-0.191.jar
 config-1.3.3.jar
 configuration-0.191.jar


### PR DESCRIPTION
What is the purpose of the change
commons-text 1.10.0 fixes a security issue - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42889

Related issues/PRs
Related issues: https://github.com/apache/incubator-linkis/issues/3926

Brief change log
pom change